### PR TITLE
fix: lowercase GHCR image name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Must be lowercase — GHCR rejects mixed-case image names
+  IMAGE_NAME: cognicellai/cognition
 
 jobs:
   # ─── Tests ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes `repository name must be lowercase` error in Docker build CI. `github.repository` returns `CognicellAI/Cognition` which GHCR rejects. Hardcode `cognicellai/cognition` instead.