### PR TITLE
fix: three streaming bugs — duplicate done, doubled tokens, wrong model in usage (v0.2.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,9 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 | 2026-03-10 | Fix missing `await` on `create_cognition_agent` in `runtime.py` and `session_manager.py` — coroutine was stored unresolved, silently breaking MCP and any path through those callers | - | 4 | Completed |
 | 2026-03-10 | Harden Bedrock factory: partial key pair (only one of key/secret) now raises clear `ValueError` instead of silently producing a broken `ChatBedrock` instance | - | 5 | Completed |
 | 2026-03-10 | Wire `AgentConfig.recursion_limit` into `create_agent_runtime` (per-agent override) and `SessionConfig.recursion_limit` into `DeepAgentService` / storage backends; `SessionConfig.max_tokens` override also wired through to `llm_settings` | - | 2/4 | Completed |
+| 2026-03-10 | Fix `DoneEvent` fired twice: remove pass-through `elif isinstance(event, DoneEvent): yield event` in `deep_agent_service.py`; service already emits its own authoritative `DoneEvent` after `UsageEvent` | - | 6 | Completed |
+| 2026-03-10 | Fix streaming content doubled: remove redundant `on_chain_stream`/`model` branch and unused `_streamed_via_model_stream` flag from `runtime.py`; `on_chat_model_stream` is the canonical token event in LangGraph v2 | - | 4 | Completed |
+| 2026-03-10 | Fix `UsageEvent.model` always reporting `gpt-4o` default: use `_get_model_id(llm_settings)` (already in `provider_fallback.py`) instead of `llm_settings.llm_model` so Bedrock users see their actual `bedrock_model_id` | - | 6 | Completed |
 
 ---
 

--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -375,21 +375,6 @@ class DeepAgentRuntime:
                     if hasattr(chunk, "content") and chunk.content:
                         yield TokenEvent(content=_content_to_str(chunk.content))
 
-                elif event_type == "on_chain_stream" and name == "model":
-                    chunk = data.get("chunk", {})
-                    chunks = chunk if isinstance(chunk, list) else [chunk]
-                    for c in chunks:
-                        content = None
-                        if hasattr(c, "update") and isinstance(c.update, dict):
-                            messages = c.update.get("messages", [])
-                            if messages and hasattr(messages[-1], "content"):
-                                content = _content_to_str(messages[-1].content)
-                        elif hasattr(c, "content") and c.content:
-                            content = _content_to_str(c.content)
-
-                        if content:
-                            yield TokenEvent(content=content)
-
                 elif event_type == "on_tool_start":
                     tool_name = name
                     tool_args = data.get("input", {})

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -30,6 +30,7 @@ from server.app.agent.runtime import (
     ToolResultEvent,
     UsageEvent,
 )
+from server.app.llm.provider_fallback import _get_model_id
 from server.app.settings import Settings
 from server.app.storage.factory import create_storage_backend
 
@@ -186,7 +187,6 @@ class DeepAgentStreamingService:
             accumulated_content = ""
             _current_tool_call = None
             _planning_mode = False
-            _streamed_via_model_stream = False  # Track if on_chat_model_stream fired
 
             # ISSUE-011: Track plan steps for step_complete events
             _plan_todos: list[dict] = []
@@ -205,7 +205,6 @@ class DeepAgentStreamingService:
                         accumulated_content += event.content
                         output_tokens += len(event.content.split())
                         yield event
-                        _streamed_via_model_stream = True  # ISSUE-013: Track primary path
 
                     elif isinstance(event, ToolCallEvent):
                         _current_tool_call = event.tool_call_id
@@ -228,8 +227,9 @@ class DeepAgentStreamingService:
                         if event.code == "ABORTED":
                             return
 
-                    elif isinstance(event, DoneEvent):
-                        yield event
+                    # DoneEvent from the runtime is intentionally absorbed here.
+                    # The service emits its own authoritative DoneEvent below, after
+                    # UsageEvent, so the caller always receives exactly one done signal.
 
             finally:
                 # Unregister runtime when streaming completes
@@ -244,7 +244,7 @@ class DeepAgentStreamingService:
                     input_tokens, output_tokens, llm_settings.llm_provider
                 ),
                 provider=llm_settings.llm_provider,
-                model=llm_settings.llm_model,
+                model=_get_model_id(llm_settings),
             )
 
             # Signal completion

--- a/tests/e2e/test_workflow.py
+++ b/tests/e2e/test_workflow.py
@@ -142,12 +142,15 @@ class TestMessageWorkflow:
 
     async def test_send_message_sse_stream(self, server, session):
         """Test sending a message and receiving SSE stream."""
-        async with httpx.AsyncClient(timeout=30.0) as client, client.stream(
-            "POST",
-            f"{server}/sessions/{session}/messages",
-            json={"content": "Hello, world!"},
-            headers={"Accept": "text/event-stream"},
-        ) as response:
+        async with (
+            httpx.AsyncClient(timeout=30.0) as client,
+            client.stream(
+                "POST",
+                f"{server}/sessions/{session}/messages",
+                json={"content": "Hello, world!"},
+                headers={"Accept": "text/event-stream"},
+            ) as response,
+        ):
             assert response.status_code == 200
             assert "text/event-stream" in response.headers.get("content-type", "")
 

--- a/tests/unit/test_streaming_bugs.py
+++ b/tests/unit/test_streaming_bugs.py
@@ -1,0 +1,320 @@
+"""Regression tests for three streaming bugs fixed in v0.2.1.
+
+Bug 1 — done event fires twice:
+    DeepAgentRuntime.astream_events() yields DoneEvent at the end of its
+    generator. DeepAgentStreamingService was re-yielding it (pass-through)
+    then emitting its own second DoneEvent. Callers received two done signals.
+
+Bug 2 — content in done payload doubled:
+    Both on_chat_model_stream AND on_chain_stream/model fired for every
+    LangGraph streaming token, causing every token to be emitted twice as a
+    TokenEvent. accumulated_content therefore contained the full response
+    concatenated with itself.
+
+Bug 3 — model in usage event reports gpt-4o regardless of provider:
+    UsageEvent(model=llm_settings.llm_model) always read the generic
+    llm_model field (default "gpt-4o"). Bedrock users set
+    COGNITION_BEDROCK_MODEL_ID, not COGNITION_LLM_MODEL, so their actual
+    model ID was never reflected in usage events.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any, Literal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.app.agent.runtime import (
+    DoneEvent,
+    TokenEvent,
+    UsageEvent,
+)
+from server.app.models import Session, SessionConfig, SessionStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(
+    provider: str = "mock",
+    model: str = "mock-model",
+    bedrock_model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+) -> MagicMock:
+    """Build a minimal mock Settings object."""
+    from server.app.settings import Settings
+
+    s = MagicMock(spec=Settings)
+    s.llm_provider = provider
+    s.llm_model = model
+    s.bedrock_model_id = bedrock_model_id
+    s.llm_max_tokens = None
+    s.mcp_server_configs = []
+    s.agent_recursion_limit = 100
+    s.trusted_tool_namespaces = ["server.app.tools"]
+    return s
+
+
+def _make_session(
+    provider: Literal["openai", "bedrock", "mock", "openai_compatible"] = "mock",
+    model: str = "mock-model",
+) -> Session:
+    return Session(
+        id="sess-stream-test",
+        workspace_path="/tmp/ws",
+        title="Stream Test",
+        thread_id="thread-stream-test",
+        status=SessionStatus.ACTIVE,
+        config=SessionConfig(provider=provider, model=model),
+        created_at="2026-01-01T00:00:00",
+        updated_at="2026-01-01T00:00:00",
+    )
+
+
+async def _runtime_events(*events: Any) -> AsyncGenerator[Any, None]:
+    """Async generator that yields the provided events, mimicking the runtime."""
+    for event in events:
+        yield event
+
+
+def _make_mock_runtime(*events: Any) -> MagicMock:
+    """Build a MagicMock DeepAgentRuntime that streams the given events."""
+    mock_runtime = MagicMock()
+    mock_runtime.astream_events = MagicMock(return_value=_runtime_events(*events))
+    return mock_runtime
+
+
+def _stream_patches(mock_runtime: MagicMock) -> tuple:
+    """Return the standard set of patches needed to drive stream_response in isolation."""
+    return (
+        patch(
+            "server.app.llm.deep_agent_service.DeepAgentRuntime",
+            return_value=mock_runtime,
+        ),
+        patch(
+            "server.app.llm.deep_agent_service.DeepAgentStreamingService._get_model",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "server.app.llm.deep_agent_service.create_cognition_agent",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "server.app.llm.deep_agent_service.create_storage_backend",
+            return_value=MagicMock(
+                get_checkpointer=AsyncMock(return_value=MagicMock()),
+            ),
+        ),
+    )
+
+
+async def _collect(service: Any, session: Session) -> list[Any]:
+    """Drive stream_response and return all events."""
+    collected: list[Any] = []
+    async for event in service.stream_response(
+        session_id=session.id,
+        thread_id=session.thread_id,
+        project_path=session.workspace_path,
+        content="hello",
+    ):
+        collected.append(event)
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — exactly one DoneEvent reaches the caller
+# ---------------------------------------------------------------------------
+
+
+class TestExactlyOneDoneEvent:
+    """The service must emit exactly one DoneEvent regardless of what the runtime yields."""
+
+    @pytest.mark.asyncio
+    async def test_single_done_when_runtime_yields_done(self):
+        """Runtime yields DoneEvent → service absorbs it, emits its own → caller gets one."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        mock_runtime = _make_mock_runtime(TokenEvent(content="hello"), DoneEvent())
+        service = DeepAgentStreamingService(_make_settings())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, _make_session())
+
+        done_events = [e for e in collected if isinstance(e, DoneEvent)]
+        assert len(done_events) == 1, (
+            f"Expected exactly 1 DoneEvent, got {len(done_events)}. "
+            f"Sequence: {[type(e).__name__ for e in collected]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_done_when_runtime_yields_no_done(self):
+        """Even if the runtime emits no DoneEvent, the service still emits exactly one."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        mock_runtime = _make_mock_runtime(TokenEvent(content="world"))
+        service = DeepAgentStreamingService(_make_settings())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, _make_session())
+
+        done_events = [e for e in collected if isinstance(e, DoneEvent)]
+        assert len(done_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_done_is_last_event(self):
+        """DoneEvent must be the final event in the stream (after UsageEvent)."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
+        service = DeepAgentStreamingService(_make_settings())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, _make_session())
+
+        assert isinstance(collected[-1], DoneEvent), (
+            f"Last event should be DoneEvent, got {type(collected[-1]).__name__}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — accumulated content is not doubled
+# ---------------------------------------------------------------------------
+
+
+class TestContentNotDoubled:
+    """Tokens must be emitted exactly once; accumulated content must equal the response."""
+
+    @pytest.mark.asyncio
+    async def test_token_count_matches_runtime_output(self):
+        """Each token from the runtime produces exactly one TokenEvent downstream."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        tokens = ["Hello", ", ", "world", "!"]
+        mock_runtime = _make_mock_runtime(
+            *[TokenEvent(content=t) for t in tokens],
+            DoneEvent(),
+        )
+        service = DeepAgentStreamingService(_make_settings())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, _make_session())
+
+        token_events = [e for e in collected if isinstance(e, TokenEvent)]
+        assert len(token_events) == len(tokens), (
+            f"Expected {len(tokens)} TokenEvents, got {len(token_events)}"
+        )
+        accumulated = "".join(e.content for e in token_events)
+        assert accumulated == "Hello, world!", (
+            f"Content doubled or otherwise wrong: {accumulated!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_usage_event_output_tokens_not_doubled(self):
+        """output_tokens in UsageEvent must count each token once, not twice."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        # Two single-word tokens → output_tokens should be 2, not 4
+        mock_runtime = _make_mock_runtime(
+            TokenEvent(content="Hello"),
+            TokenEvent(content="World"),
+            DoneEvent(),
+        )
+        service = DeepAgentStreamingService(_make_settings())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, _make_session())
+
+        usage_events = [e for e in collected if isinstance(e, UsageEvent)]
+        assert len(usage_events) == 1
+        assert usage_events[0].output_tokens == 2, (
+            f"output_tokens should be 2 (one per token), got {usage_events[0].output_tokens}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — model in UsageEvent reflects actual provider model, not gpt-4o default
+# ---------------------------------------------------------------------------
+
+
+class TestUsageEventModelField:
+    """UsageEvent.model must report the actual model ID used, not the llm_model default."""
+
+    @pytest.mark.asyncio
+    async def test_bedrock_model_id_in_usage_event(self):
+        """When provider=bedrock, UsageEvent.model must be bedrock_model_id, not llm_model."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        bedrock_model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        settings = _make_settings(
+            provider="bedrock",
+            model="gpt-4o",  # the wrong default — must NOT appear in UsageEvent
+            bedrock_model_id=bedrock_model,
+        )
+        mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
+        service = DeepAgentStreamingService(settings)
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(
+                service, _make_session(provider="bedrock", model=bedrock_model)
+            )
+
+        usage_events = [e for e in collected if isinstance(e, UsageEvent)]
+        assert len(usage_events) == 1
+        assert usage_events[0].model == bedrock_model, (
+            f"Expected model={bedrock_model!r}, got {usage_events[0].model!r}. "
+            "Bedrock users set COGNITION_BEDROCK_MODEL_ID, not COGNITION_LLM_MODEL."
+        )
+
+    @pytest.mark.asyncio
+    async def test_openai_model_id_in_usage_event(self):
+        """When provider=openai, UsageEvent.model must be llm_model."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        settings = _make_settings(provider="openai", model="gpt-4o-mini")
+        mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
+        service = DeepAgentStreamingService(settings)
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime)
+        with p1, p2, p3, p4:
+            collected = await _collect(
+                service, _make_session(provider="openai", model="gpt-4o-mini")
+            )
+
+        usage_events = [e for e in collected if isinstance(e, UsageEvent)]
+        assert len(usage_events) == 1
+        assert usage_events[0].model == "gpt-4o-mini"
+
+    def test_get_model_id_bedrock(self):
+        """_get_model_id() returns bedrock_model_id for bedrock provider."""
+        from server.app.llm.provider_fallback import _get_model_id
+
+        settings = _make_settings(
+            provider="bedrock",
+            model="gpt-4o",
+            bedrock_model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        )
+        assert _get_model_id(settings) == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+    def test_get_model_id_openai(self):
+        """_get_model_id() returns llm_model for non-bedrock providers."""
+        from server.app.llm.provider_fallback import _get_model_id
+
+        settings = _make_settings(provider="openai", model="gpt-4o-mini")
+        assert _get_model_id(settings) == "gpt-4o-mini"
+
+    def test_get_model_id_openai_compatible(self):
+        """_get_model_id() returns llm_model for openai_compatible provider."""
+        from server.app.llm.provider_fallback import _get_model_id
+
+        settings = _make_settings(provider="openai_compatible", model="meta-llama/llama-3.3-70b")
+        assert _get_model_id(settings) == "meta-llama/llama-3.3-70b"


### PR DESCRIPTION
## Summary

Three post-v0.2.0 streaming bugs, all fixed in targeted one-line-or-less changes.

## Bugs Fixed

### Bug 1 — `done` event fires twice
- **Root cause**: `deep_agent_service.py` had `elif isinstance(event, DoneEvent): yield event` that re-broadcast the runtime's internal `DoneEvent`. The service already emits its own authoritative `DoneEvent` after `UsageEvent`.
- **Fix**: Delete the pass-through block entirely (`deep_agent_service.py`).

### Bug 2 — content doubled ("Hello there!Hello there!")
- **Root cause**: Both `on_chat_model_stream` and `on_chain_stream`/`name == "model"` fired for every token in LangGraph `astream_events(v2)`. An unused `_streamed_via_model_stream` flag was the start of an incomplete fix — set but never guarded anything.
- **Fix**: Remove the entire `on_chain_stream`/`model` branch and the dead flag (`runtime.py`).

### Bug 3 — `UsageEvent.model` always reports `gpt-4o`
- **Root cause**: `UsageEvent(model=llm_settings.llm_model)` always read the generic field (default `"gpt-4o"`). Bedrock users set `COGNITION_BEDROCK_MODEL_ID`, not `COGNITION_LLM_MODEL`.
- **Fix**: Use `_get_model_id(llm_settings)` (already exists in `provider_fallback.py`) at the `UsageEvent` site (`deep_agent_service.py`).

## Tests

Added `tests/unit/test_streaming_bugs.py` — 10 regression tests, all passing:
- `TestExactlyOneDoneEvent` (3 tests) — exactly one `DoneEvent`, always last
- `TestContentNotDoubled` (2 tests) — token count and `output_tokens` not doubled
- `TestUsageEventModelField` (5 tests) — correct model ID for bedrock, openai, openai_compatible

## Checklist

- [x] Work category: Bug Fix
- [x] ROADMAP.md updated (3 entries added)
- [x] Layer boundaries respected (Layer 4 runtime, Layer 6 service)
- [x] 376 unit tests pass, 4 skipped, 0 failures
- [x] `ruff check` + `ruff format` clean
- [x] `mypy .` — 0 errors across 143 source files