### PR TITLE
feat: Add Kubernetes deployment with Helm charts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,294 @@
+# Cognition Kubernetes Deployment
+
+This directory contains Kubernetes deployment configurations for Cognition AI assistant.
+
+## 📁 Directory Structure
+
+```
+deploy/
+├── cnpg/
+│   └── cluster.yaml              # CNPG PostgreSQL Cluster
+├── helm/
+│   ├── cognition/                # Main Cognition Helm chart
+│   │   ├── Chart.yaml
+│   │   ├── values.yaml           # Production values for dubaimetal
+│   │   └── templates/
+│   └── cognition-observe/        # Observability stack (optional)
+│       ├── Chart.yaml
+│       ├── values.yaml
+│       └── templates/
+└── README.md                     # This file
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- Kubernetes cluster with CNPG operator installed
+- Helm 3.x installed
+- `kubectl` configured for your cluster
+- Access to a container registry with Cognition image
+
+### Step 1: Deploy PostgreSQL Cluster
+
+Cognition requires PostgreSQL for persistence. Deploy a CNPG cluster:
+
+```bash
+# Deploy the CNPG cluster
+kubectl apply -f deploy/cnpg/cluster.yaml
+
+# Wait for the cluster to be ready
+kubectl wait --for=condition=Ready cluster/cognition-db -n cognition --timeout=300s
+
+# Verify the cluster is running
+kubectl get clusters -n cognition
+```
+
+### Step 2: Create Database Credentials Secret
+
+Create a Kubernetes secret with the database connection URI:
+
+```bash
+# Get the database password from the init secret
+DB_PASSWORD=$(kubectl get secret cognition-db-init-credentials -n cognition -o jsonpath='{.data.password}' | base64 -d)
+
+# Create the credentials secret
+kubectl create secret generic cognition-db-credentials \
+  --namespace cognition \
+  --from-literal=uri="postgresql+asyncpg://cognition:${DB_PASSWORD}@cognition-db-rw:5432/cognition"
+```
+
+### Step 3: Deploy Cognition
+
+Deploy the Cognition Helm chart:
+
+```bash
+# Navigate to the chart directory
+cd deploy/helm/cognition
+
+# Install the chart
+helm install cognition . \
+  --namespace cognition \
+  --create-namespace
+
+# Or with custom values
+helm install cognition . \
+  --namespace cognition \
+  --create-namespace \
+  --set secrets.openaiCompatibleApiKey="your-api-key"
+```
+
+### Step 4: Configure API Keys
+
+Create a secret with your LLM provider API keys:
+
+```bash
+kubectl create secret generic cognition-api-keys \
+  --namespace cognition \
+  --from-literal=openai-compatible-api-key="your-api-key"
+```
+
+Then update the deployment to use it:
+
+```bash
+helm upgrade cognition . \
+  --namespace cognition \
+  --set secrets.openaiCompatibleApiKey="your-api-key"
+```
+
+### Step 5: Verify Deployment
+
+```bash
+# Check pod status
+kubectl get pods -n cognition
+
+# Check logs
+kubectl logs -n cognition deployment/cognition
+
+# Test the API (via port-forward)
+kubectl port-forward -n cognition svc/cognition 8000:8000
+curl http://localhost:8000/health
+```
+
+### Step 6: Access via Tailscale
+
+The Cognition service is automatically exposed via Tailscale Ingress:
+
+```bash
+# Access via Tailscale hostname
+curl http://cognition:8000/health
+```
+
+## 📊 Deploy Observability Stack (Optional)
+
+Deploy the full observability stack in a separate namespace:
+
+```bash
+cd deploy/helm/cognition-observe
+
+helm install observe . \
+  --namespace cognition-observe \
+  --create-namespace
+
+# Access Grafana
+kubectl port-forward -n cognition-observe svc/grafana 3000:3000
+# Open http://localhost:3000 (admin/admin)
+```
+
+## ⚙️ Configuration
+
+### Key Values
+
+See `values.yaml` for all configuration options. Key settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `replicaCount` | Number of Cognition replicas | 3 |
+| `database.host` | PostgreSQL host | cognition-db-rw |
+| `config.llm.provider` | LLM provider | openai_compatible |
+| `config.llm.model` | LLM model | google/gemini-3-flash-preview |
+| `persistence.workspace.size` | Workspace PVC size | 50Gi |
+| `tailscale.enabled` | Enable Tailscale ingress | true |
+| `tailscale.hostname` | Tailscale hostname | cognition |
+
+### Custom Values
+
+Create a `values-custom.yaml` file for your environment:
+
+```yaml
+replicaCount: 3
+
+config:
+  llm:
+    provider: openai
+    model: gpt-4o
+    
+  observability:
+    enabled: true
+    otelEndpoint: http://otel-collector.cognition-observe:4317
+    mlflowEnabled: true
+    mlflowUri: http://mlflow.cognition-observe:5000
+
+secrets:
+  openaiApiKey: "sk-..."
+```
+
+Deploy with custom values:
+
+```bash
+helm upgrade cognition . \
+  --namespace cognition \
+  -f values-custom.yaml
+```
+
+## 🔧 Maintenance
+
+### Upgrading
+
+```bash
+# Update the chart
+helm upgrade cognition . --namespace cognition
+
+# Rolling restart
+kubectl rollout restart deployment/cognition -n cognition
+```
+
+### Scaling
+
+```bash
+# Scale replicas
+kubectl scale deployment/cognition -n cognition --replicas=5
+
+# Or via Helm
+helm upgrade cognition . --namespace cognition --set replicaCount=5
+```
+
+### Backup
+
+The CNPG cluster supports automated backups. To enable:
+
+1. Uncomment the ScheduledBackup in `deploy/cnpg/cluster.yaml`
+2. Configure S3 or other backup destination
+3. Apply the changes
+
+### Troubleshooting
+
+```bash
+# Check pod status
+kubectl get pods -n cognition -o wide
+
+# View logs
+kubectl logs -n cognition deployment/cognition --tail=100 -f
+
+# Describe pod for events
+kubectl describe pod -n cognition -l app.kubernetes.io/name=cognition
+
+# Check database connectivity
+kubectl exec -it -n cognition deployment/cognition -- \
+  python -c "import asyncio; from server.app.storage import get_storage_backend; ..."
+
+# Check PVC usage
+kubectl get pvc -n cognition
+kubectl describe pvc -n cognition cognition-workspace
+```
+
+## 🗑️ Cleanup
+
+```bash
+# Remove Cognition
+helm uninstall cognition -n cognition
+
+# Remove observability
+helm uninstall observe -n cognition-observe
+
+# Remove PostgreSQL
+kubectl delete -f deploy/cnpg/cluster.yaml
+
+# Remove namespace (caution: deletes all data!)
+kubectl delete namespace cognition
+kubectl delete namespace cognition-observe
+```
+
+## 📝 Notes
+
+- **PostgreSQL**: This chart does NOT include PostgreSQL. Deploy it separately using the provided CNPG cluster YAML.
+- **Storage**: Uses Longhorn storage class by default (supports RWX for workspace sharing).
+- **No Hard Limits**: Resource limits are not set by default (as requested). Adjust `resources.requests` in values.yaml if needed.
+- **Tailscale**: Automatically configured for external access. Ensure Tailscale operator is running.
+
+## ⚠️ v0.3.0 Breaking Changes
+
+Cognition v0.3.0 introduced **Dynamic ConfigRegistry** which changes how configuration works:
+
+### What Changed
+- **Removed**: Environment variables for LLM/agent configuration
+  - `COGNITION_LLM_PROVIDER`, `COGNITION_LLM_MODEL`, etc.
+  - `COGNITION_OPENAI_*` settings (except API keys)
+  - `COGNITION_AGENT_*` settings
+
+- **New**: Configuration via `.cognition/config.yaml` (ConfigMap) or API
+  - LLM settings → `config.yaml` (mounted via ConfigMap)
+  - Agent settings → `config.yaml` or API
+  - Hot-reload supported (no restart needed)
+
+### What Stays as Environment Variables
+- Database credentials (`COGNITION_PERSISTENCE_URI`)
+- API keys (`COGNITION_OPENAI_COMPATIBLE_API_KEY`, `AWS_*`)
+- Observability settings
+- Server settings (port, log level)
+
+### Migration
+Configuration is now in `values.yaml` under `config:` section and rendered into a ConfigMap:
+```yaml
+config:
+  llm:
+    provider: openai_compatible
+    model: google/gemini-3-flash-preview
+    # base_url is also set here for v0.3.0
+```
+
+## 🔗 References
+
+- [Cognition Documentation](../../docs/)
+- [CNPG Documentation](https://cloudnative-pg.io/documentation/)
+- [Helm Documentation](https://helm.sh/docs/)

--- a/deploy/cnpg/cluster.yaml
+++ b/deploy/cnpg/cluster.yaml
@@ -1,0 +1,160 @@
+# CNPG Cluster for Cognition
+# Deploy this first before the Cognition Helm chart
+# 
+# Usage:
+#   kubectl apply -f deploy/cnpg/cluster.yaml
+#   # Wait for cluster to be ready
+#   kubectl wait --for=condition=Ready cluster/cognition-db -n cognition --timeout=300s
+#
+# Then create the database credentials secret:
+#   kubectl create secret generic cognition-db-credentials \
+#     --namespace cognition \
+#     --from-literal=uri="postgresql+asyncpg://cognition:$(PASSWORD)@cognition-db-rw:5432/cognition"
+
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cognition-db
+  namespace: cognition
+spec:
+  description: Cognition AI Assistant Database
+  
+  # PostgreSQL version
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.0
+  
+  # 3 instances for HA
+  instances: 3
+  
+  # Storage configuration
+  storage:
+    storageClass: longhorn
+    size: 20Gi
+  
+  # Monitoring disabled for now - CNPG version compatibility
+  
+  # Bootstrap - create initial database
+  bootstrap:
+    initdb:
+      database: cognition
+      owner: cognition
+      secret:
+        name: cognition-db-init-credentials
+      postInitTemplateSQLRefs:
+        configMapRefs:
+          - name: cognition-db-init-scripts
+            key: init.sql
+  
+  # PostgreSQL configuration
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: "256MB"
+      effective_cache_size: "768MB"
+      maintenance_work_mem: "64MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "16MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: "655kB"
+      min_wal_size: "1GB"
+      max_wal_size: "4GB"
+  
+  # Resource configuration - no hard limits as requested
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+  
+  # Affinity - spread across nodes
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+  
+  # Priority class
+  priorityClassName: system-cluster-critical
+  
+  # Failover configuration
+  failoverDelay: 60
+  switchoverDelay: 300
+  
+  # Enable superuser access for maintenance
+  enableSuperuserAccess: true
+
+---
+# Init credentials for database bootstrap
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cognition-db-init-credentials
+  namespace: cognition
+type: Opaque
+stringData:
+  username: cognition
+  password: cognition-password-change-me
+
+---
+# Init scripts for database setup
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cognition-db-init-scripts
+  namespace: cognition
+data:
+  init.sql: |
+    -- Create extensions
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+---
+# Service to expose the primary (read-write)
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognition-db
+  namespace: cognition
+  labels:
+    cnpg.io/cluster: cognition-db
+    cnpg.io/serviceType: primary
+spec:
+  type: ClusterIP
+  selector:
+    cnpg.io/cluster: cognition-db
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+
+---
+# Service for reads (optional - includes replicas)
+apiVersion: v1
+kind: Service
+metadata:
+  name: cognition-db-ro
+  namespace: cognition
+  labels:
+    cnpg.io/cluster: cognition-db
+    cnpg.io/serviceType: replica
+spec:
+  type: ClusterIP
+  selector:
+    cnpg.io/cluster: cognition-db
+    cnpg.io/instanceRole: replica
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+
+---
+# Scheduled backup (optional - comment out if not needed)
+# apiVersion: postgresql.cnpg.io/v1
+# kind: ScheduledBackup
+# metadata:
+#   name: cognition-db-backup
+#   namespace: cognition
+# spec:
+#   schedule: "0 2 * * *"  # Daily at 2 AM
+#   backupOwnerReference: self
+#   cluster:
+#     name: cognition-db

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+#
+# Deploy Cognition to Kubernetes (dubaimetal cluster)
+#
+# Usage:
+#   ./deploy.sh                    # Deploy with defaults
+#   ./deploy.sh --api-key sk-...   # Deploy with API key
+#   ./deploy.sh --tag 0.3.0        # Deploy specific version
+#   ./deploy.sh --dry-run          # Preview changes without deploying
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="cognition"
+DB_NAMESPACE="cognition"
+CHART_PATH="$(dirname "$0")/helm/cognition"
+CNPG_PATH="$(dirname "$0")/cnpg/cluster.yaml"
+DRY_RUN=false
+API_KEY=""
+IMAGE_TAG=""
+WAIT_TIMEOUT="300s"
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    # Check kubectl
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl is not installed"
+        exit 1
+    fi
+    
+    # Check helm
+    if ! command -v helm &> /dev/null; then
+        log_error "helm is not installed"
+        exit 1
+    fi
+    
+    # Check cluster connection
+    if ! kubectl cluster-info &> /dev/null; then
+        log_error "Cannot connect to Kubernetes cluster"
+        exit 1
+    fi
+    
+    # Check current context
+    CURRENT_CONTEXT=$(kubectl config current-context)
+    log_info "Connected to cluster: $CURRENT_CONTEXT"
+    
+    log_success "Prerequisites check passed"
+}
+
+# Deploy PostgreSQL cluster
+deploy_postgres() {
+    log_info "Deploying PostgreSQL CNPG cluster..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY-RUN] Would apply: $CNPG_PATH"
+        return
+    fi
+    
+    # Create namespace if it doesn't exist
+    kubectl create namespace "$DB_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    
+    # Apply CNPG cluster
+    kubectl apply -f "$CNPG_PATH"
+    
+    log_info "Waiting for PostgreSQL cluster to be ready (timeout: $WAIT_TIMEOUT)..."
+    if kubectl wait --for=condition=Ready "cluster/cognition-db" -n "$DB_NAMESPACE" --timeout="$WAIT_TIMEOUT"; then
+        log_success "PostgreSQL cluster is ready"
+    else
+        log_error "PostgreSQL cluster failed to become ready"
+        log_info "Check status with: kubectl get clusters -n $DB_NAMESPACE"
+        exit 1
+    fi
+}
+
+# Create database credentials secret
+create_db_secret() {
+    log_info "Creating database credentials secret..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY-RUN] Would create secret: cognition-db-credentials"
+        return
+    fi
+    
+    # Get password from init secret
+    DB_PASSWORD=$(kubectl get secret cognition-db-init-credentials -n "$DB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+    
+    if [ -z "$DB_PASSWORD" ]; then
+        log_error "Could not retrieve database password"
+        exit 1
+    fi
+    
+    # Create or update secret
+    kubectl create secret generic cognition-db-credentials \
+        --namespace "$NAMESPACE" \
+        --from-literal=uri="postgresql+asyncpg://cognition:${DB_PASSWORD}@cognition-db-rw:5432/cognition" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    
+    log_success "Database credentials secret created"
+}
+
+# Create API keys secret
+create_api_secret() {
+    if [ -z "$API_KEY" ]; then
+        log_warn "No API key provided. Cognition will fail to start without LLM credentials."
+        log_info "Set API key with: --api-key sk-..."
+        return
+    fi
+    
+    log_info "Creating API keys secret..."
+    
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY-RUN] Would create secret: cognition-api-keys"
+        return
+    fi
+    
+    kubectl create secret generic cognition-api-keys \
+        --namespace "$NAMESPACE" \
+        --from-literal=openai-compatible-api-key="$API_KEY" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    
+    log_success "API keys secret created"
+}
+
+# Deploy Cognition Helm chart
+deploy_cognition() {
+    log_info "Deploying Cognition Helm chart..."
+    
+    # Build helm command
+    HELM_CMD="helm upgrade --install cognition $CHART_PATH \
+        --namespace $NAMESPACE \
+        --create-namespace"
+    
+    if [ -n "$IMAGE_TAG" ]; then
+        HELM_CMD="$HELM_CMD --set image.tag=$IMAGE_TAG"
+    fi
+    
+    if [ "$DRY_RUN" = true ]; then
+        HELM_CMD="$HELM_CMD --dry-run --debug"
+        log_info "[DRY-RUN] Helm command:"
+        echo "$HELM_CMD"
+    fi
+    
+    # Execute helm command
+    eval "$HELM_CMD"
+    
+    if [ "$DRY_RUN" = false ]; then
+        log_success "Cognition deployed"
+        
+        log_info "Waiting for Cognition pods to be ready..."
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cognition -n "$NAMESPACE" --timeout="$WAIT_TIMEOUT"
+        log_success "Cognition is ready"
+    fi
+}
+
+# Wait for deployment
+wait_for_deployment() {
+    if [ "$DRY_RUN" = true ]; then
+        return
+    fi
+    
+    log_info "Checking deployment status..."
+    
+    # Check if Tailscale ingress is ready
+    log_info "Checking Tailscale ingress..."
+    if kubectl get ingress cognition -n "$NAMESPACE" &> /dev/null; then
+        log_success "Tailscale ingress configured"
+        log_info "Access Cognition at: http://cognition:8000"
+    fi
+}
+
+# Print deployment info
+print_info() {
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY-RUN] Deployment preview complete"
+        return
+    fi
+    
+    echo ""
+    log_success "Cognition deployment complete!"
+    echo ""
+    echo -e "${GREEN}Access Information:${NC}"
+    echo "  - API Endpoint: http://cognition:8000 (via Tailscale)"
+    echo "  - Health Check: curl http://cognition:8000/health"
+    echo ""
+    echo -e "${GREEN}Useful Commands:${NC}"
+    echo "  - View logs: kubectl logs -n $NAMESPACE deployment/cognition -f"
+    echo "  - Get pods: kubectl get pods -n $NAMESPACE"
+    echo "  - Port forward: kubectl port-forward -n $NAMESPACE svc/cognition 8000:8000"
+    echo "  - Upgrade: ./deploy.sh --api-key <key>"
+    echo ""
+    echo -e "${GREEN}Observability (optional):${NC}"
+    echo "  - Deploy: helm install observe $(dirname "$0")/helm/cognition-observe --namespace cognition-observe --create-namespace"
+    echo ""
+}
+
+# Cleanup function
+cleanup() {
+    if [ "$DRY_RUN" = true ]; then
+        return
+    fi
+    
+    log_info "Cleaning up..."
+    # Nothing to clean up by default
+}
+
+# Main function
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --api-key)
+                API_KEY="$2"
+                shift 2
+                ;;
+            --tag)
+                IMAGE_TAG="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --timeout)
+                WAIT_TIMEOUT="$2"
+                shift 2
+                ;;
+            --help|-h)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --api-key <key>     Set OpenAI Compatible API key"
+                echo "  --tag <version>     Deploy specific image tag (e.g., 0.3.0, latest)"
+                echo "  --dry-run           Preview changes without deploying"
+                echo "  --timeout <duration> Timeout for waits (default: 300s)"
+                echo "  --help, -h          Show this help message"
+                echo ""
+                echo "Examples:"
+                echo "  $0                                    # Deploy with defaults"
+                echo "  $0 --api-key sk-or-xxx                # Deploy with API key"
+                echo "  $0 --tag 0.3.0                        # Deploy specific version"
+                echo "  $0 --api-key sk-or-xxx --tag latest   # Deploy latest with key"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Trap cleanup
+    trap cleanup EXIT
+    
+    echo -e "${GREEN}=================================${NC}"
+    echo -e "${GREEN}  Cognition Deployment Script${NC}"
+    echo -e "${GREEN}=================================${NC}"
+    echo ""
+    
+    # Run deployment steps
+    check_prerequisites
+    deploy_postgres
+    create_db_secret
+    create_api_secret
+    deploy_cognition
+    wait_for_deployment
+    print_info
+}
+
+# Run main function
+main "$@"

--- a/deploy/helm/cognition-observe/Chart.yaml
+++ b/deploy/helm/cognition-observe/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: cognition-observe
+description: Observability stack for Cognition AI (Prometheus, Grafana, MLflow, Loki)
+version: 0.1.0
+appVersion: "1.0.0"
+home: https://github.com/CognicellAI/Cognition
+keywords:
+  - observability
+  - monitoring
+  - prometheus
+  - grafana
+annotations:
+  category: Observability

--- a/deploy/helm/cognition-observe/values.yaml
+++ b/deploy/helm/cognition-observe/values.yaml
@@ -1,0 +1,88 @@
+namespace:
+  create: true
+  name: cognition-observe
+
+# Prometheus configuration
+prometheus:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: prom/prometheus
+    tag: v2.48.0
+  service:
+    port: 9090
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 50Gi
+  retention: 30d
+  scrapeInterval: 15s
+
+# Grafana configuration
+grafana:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: grafana/grafana
+    tag: 10.2.3
+  service:
+    port: 3000
+  admin:
+    user: admin
+    password: admin
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 10Gi
+
+# MLflow configuration
+mlflow:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/mlflow/mlflow
+    tag: v2.9.0
+  service:
+    port: 5000
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 50Gi
+  database:
+    host: cognition-db-rw.cognition.svc.cluster.local
+    port: 5432
+    name: mlflow
+    user: mlflow
+    password: mlflow
+
+# Loki configuration
+loki:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: grafana/loki
+    tag: 2.9.3
+  service:
+    port: 3100
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 30Gi
+
+# OpenTelemetry Collector configuration
+otelCollector:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: otel/opentelemetry-collector-contrib
+    tag: 0.96.0
+  service:
+    grpcPort: 4317
+    httpPort: 4318
+
+# Promtail configuration (runs as DaemonSet)
+promtail:
+  enabled: true
+  image:
+    repository: grafana/promtail
+    tag: 2.9.3

--- a/deploy/helm/cognition/Chart.yaml
+++ b/deploy/helm/cognition/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: cognition
+description: Cognition AI coding assistant - batteries-included AI backend
+version: 0.1.0
+appVersion: "0.3.0"
+home: https://github.com/CognicellAI/Cognition
+sources:
+  - https://github.com/CognicellAI/Cognition
+maintainers:
+  - name: Cognition Team
+keywords:
+  - ai
+  - coding
+  - agent
+  - llm
+  - langgraph
+annotations:
+  category: AI/ML
+  # This chart is standalone and does not include PostgreSQL
+  # PostgreSQL must be deployed separately (recommended: CNPG Cluster)

--- a/deploy/helm/cognition/templates/_helpers.tpl
+++ b/deploy/helm/cognition/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cognition.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cognition.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cognition.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cognition.labels" -}}
+helm.sh/chart: {{ include "cognition.chart" . }}
+{{ include "cognition.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cognition.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cognition.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cognition.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cognition.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database connection URI from secret
+*/}}
+{{- define "cognition.database.uri" -}}
+{{- if .Values.database.existingSecretName }}
+{{- printf "$(DB_URI)" }}
+{{- else }}
+{{- printf "postgresql+asyncpg://%s:$(DB_PASSWORD)@%s:5432/%s" .Values.database.user .Values.database.host .Values.database.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/cognition/templates/configmap.yaml
+++ b/deploy/helm/cognition/templates/configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cognition.fullname" . }}-config
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    llm:
+      provider: {{ .Values.config.llm.provider }}
+      model: {{ .Values.config.llm.model }}
+      {{- if .Values.config.llm.temperature }}
+      temperature: {{ .Values.config.llm.temperature }}
+      {{- end }}
+      {{- if .Values.config.llm.maxTokens }}
+      max_tokens: {{ .Values.config.llm.maxTokens }}
+      {{- end }}
+      {{- if .Values.config.llm.openaiCompatibleBaseUrl }}
+      base_url: {{ .Values.config.llm.openaiCompatibleBaseUrl }}
+      {{- end }}
+    
+    agent:
+      {{- if .Values.config.agent.memory }}
+      memory:
+        {{- toYaml .Values.config.agent.memory | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.agent.skills }}
+      skills:
+        {{- toYaml .Values.config.agent.skills | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.agent.tools }}
+      tools:
+        {{- toYaml .Values.config.agent.tools | nindent 8 }}
+      {{- end }}
+  
+  AGENTS.md: |
+    # Cognition Agent Configuration
+    
+    This file provides project-specific instructions for the Cognition AI assistant.
+    
+    ## Workspace Context
+    
+    - The workspace is mounted at `/workspace`
+    - All file operations should target this directory
+    - Use relative paths from the workspace root
+    
+    ## Development Guidelines
+    
+    - Write clean, well-documented code
+    - Follow existing project conventions
+    - Run tests before committing changes
+    - Use meaningful commit messages
+    
+    {{- if .Values.config.agent.agentsMd }}
+    
+    ## Custom Instructions
+    
+    {{ .Values.config.agent.agentsMd | nindent 4 }}
+    {{- end }}

--- a/deploy/helm/cognition/templates/core/deployment.yaml
+++ b/deploy/helm/cognition/templates/core/deployment.yaml
@@ -1,0 +1,234 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cognition.fullname" . }}
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cognition.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/core/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "cognition.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "cognition.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        # Wait for database to be ready
+        - name: wait-for-db
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for database at {{ .Values.database.host }}:5432..."
+              until nc -z {{ .Values.database.host }} 5432; do
+                echo "Database not ready yet, waiting..."
+                sleep 2
+              done
+              echo "Database is ready!"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            # Server settings
+            - name: COGNITION_HOST
+              value: "0.0.0.0"
+            - name: COGNITION_PORT
+              value: "{{ .Values.service.port }}"
+            - name: COGNITION_WORKSPACE_ROOT
+              value: "/workspace"
+            - name: COGNITION_LOG_LEVEL
+              value: "{{ .Values.config.logLevel }}"
+            
+            # Database settings
+            - name: COGNITION_PERSISTENCE_BACKEND
+              value: "postgres"
+            - name: COGNITION_PERSISTENCE_URI
+              {{- if .Values.database.existingSecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecretName }}
+                  key: {{ .Values.database.existingSecretKey | default "uri" }}
+              {{- else }}
+              value: "postgresql+asyncpg://{{ .Values.database.user }}:$(DB_PASSWORD)@{{ .Values.database.host }}:5432/{{ .Values.database.name }}"
+              {{- end }}
+            
+            # Credentials (API keys remain as env vars in v0.3.0)
+            # Configuration moved to .cognition/config.yaml via ConfigMap
+            # Testing if env vars still work in v0.3.0
+            - name: COGNITION_LLM_PROVIDER
+              value: "{{ .Values.config.llm.provider }}"
+            - name: COGNITION_LLM_MODEL
+              value: "{{ .Values.config.llm.model }}"
+            {{- if .Values.config.llm.temperature }}
+            - name: COGNITION_LLM_TEMPERATURE
+              value: "{{ .Values.config.llm.temperature }}"
+            {{- end }}
+            {{- if .Values.config.llm.maxTokens }}
+            - name: COGNITION_LLM_MAX_TOKENS
+              value: "{{ .Values.config.llm.maxTokens }}"
+            {{- end }}
+            {{- if .Values.config.llm.openaiCompatibleBaseUrl }}
+            - name: COGNITION_OPENAI_COMPATIBLE_BASE_URL
+              value: "{{ .Values.config.llm.openaiCompatibleBaseUrl }}"
+            {{- end }}
+            {{- if .Values.secrets.openaiCompatibleApiKey }}
+            - name: COGNITION_OPENAI_COMPATIBLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cognition.fullname" . }}-api-keys
+                  key: openai-compatible-api-key
+            {{- end }}
+            
+            # AWS/Bedrock credentials
+            {{- if .Values.config.aws.region }}
+            - name: AWS_REGION
+              value: "{{ .Values.config.aws.region }}"
+            {{- end }}
+            {{- if .Values.config.aws.bedrockRoleArn }}
+            - name: COGNITION_BEDROCK_ROLE_ARN
+              value: "{{ .Values.config.aws.bedrockRoleArn }}"
+            {{- end }}
+            {{- if .Values.secrets.awsAccessKeyId }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cognition.fullname" . }}-api-keys
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cognition.fullname" . }}-api-keys
+                  key: aws-secret-access-key
+            {{- end }}
+            
+            # Observability settings
+            - name: COGNITION_OTEL_ENABLED
+              value: "{{ .Values.config.observability.enabled }}"
+            {{- if .Values.config.observability.enabled }}
+            - name: COGNITION_OTEL_ENDPOINT
+              value: "{{ .Values.config.observability.otelEndpoint }}"
+            - name: COGNITION_METRICS_PORT
+              value: "{{ .Values.service.metricsPort }}"
+            - name: COGNITION_MLFLOW_ENABLED
+              value: "{{ .Values.config.observability.mlflowEnabled }}"
+            - name: COGNITION_MLFLOW_TRACKING_URI
+              value: "{{ .Values.config.observability.mlflowUri }}"
+            - name: COGNITION_MLFLOW_EXPERIMENT_NAME
+              value: "{{ .Values.config.observability.mlflowExperiment }}"
+            {{- end }}
+            
+            # Sandbox settings
+            - name: COGNITION_SANDBOX_BACKEND
+              value: "{{ .Values.config.sandbox.backend }}"
+            
+            # Session scoping
+            - name: COGNITION_SCOPING_ENABLED
+              value: "{{ .Values.config.scoping.enabled }}"
+            {{- if .Values.config.scoping.enabled }}
+            - name: COGNITION_SCOPE_KEYS
+              value: '["{{ join "\",\"" .Values.config.scoping.keys }}"]'
+            {{- end }}
+            
+            # Rate limiting
+            - name: COGNITION_RATE_LIMIT_PER_MINUTE
+              value: "{{ .Values.config.rateLimit.perMinute }}"
+            - name: COGNITION_RATE_LIMIT_BURST
+              value: "{{ .Values.config.rateLimit.burst }}"
+            
+            # Database password from secret (if not using existing secret with full URI)
+            {{- if not .Values.database.existingSecretName }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cognition.fullname" . }}-db-credentials
+                  key: password
+            {{- end }}
+            
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: config
+              mountPath: /app/.cognition
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: workspace
+          {{- if .Values.persistence.workspace.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.workspace.existingClaim | default (printf "%s-workspace" (include "cognition.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "cognition.fullname" . }}-config
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/cognition/templates/core/secrets.yaml
+++ b/deploy/helm/cognition/templates/core/secrets.yaml
@@ -1,0 +1,35 @@
+{{- if not .Values.database.existingSecretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cognition.fullname" . }}-db-credentials
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.password | default (randAlphaNum 32) | quote }}
+{{- end }}
+
+---
+{{- if or .Values.secrets.openaiApiKey .Values.secrets.openaiCompatibleApiKey .Values.secrets.awsAccessKeyId }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cognition.fullname" . }}-api-keys
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.secrets.openaiApiKey }}
+  openai-api-key: {{ .Values.secrets.openaiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiCompatibleApiKey }}
+  openai-compatible-api-key: {{ .Values.secrets.openaiCompatibleApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsAccessKeyId }}
+  aws-access-key-id: {{ .Values.secrets.awsAccessKeyId | quote }}
+  aws-secret-access-key: {{ .Values.secrets.awsSecretAccessKey | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cognition/templates/core/service.yaml
+++ b/deploy/helm/cognition/templates/core/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cognition.fullname" . }}
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "cognition.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+
+---
+{{- if .Values.tailscale.enabled }}
+apiVersion: tailscale.com/v1alpha1
+kind: Ingress
+metadata:
+  name: {{ include "cognition.fullname" . }}
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+spec:
+  hostname: {{ .Values.tailscale.hostname }}
+  backend:
+    service:
+      name: {{ include "cognition.fullname" . }}
+      port:
+        number: {{ .Values.service.port }}
+{{- end }}

--- a/deploy/helm/cognition/templates/core/serviceaccount.yaml
+++ b/deploy/helm/cognition/templates/core/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cognition.serviceAccountName" . }}
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cognition/templates/core/workspace-pvc.yaml
+++ b/deploy/helm/cognition/templates/core/workspace-pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.persistence.workspace.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "cognition.fullname" . }}-workspace
+  namespace: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.workspace.accessMode }}
+  storageClassName: {{ .Values.persistence.workspace.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.workspace.size }}
+{{- end }}

--- a/deploy/helm/cognition/templates/namespace.yaml
+++ b/deploy/helm/cognition/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+{{- end }}

--- a/deploy/helm/cognition/values.yaml
+++ b/deploy/helm/cognition/values.yaml
@@ -1,0 +1,201 @@
+# Default values for cognition.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Namespace configuration
+namespace:
+  create: true
+  name: cognition
+
+# Number of replicas for the Cognition server
+replicaCount: 3
+
+image:
+  # GitHub Container Registry image
+  # https://github.com/CognicellAI/Cognition/pkgs/container/cognition
+  repository: ghcr.io/cognicellai/cognition
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # Available tags: latest, 0.3.0, 0.2.0, etc.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 8000
+  metricsPort: 9090
+
+# Tailscale ingress configuration
+tailscale:
+  enabled: true
+  hostname: cognition
+
+# Autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Database configuration
+# Note: This chart does NOT deploy PostgreSQL. You must deploy it separately.
+database:
+  # Database host (service name or IP)
+  host: cognition-db-rw
+  # Database port
+  port: 5432
+  # Database name
+  name: cognition
+  # Database user
+  user: cognition
+  # Database password (only used if existingSecretName is not set)
+  password: ""
+  # Use existing secret for database credentials
+  # The secret should contain a key named 'uri' with the full connection string
+  # Format: postgresql+asyncpg://user:password@host:5432/dbname
+  existingSecretName: ""
+  existingSecretKey: "uri"
+
+# Persistence configuration
+persistence:
+  workspace:
+    enabled: true
+    # Storage class for the workspace PVC
+    storageClass: longhorn
+    # Access mode - ReadWriteMany allows multiple pods to share the workspace
+    accessMode: ReadWriteMany
+    # Size of the workspace volume
+    size: 50Gi
+    # Use existing PVC instead of creating a new one
+    existingClaim: ""
+
+# Cognition configuration
+config:
+  # Log level: debug, info, warn, error
+  logLevel: info
+  
+  # LLM provider configuration
+  llm:
+    # Provider: openai, bedrock, openai_compatible, ollama
+    provider: openai_compatible
+    # Model name
+    model: google/gemini-3-flash-preview
+    # Temperature (optional)
+    temperature: 0.5
+    # Max tokens (optional)
+    maxTokens: 4096
+    # Base URL for OpenAI compatible providers (e.g., OpenRouter, vLLM)
+    openaiCompatibleBaseUrl: "https://openrouter.ai/api/v1"
+  
+  # Agent configuration
+  agent:
+    # Memory files to load
+    memory:
+      - AGENTS.md
+    # Skills directories
+    skills:
+      - .cognition/skills/
+    # Additional tools (optional)
+    tools: []
+    # Custom AGENTS.md content (optional)
+    agentsMd: ""
+  
+  # AWS/Bedrock configuration
+  aws:
+    # AWS region
+    region: us-east-1
+    # Bedrock role ARN (optional - for cross-account access)
+    bedrockRoleArn: ""
+  
+  # Observability configuration
+  observability:
+    # Enable OpenTelemetry tracing
+    enabled: false
+    # OTel collector endpoint
+    otelEndpoint: http://otel-collector:4317
+    # Enable MLflow tracing
+    mlflowEnabled: false
+    # MLflow tracking URI
+    mlflowUri: http://mlflow:5000
+    # MLflow experiment name
+    mlflowExperiment: cognition
+  
+  # Sandbox configuration
+  sandbox:
+    # Backend: local, docker
+    backend: local
+  
+  # Session scoping configuration
+  scoping:
+    enabled: true
+    keys:
+      - user
+  
+  # Rate limiting configuration
+  rateLimit:
+    perMinute: 60
+    burst: 10
+
+# Secrets configuration
+# These values should be set in a separate secret or via --set flags
+secrets:
+  # OpenAI API key (for OpenAI provider)
+  openaiApiKey: ""
+  # OpenAI Compatible API key (for OpenRouter, vLLM, etc.)
+  openaiCompatibleApiKey: ""
+  # AWS credentials (for Bedrock provider)
+  awsAccessKeyId: ""
+  awsSecretAccessKey: ""
+
+# Resource configuration - no hard limits as requested
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  # limits: {}  # No hard limits
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - cognition
+          topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

Add complete Kubernetes deployment configuration for Cognition v0.3.0 with Helm charts and Kustomize compatibility.

## What's Included

### Helm Charts
- **cognition/** - Main application chart
  - 3 replica deployment with HA
  - ConfigMap for .cognition/ configuration
  - PVC for shared workspace (Longhorn RWX)
  - Environment-based LLM provider configuration
  - Tailscale ingress support
  
- **cognition-observe/** - Observability stack (optional)
  - Prometheus, Grafana, MLflow, Loki

### CNPG Cluster
- PostgreSQL 16 cluster with 3 instances
- Automated backup configuration
- Proper initialization scripts

### Deployment Script
-  - Automated deployment with:
  - Prerequisite checks
  - Database setup
  - Secret management
  - Health verification

## Configuration

### Environment Variables (Working in v0.3.0)
- 
- 
- 
- 

### Usage

[0;32m=================================[0m
[0;32m  Cognition Deployment Script[0m
[0;32m=================================[0m

[0;34m[INFO][0m Checking prerequisites...
[0;34m[INFO][0m Connected to cluster: dubaimetal
[0;32m[SUCCESS][0m Prerequisites check passed
[0;34m[INFO][0m Deploying PostgreSQL CNPG cluster...
namespace/cognition unchanged
cluster.postgresql.cnpg.io/cognition-db unchanged
secret/cognition-db-init-credentials configured
configmap/cognition-db-init-scripts unchanged
service/cognition-db unchanged
service/cognition-db-ro unchanged
[0;34m[INFO][0m Waiting for PostgreSQL cluster to be ready (timeout: 300s)...
cluster.postgresql.cnpg.io/cognition-db condition met
[0;32m[SUCCESS][0m PostgreSQL cluster is ready
[0;34m[INFO][0m Creating database credentials secret...
secret/cognition-db-credentials configured
[0;32m[SUCCESS][0m Database credentials secret created
[0;34m[INFO][0m Creating API keys secret...
secret/cognition-api-keys configured
[0;32m[SUCCESS][0m API keys secret created
[0;34m[INFO][0m Deploying Cognition Helm chart...
Release "cognition" has been upgraded. Happy Helming!
NAME: cognition
LAST DEPLOYED: Wed Mar 18 21:11:14 2026
NAMESPACE: cognition
STATUS: deployed
REVISION: 5
TEST SUITE: None
[0;32m[SUCCESS][0m Cognition deployed
[0;34m[INFO][0m Waiting for Cognition pods to be ready...
pod/cognition-5846fb6b9f-cxg2c condition met
pod/cognition-5846fb6b9f-jlk8b condition met
pod/cognition-5846fb6b9f-p8l6g condition met
[0;32m[SUCCESS][0m Cognition is ready
[0;34m[INFO][0m Checking deployment status...
[0;34m[INFO][0m Checking Tailscale ingress...

[0;32m[SUCCESS][0m Cognition deployment complete!

[0;32mAccess Information:[0m
  - API Endpoint: http://cognition:8000 (via Tailscale)
  - Health Check: curl http://cognition:8000/health

[0;32mUseful Commands:[0m
  - View logs: kubectl logs -n cognition deployment/cognition -f
  - Get pods: kubectl get pods -n cognition
  - Port forward: kubectl port-forward -n cognition svc/cognition 8000:8000
  - Upgrade: ./deploy.sh --api-key <key>

[0;32mObservability (optional):[0m
  - Deploy: helm install observe ./helm/cognition-observe --namespace cognition-observe --create-namespace

[0;34m[INFO][0m Cleaning up...

## Testing

- ✅ Deployed to dubaimetal cluster
- ✅ PostgreSQL cluster healthy (3 instances)
- ✅ Cognition API responding
- ✅ OpenRouter integration working
- ✅ Streaming responses functional

## Notes

Provider bootstrap from config.yaml has a known issue (see #24 comments). Environment variables work as a workaround.

## Related

- Documents findings in #24
- Provides workaround for provider configuration