### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,52 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [0.2.0] — 2026-03-10
+## [0.5.0] — 2026-03-22
+
+### Features
+
+- **Source-in-DB tools** (`POST /tools` with `code` field): Register custom Python tools via the REST API without filesystem access. Tool source is stored in the ConfigRegistry and executed at runtime. Enables builder applications running in separate containers to extend agent capabilities dynamically — no server restart, no container rebuild, no SSH required. `GET /tools` now returns tools from both file discovery and ConfigRegistry with a `source_type` discriminator (`file`, `api_code`, `api_path`).
+
+- **LangGraph Store for cross-session agent memory**: All storage backends (`SqliteStorageBackend`, `PostgresStorageBackend`, `MemoryStorageBackend`) now expose `get_store()` returning a LangGraph `BaseStore` instance. `create_deep_agent()` receives `store=` and `context_schema=CognitionContext`, making `runtime.store` available inside agent nodes and middleware. `CognitionContext` scopes Store namespaces per user — user A cannot read user B's stored data. Built-in memory tools are planned (#45).
+
+- **Full `AgentDefinition` field wiring**: `stream_response()` previously consumed only 3 of 12+ `AgentDefinition` fields. Now wires `memory`, `interrupt_on`, `middleware` (resolved from declarative names), `tools` (merged with registry tools), and `config.model`/`config.provider`/`config.temperature`/`config.recursion_limit` as a new agent-level override tier. Resolution hierarchy: session → agent definition → ConfigRegistry → global default.
+
+### Dependency Upgrades
+
+- **deepagents 0.3.12 → 0.4.12**: Includes security fix for `CompositeBackend` path boundary enforcement (0.4.6), bug fix for full routed path in write/edit results (0.4.7), and `create_summarization_tool_middleware()` factory (0.4.8).
+- **langgraph 1.0.8 → 1.1.3**, **langchain 1.2.9 → 1.2.13**: Enables `astream()` with `version="v2"` unified StreamPart format.
+- **anthropic 0.79.0 → 0.86.0**, **langchain-anthropic 1.3.2 → 1.4.0**.
+
+### Bug Fixes
+
+- **Streaming: broken tool call ID correlation**: `DeepAgentRuntime` was using `id(data)` — a CPython memory address — as `tool_call_id`, making it impossible for clients to correlate `tool_call` and `tool_result` events. Fixed by migrating from `astream_events()` to `astream(stream_mode=["messages", "updates", "custom"], subgraphs=True, version="v2")`. Tool IDs now come from real LangGraph-assigned identifiers.
+
+- **Streaming: no subagent visibility**: `astream_events()` did not surface subgraph execution. Subagent activity is now emitted as `DelegationEvent` via `chunk["ns"]` namespace detection.
+
+- **`AsyncPostgresStore` initialization error**: `from_conn_string()` is an `@asynccontextmanager`, not a coroutine. Calling it directly produced `'_AsyncGeneratorContextManager' object has no attribute 'setup'`, causing every streaming response to fail in Postgres deployments. Fixed by creating a `psycopg.AsyncConnection` directly (same pattern as `AsyncPostgresSaver`). Discovered via E2E testing against docker-compose.
+
+- **`execute()` signature mismatch**: deepagents 0.4.3 added `timeout: int | None = None` to `SandboxBackendProtocol.execute()`. Updated `CognitionLocalSandboxBackend` and `CognitionDockerSandboxBackend` to match. Also fixed a latent `AttributeError`: `self._timeout` did not exist; now uses `self._default_timeout` from the parent class.
+
+### Removed
+
+- **`ContextManager` / `context.py`**: Removed `ContextManager`, `FileRelevanceScorer`, and `ProjectIndex` (~305 lines). `ContextManager` shelled out to `find`/`stat` at session init time (N+1 subprocess calls), producing a stale static snapshot. Agents now discover project structure dynamically via their built-in `ls`/`glob`/`grep` filesystem tools.
+
+- **AST security scanning**: Removed `BANNED_IMPORTS`, `BANNED_CALLS`, `BANNED_OS_CALLS`, `SecurityASTVisitor`, and `scan_for_security_violations()` from `agent_registry.py`. AST scanning was bypassable via reflection and inconsistent with API-registered source-in-DB tools (which could not be scanned). `COGNITION_TOOL_SECURITY` (`warn`/`strict`) is also removed. The consistent security model is: trust is established at the API authentication boundary; `COGNITION_BLOCKED_TOOLS` enforces per-name tool blocking at the middleware layer. See `AGENTS.md` for the full trust model.
+
+- **Dead code**: Removed `_planning_mode`, `_plan_todos`, `_current_step_index`, `_completed_steps` tracking variables from `stream_response()` (assigned but never read). Removed duplicate `write_todos` prompt injections from `SYSTEM_PROMPT` and `_build_messages()` — Deep Agents' `TodoListMiddleware` handles this natively.
+
+### Migration Notes
+
+| Change | Migration |
+|---|---|
+| `COGNITION_TOOL_SECURITY` removed | Remove from your `.env`. Use `COGNITION_BLOCKED_TOOLS` for tool name blocking; enforce authorization on `POST /tools` at the Gateway layer. |
+| `ToolRegistration.path` is now optional | Existing DB entries with a `path` value continue to work. New entries require exactly one of `path` or `code`. |
+| `POST /tools` now requires `code` XOR `path` | Pass `"code": "..."` for inline source or `"path": "module.path"` for a module path — not both, not neither. |
+| Streaming `tool_call_id` format changed | Old: `"{tool_name}_{cpython_id}"`. New: real LangGraph-assigned ID (e.g. `"tool_ls_abc123"`). Update any client code that parsed the old format. |
+
+---
+
+## [0.4.0] — 2026-03-19
 
 ### Features
 
@@ -151,5 +196,7 @@ Initial public release of Cognition — a batteries-included AI backend built on
 - Fixed `DiscoveredModel` attribute access in models route
 - Fixed stale `# type: ignore` comments after adding `types-PyYAML` stubs
 
+[0.5.0]: https://github.com/CognicellAI/Cognition/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/CognicellAI/Cognition/releases/tag/v0.4.0
 [0.1.1]: https://github.com/CognicellAI/Cognition/releases/tag/v0.1.1
 [0.1.0]: https://github.com/CognicellAI/Cognition/releases/tag/v0.1.0

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -80,7 +80,7 @@ Returns server health status.
 ```json
 {
   "status": "healthy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "active_sessions": 3,
   "circuit_breakers": [],
   "timestamp": "2026-03-19T12:00:00Z"

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -62,7 +62,7 @@ Verify it's up:
 
 ```bash
 curl -s http://localhost:8000/health
-# {"status": "healthy", "version": "0.4.0", ...}
+# {"status": "healthy", "version": "0.5.0", ...}
 ```
 
 > **Don't want Docker?** Install with `uv sync --extra openai` and run `uv run uvicorn server.app.main:app --reload --port 8000`. See [Deployment](./deployment.md) for production options (PostgreSQL, Kubernetes, multi-instance).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognition"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local AI coding assistant built on LangGraph Deep Agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -150,7 +150,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="Cognition",
     description="AI-powered coding assistant",
-    version="0.4.0",
+    version="0.5.0",
     lifespan=lifespan,
 )
 
@@ -184,7 +184,7 @@ async def health_check() -> HealthStatus:
 
     return HealthStatus(
         status="healthy",
-        version="0.4.0",
+        version="0.5.0",
         active_sessions=len(sessions_list),
         circuit_breakers=[],
         timestamp=datetime.now(UTC),

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 
 [[package]]
 name = "cognition"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "deepagents" },


### PR DESCRIPTION
## Release v0.5.0

Version bump `0.4.0 → 0.5.0` and CHANGELOG for all changes in the deep-agents-alignment initiative.

### What's in this release (since v0.4.0)

**New features:**
- Source-in-DB tools — register tools via `POST /tools` with inline Python source (no filesystem access required)
- LangGraph Store for cross-session agent memory — `runtime.store` available in all agent nodes and middleware
- Full `AgentDefinition` field wiring — all 12+ fields now consumed at runtime (previously only 3 were)

**Bug fixes:**
- Streaming `tool_call_id` correlation was broken (CPython `id(data)` — different value at start vs end)
- `AsyncPostgresStore` initialization error (`_AsyncGeneratorContextManager has no attribute setup`) — every streaming response failed in Postgres deployments
- `execute()` signature mismatch with deepagents 0.4.3

**Removed:**
- `ContextManager` / `context.py` (~305 lines of N+1 subprocess calls at session init)
- AST security scanning (`BANNED_IMPORTS`, `SecurityASTVisitor`, `COGNITION_TOOL_SECURITY`)
- Dead tracking state variables and duplicate `write_todos` prompt injections

**Deps:** deepagents 0.3.12→0.4.12, langgraph 1.0.8→1.1.3, langchain 1.2.9→1.2.13, anthropic 0.79.0→0.86.0

See [CHANGELOG.md](../../blob/main/CHANGELOG.md) for full details and migration notes.

---

After this PR merges, create the GitHub release from the `v0.5.0` tag to trigger Docker image builds and PyPI publish.