### PR TITLE
feat: Kubernetes sandbox backend using agent-sandbox CRD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,34 +46,6 @@ jobs:
       - name: Run linting
         run: uv run ruff check .
 
-  # ─── PyPI publish ─────────────────────────────────────────────────────────
-  publish-pypi:
-    needs: test
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Build package
-        run: uv build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
-
   # ─── Cache warm-up (every push to main) ───────────────────────────────────
   # Builds without pushing on every push to main so that layer caches are
   # warm when a release fires. Scoped per-image to avoid eviction conflicts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.7.0] — 2026-04-11
+
+### Features
+
+- **Kubernetes sandbox backend**: Cognition can now run agent commands in K8s-native sandboxes using the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD and controller. This is the third sandbox backend (alongside `local` and `docker`) and the only one that works when Cognition itself is deployed on Kubernetes with security hardening (`readOnlyRootFilesystem`, `capabilities.drop: ["ALL"]`, `runAsNonRoot`).
+
+  The implementation follows the `langchain-<provider>` convention with a standalone `langchain-k8s-sandbox` workspace package that has zero Cognition imports. Cognition wraps it in `CognitionKubernetesSandboxBackend` which adds domain policy (protected paths, scoping labels, session lifecycle).
+
+  Key capabilities:
+  - Lazy sandbox creation on first `execute()` (no pod until agent invokes a shell tool)
+  - `sh -c` command wrapping for heredoc/pipe support required by BaseSandbox file operations
+  - TTL-based auto-cleanup via `spec.shutdownTime` patch on Sandbox CR
+  - Scoping labels (`cognition.io/user`, `cognition.io/session`) on SandboxClaim CRs
+  - Session deletion triggers `terminate()` via `SessionAgentManager.unregister_session()`
+  - Startup validation checks CRD existence (fatal) and router health (warning)
+  - Helm chart RBAC (namespace-scoped Role + cluster-scoped ClusterRole for CRD reads)
+  - Optional NetworkPolicy to deny sandbox egress (`config.sandbox.k8s.denyEgress`)
+  - SandboxTemplate example with `/tmp` and `/workspace` emptyDir volumes
+  - 35 unit tests + 13 e2e tests (skip unless `COGNITION_K8S_E2E=1`)
+
+### Bug Fixes
+
+- Fix agent cache returning raw `CompiledStateGraph` instead of `CognitionAgentResult` on cache hit, causing `AttributeError: 'CompiledStateGraph' object has no attribute 'sandbox_backend'` in streaming service.
+
+---
+
 ## [0.6.0] — 2026-03-23
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,13 @@ WORKDIR /app
 
 # Copy lockfile and project metadata first for layer caching
 COPY pyproject.toml uv.lock README.md ./
+COPY packages/ ./packages/
 
 # Install production deps only using the frozen lockfile (no test extras)
 # --no-dev: skip dev-only deps (ruff, mypy, pre-commit)
 # --no-install-project: deps only — source code is copied in the next stage
-# --extra openai,bedrock,deploy: include all production extras
-RUN uv sync --frozen --no-dev --no-install-project --extra openai --extra bedrock --extra deploy
+# --extra openai,bedrock,deploy,k8s: include all production extras
+RUN uv sync --frozen --no-dev --no-install-project --extra openai --extra bedrock --extra deploy --extra k8s
 
 # Production stage
 FROM python:3.11-slim AS production
@@ -63,6 +64,7 @@ WORKDIR /app
 COPY server/ ./server/
 COPY client/ ./client/
 COPY shared/ ./shared/
+COPY packages/ ./packages/
 COPY pyproject.toml .
 
 # Create workspace directory and set permissions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,6 +156,7 @@ The following fallback patterns exist and are tracked for removal. They produce 
 | **MCP server wiring** | Layer 4/5 | Completed | `COGNITION_MCP_SERVERS` env var / YAML key configures remote MCP servers; each entry validated (HTTP/HTTPS only) at startup; tools from MCP servers available to agent in all execution paths | 0.5 days | None |
 | **Bedrock IAM role support** | Layer 5 | Completed | Ambient credentials (instance profile, ECS task role, Lambda, IRSA) work without any key configuration; `COGNITION_BEDROCK_ROLE_ARN` enables cross-account role assumption; `AWS_SESSION_TOKEN` supported for STS temp credentials; partial key pair raises clear error | 0.5 days | None |
 | **Wire rate_limit_per_minute / rate_limit_burst to RateLimiter** | Layer 6 | Completed | `COGNITION_RATE_LIMIT_PER_MINUTE` and `COGNITION_RATE_LIMIT_BURST` are actually enforced by the rate limiter (previously reported in `/config` but ignored) | 0.25 days | None |
+| **K8s sandbox backend** | Layer 3/4 | Completed | `langchain-k8s-sandbox` workspace package; `CognitionKubernetesSandboxBackend`; Helm RBAC + values; SandboxTemplate example; 35 unit tests + 13 e2e tests; live-verified on Talos cluster | 5 days | agent-sandbox controller installed separately |
 | Multi-user session isolation | Layer 2 | Pending | Users can only see/access their own sessions | 2 days | P0: Session lifecycle |
 | Graceful abort/cancellation | Layer 4 | Pending | Abort button immediately stops execution; no zombie processes | 1 day | P0: Session lifecycle |
 | Proper error propagation | Layer 5/6 | Completed | All 14 fallback sites resolved: provider errors surface with `LLMProviderConfigError`, registry-missing returns 503, silent `except Exception: pass` replaced with logged warnings throughout | 2 days | None |
@@ -355,4 +356,4 @@ Per AGENTS.md requirements:
    - Features/Architectural: Before starting work
    - Security/Bug/Performance/Dependency: As part of PR
 
-**Last Updated**: 2026-03-19 (model catalog integration)
+**Last Updated**: 2026-04-11 (K8s sandbox backend)

--- a/deploy/examples/cognition-sandbox-template.yaml
+++ b/deploy/examples/cognition-sandbox-template.yaml
@@ -1,0 +1,55 @@
+# SandboxTemplate for Cognition K8s sandbox backend.
+# Apply this before deploying Cognition with config.sandbox.backend=kubernetes.
+#
+# Prerequisites:
+# 1. Install agent-sandbox controller + extensions
+#    kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/manifest.yaml
+#    kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/extensions.yaml
+# 2. Deploy the sandbox-router (see agent-sandbox docs)
+# 3. Build and push the cognition-sandbox image
+#    docker build -f Dockerfile.sandbox -t cognition-sandbox:latest .
+#    docker push cognition-sandbox:latest
+# 4. Apply this template
+#    kubectl apply -f cognition-sandbox-template.yaml
+
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: cognition-sandbox
+  labels:
+    app.kubernetes.io/part-of: cognition
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - name: sandbox
+        image: cognition-sandbox:latest
+        ports:
+        - containerPort: 8888
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "1"
+          requests:
+            memory: "256Mi"
+            cpu: "0.5"
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: workspace
+          mountPath: /workspace
+      volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: "128Mi"
+      - name: workspace
+        emptyDir:
+          sizeLimit: "1Gi"

--- a/deploy/helm/cognition/templates/core/deployment.yaml
+++ b/deploy/helm/cognition/templates/core/deployment.yaml
@@ -150,6 +150,20 @@ spec:
             # Sandbox settings
             - name: COGNITION_SANDBOX_BACKEND
               value: "{{ .Values.config.sandbox.backend }}"
+            {{- if eq .Values.config.sandbox.backend "kubernetes" }}
+            - name: COGNITION_K8S_SANDBOX_TEMPLATE
+              value: "{{ .Values.config.sandbox.k8s.template }}"
+            - name: COGNITION_K8S_SANDBOX_NAMESPACE
+              value: "{{ .Values.config.sandbox.k8s.namespace | default .Release.Namespace }}"
+            - name: COGNITION_K8S_SANDBOX_ROUTER_URL
+              value: "{{ .Values.config.sandbox.k8s.routerUrl | default (printf "http://sandbox-router-svc.%s.svc.cluster.local:8080" (.Values.config.sandbox.k8s.namespace | default .Release.Namespace)) }}"
+            - name: COGNITION_K8S_SANDBOX_TTL
+              value: "{{ .Values.config.sandbox.k8s.ttl }}"
+            {{- if .Values.config.sandbox.k8s.warmPool }}
+            - name: COGNITION_K8S_SANDBOX_WARM_POOL
+              value: "{{ .Values.config.sandbox.k8s.warmPool }}"
+            {{- end }}
+            {{- end }}
             
             # Session scoping
             - name: COGNITION_SCOPING_ENABLED

--- a/deploy/helm/cognition/templates/core/rbac.yaml
+++ b/deploy/helm/cognition/templates/core/rbac.yaml
@@ -1,0 +1,65 @@
+{{- if eq .Values.config.sandbox.backend "kubernetes" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cognition.fullname" . }}-sandbox-reader
+  namespace: {{ .Values.config.sandbox.k8s.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes/status"]
+    verbs: ["get"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims", "sandboxtemplates"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cognition.fullname" . }}-sandbox-reader
+  namespace: {{ .Values.config.sandbox.k8s.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cognition.fullname" . }}-sandbox-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cognition.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cognition.fullname" . }}-crd-reader
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+    resourceNames:
+      - sandboxes.agents.x-k8s.io
+      - sandboxclaims.extensions.agents.x-k8s.io
+      - sandboxtemplates.extensions.agents.x-k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cognition.fullname" . }}-crd-reader
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cognition.fullname" . }}-crd-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cognition.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/cognition/templates/networking/sandbox-networkpolicy.yaml
+++ b/deploy/helm/cognition/templates/networking/sandbox-networkpolicy.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.config.sandbox.backend "kubernetes") .Values.config.sandbox.k8s.denyEgress }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cognition.fullname" . }}-sandbox-deny-egress
+  namespace: {{ .Values.config.sandbox.k8s.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "cognition.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      agents.x-k8s.io/sandbox: "true"
+  policyTypes:
+    - Egress
+  egress: []
+{{- end }}

--- a/deploy/helm/cognition/values.yaml
+++ b/deploy/helm/cognition/values.yaml
@@ -151,8 +151,22 @@ config:
   
   # Sandbox configuration
   sandbox:
-    # Backend: local, docker
+    # Backend: local, docker, kubernetes
     backend: local
+    # Kubernetes-specific settings (only used when backend=kubernetes)
+    k8s:
+      # SandboxTemplate CR name for sandbox pod spec
+      template: cognition-sandbox
+      # Kubernetes namespace for sandbox CRs (defaults to release namespace)
+      namespace: ""
+      # URL of the sandbox-router service
+      routerUrl: ""
+      # Time-to-live in seconds for sandbox auto-cleanup
+      ttl: 3600
+      # Optional SandboxWarmPool CR name for pre-warmed allocation
+      warmPool: ""
+      # Deny all egress from sandbox pods (K8s equivalent of Docker network_mode: "none")
+      denyEgress: false
   
   # Session scoping configuration
   scoping:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The documentation is organized into two sections: **Concepts** explain how Cogni
 | [Sessions & Messages](./concepts/sessions-and-messages.md) | Session lifecycle, message persistence, SSE streaming, and reconnection |
 | [Agent Runtime](./concepts/agent-runtime.md) | AgentRuntime protocol, AgentDefinition model, and the multi-agent registry |
 | [Storage & Execution](./concepts/storage-and-execution.md) | StorageBackend and ExecutionBackend protocols and their implementations |
+| [Kubernetes Sandbox](./concepts/kubernetes-sandbox.md) | K8s-native sandbox isolation using the agent-sandbox CRD and controller |
 | [Observability](./concepts/observability.md) | OpenTelemetry traces, Prometheus metrics, and MLflow experiment tracking |
 | [Security](./concepts/security.md) | Session scoping, sandbox isolation, tool security, rate limiting, and CORS |
 

--- a/docs/concepts/kubernetes-sandbox.md
+++ b/docs/concepts/kubernetes-sandbox.md
@@ -1,0 +1,393 @@
+# Kubernetes Sandbox Backend
+
+How Cognition runs agent commands in Kubernetes-native sandboxes using the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD and controller.
+
+---
+
+## Why a K8s Backend
+
+Cognition ships three sandbox backends:
+
+| Backend | Isolation | Works on K8s? |
+|---|---|---|
+| `local` | None — commands run as server process user | Yes, but no isolation |
+| `docker` | Container per session | No — requires Docker socket + privileged mode |
+| `kubernetes` | Sandbox pod per session | Yes — K8s-native, no special privileges needed |
+
+The Cognition Helm chart deploys the server with `readOnlyRootFilesystem: true`, `capabilities.drop: ["ALL"]`, and `runAsNonRoot: true`. The Docker backend cannot work under these constraints. The K8s backend uses the agent-sandbox CRD + controller + router to provide isolated sandbox pods without requiring any privileged access from the Cognition server.
+
+---
+
+## Two-Package Split
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Cognition (this repo)                              │
+│                                                     │
+│  CognitionKubernetesSandboxBackend                  │
+│  • Protected path enforcement (.cognition/)         │
+│  • Scoping labels from CognitionContext             │
+│  • Session-scoped lifecycle                         │
+│  • Delegates all execution to K8sSandbox            │
+│                                                     │
+│  Wraps ──────────────────────────────────┐          │
+│                                         │          │
+└─────────────────────────────────────────┼──────────┘
+                                          │
+┌─────────────────────────────────────────┼──────────┐
+│  langchain-k8s-sandbox (standalone pkg) │          │
+│                                         ▼          │
+│  K8sSandbox(BaseSandbox)                          │
+│  • Lazy init on first execute()                   │
+│  • Labels passthrough to Sandbox CR               │
+│  • TTL via spec.shutdownTime patch                │
+│  • BaseSandbox file ops via execute()             │
+│                                                   │
+│  Uses ─────────────────────────────────┐          │
+│                                       │          │
+└───────────────────────────────────────┼──────────┘
+                                      │
+┌──────────────────────────────────────┼────────────┐
+│  k8s-agent-sandbox SDK (PyPI)       │            │
+│                                     ▼            │
+│  SandboxClient                                   │
+│  • create_sandbox(template, namespace, labels)   │
+│  • sandbox.commands.run(cmd, timeout)            │
+│  • sandbox.terminate()                           │
+│  • SandboxDirectConnectionConfig(router_url)     │
+└──────────────────────────────────────────────────┘
+```
+
+The split follows the `langchain-<provider>` convention. `langchain-k8s-sandbox` is published as a standalone package with zero Cognition imports. Cognition wraps it with domain policy (protected paths, scoping labels, session lifecycle).
+
+Design doc for the standalone package: [`packages/langchain-k8s-sandbox/DESIGN.md`](../../packages/langchain-k8s-sandbox/DESIGN.md)
+
+---
+
+## Execution Flow
+
+```
+User sends message
+        │
+        ▼
+┌──────────────────┐
+│  Cognition API   │  POST /sessions/{id}/messages
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│  CognitionAgent  │  LangGraph ReAct loop
+│  (runtime)       │  decides to call a shell tool
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────────────────────────────┐
+│  CognitionKubernetesSandboxBackend       │
+│  ┌────────────────────────────────────┐  │
+│  │ Protected path guard (write/edit)  │  │
+│  └──────────────┬─────────────────────┘  │
+│                 ▼                         │
+│  K8sSandbox.execute()                     │
+│  (lazy creates Sandbox CR on first call) │
+└─────────────────┬────────────────────────┘
+                  │
+    ┌─────────────┴─────────────┐
+    ▼ (first call)              ▼ (subsequent calls)
+┌──────────────────┐    ┌──────────────────┐
+│ SDK:             │    │ SDK:             │
+│ create_sandbox() │    │ commands.run()   │
+│ + patch TTL      │    │                  │
+└──────┬───────────┘    └────────┬─────────┘
+       │                         │
+       ▼                         │
+┌──────────────────┐             │
+│ K8s API Server   │             │
+│ → SandboxClaim   │             │
+│ → controller     │             │
+│ → Sandbox CR     │             │
+│ → Pod spawned    │             │
+└──────────────────┘             │
+                                 │
+       ┌─────────────────────────┘
+       ▼
+┌──────────────────┐
+│ sandbox-router   │  Routes by X-Sandbox-ID header
+│ :8080            │
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│ Sandbox Pod      │  python-runtime :8888
+│ (from template)  │  Executes command
+│                  │  Returns stdout/stderr/exit_code
+└──────────────────┘
+```
+
+The sandbox is **never created for conversation-only messages**. Only when the agent invokes a shell tool (`bash`, `write_file`, `read_file`, etc.) does `_ensure_sandbox()` trigger pod creation.
+
+---
+
+## Shell Interpretation
+
+The agent-sandbox SDK's `commands.run()` executes commands directly (like `exec`), not through a shell. This means heredocs, pipes, redirects, and variable expansion do not work with raw command strings.
+
+`K8sSandbox.execute()` wraps every command in `sh -c` using `shlex.quote()`:
+
+```python
+sh_command = f"sh -c {shlex.quote(command)}"
+result = sandbox.commands.run(sh_command, timeout=effective_timeout)
+```
+
+This is the same pattern used by `ModalSandbox` (the reference deepagents integration, which wraps in `bash -c`). The wrapping is required because `BaseSandbox`'s `write()`, `read()`, and `edit()` methods construct commands with heredoc syntax to pass base64-encoded payloads via stdin — these only work through a shell interpreter.
+
+---
+
+## Scoping Labels
+
+CognitionContext fields are mapped to `cognition.io/*` labels on the Sandbox CR, enabling multi-tenant visibility:
+
+```python
+labels = {
+    "cognition.io/user": context.user_id,
+    "cognition.io/org": context.org_id,
+    "cognition.io/project": context.project_id,
+    "cognition.io/session": session_id,
+}
+```
+
+Queryable with kubectl:
+
+```bash
+kubectl get sandboxes -n cognition -l cognition.io/user=alice
+```
+
+Labels are set at SandboxClaim creation time and cannot be changed afterward. They are for observability and traceability only — not for K8s admission policy enforcement (that's a v2 hardening item).
+
+---
+
+## Settings
+
+Five environment variables control the K8s sandbox backend:
+
+| Env Var | Default | Description |
+|---|---|---|
+| `COGNITION_K8S_SANDBOX_TEMPLATE` | `cognition-sandbox` | SandboxTemplate CR name |
+| `COGNITION_K8S_SANDBOX_NAMESPACE` | `default` | K8s namespace for sandbox CRs |
+| `COGNITION_K8S_SANDBOX_ROUTER_URL` | `http://sandbox-router-svc.default.svc.cluster.local:8080` | Router service URL |
+| `COGNITION_K8S_SANDBOX_TTL` | `3600` | Auto-cleanup after N seconds |
+| `COGNITION_K8S_SANDBOX_WARM_POOL` | (none) | SandboxWarmPool CR name (reserved) |
+
+Set `COGNITION_SANDBOX_BACKEND=kubernetes` to activate.
+
+Helm values under `config.sandbox.k8s.*`:
+
+```yaml
+config:
+  sandbox:
+    backend: kubernetes
+    k8s:
+      template: cognition-sandbox
+      namespace: cognition
+      routerUrl: http://sandbox-router-svc.cognition.svc.cluster.local:8080
+      ttl: 3600
+      warmPool: ""
+```
+
+---
+
+## Session Lifecycle
+
+```
+Session created      →  create_sandbox_backend("kubernetes", labels={...})
+                         No Sandbox CR yet. Backend stores config only.
+                              │
+                              ▼
+First tool call      →  CognitionKubernetesSandboxBackend.execute()
+                         → K8sSandbox._ensure_sandbox()
+                         → SandboxClient.create_sandbox()
+                         → Pod appears with scoping labels + TTL
+                              │
+                              ▼
+Subsequent calls     →  execute() routes through existing sandbox
+                              │
+                              ▼
+Session destroyed    →  backend.terminate()  ← Wired via SessionAgentManager.unregister_session()
+                         → sandbox.terminate()
+                         → SandboxClaim deleted
+                         → Controller deletes Sandbox + Pod
+```
+
+**TTL safety net**: If `terminate()` is never called (server crash, network partition), the controller deletes the Sandbox CR when `spec.shutdownTime` expires.
+
+**Termination wiring**: `terminate()` is called from `SessionAgentManager.unregister_session()` when a session is deleted via `DELETE /sessions/{id}`. This ensures sandbox pods are cleaned up when sessions are destroyed.
+
+---
+
+## Deployment Prerequisites
+
+When using `config.sandbox.backend: kubernetes`, the following must be installed **before** deploying Cognition:
+
+| Prerequisite | Install | Purpose |
+|---|---|---|
+| agent-sandbox controller | `kubectl apply -f .../v0.3.10/manifest.yaml` | Reconciles Sandbox CRs into pods |
+| agent-sandbox extensions | `kubectl apply -f .../v0.3.10/extensions.yaml` | SandboxTemplate, SandboxClaim, SandboxWarmPool CRDs |
+| sandbox-router | Deploy from [agent-sandbox router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/python/agentic-sandbox-client/sandbox-router) | Proxies commands to sandbox pods |
+| SandboxTemplate CR | User creates this | Defines sandbox pod spec (image, resources, security) |
+
+These are **not** bundled in Cognition's Helm chart. The agent-sandbox controller is cluster-scoped infrastructure, not per-application.
+
+The Cognition Helm chart creates the RBAC (Role + RoleBinding) automatically when `backend=kubernetes`.
+
+---
+
+## Helm Chart
+
+### RBAC (conditional on `backend=kubernetes`)
+
+Namespace-scoped Role for sandbox lifecycle:
+
+```yaml
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch", "patch"]          # patch for shutdownTime
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims", "sandboxtemplates"]
+    verbs: ["get", "list", "watch", "create", "delete"]  # SDK lifecycle
+```
+
+Cluster-scoped ClusterRole for startup validation (CRD existence checks):
+
+```yaml
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+    resourceNames:
+      - sandboxes.agents.x-k8s.io
+      - sandboxclaims.extensions.agents.x-k8s.io
+      - sandboxtemplates.extensions.agents.x-k8s.io
+```
+
+Both are created automatically by the Helm chart when `backend=kubernetes`.
+
+### Example SandboxTemplate
+
+See [`deploy/examples/cognition-sandbox-template.yaml`](../../deploy/examples/cognition-sandbox-template.yaml).
+
+The template must include writable volume mounts for `/tmp` and `/workspace`. The runtime image uses `readOnlyRootFilesystem: true` for security, which makes the root filesystem read-only. Without writable mount points, `BaseSandbox` file operations that write temporary data (e.g., heredoc payloads) will fail with "Read-only file system" errors.
+
+### NetworkPolicy (optional)
+
+Set `config.sandbox.k8s.denyEgress: true` in Helm values to deny all egress from sandbox pods. This is the K8s equivalent of Docker's `network_mode: "none"`.
+
+### Startup Validation
+
+When `sandbox_backend=kubernetes`, the server validates at startup that:
+1. The `sandboxes.agents.x-k8s.io` CRD exists (fatal if missing)
+2. The `sandboxclaims.extensions.agents.x-k8s.io` CRD exists (fatal if missing)
+3. The router health endpoint (`/healthz`) is reachable (warning if not)
+
+If CRDs are missing, the server fails to start with a clear error message including install commands.
+
+---
+
+## Live Demo Results
+
+Verified on a Talos Linux cluster (amd64, K8s v1.34.1):
+
+```
+Creating sandbox...
+Sandbox sandbox-claim-a71288fe is ready.     # ~2s (image cached)
+Running: echo Hello from K8s sandbox!
+  stdout: Hello from K8s sandbox!
+  exit_code: 0
+Running: python3 platform check
+  stdout: sandbox-claim-a71288fe 3.11.15
+Running: uname -a
+  stdout: Linux sandbox-claim-a71288fe 6.12.48-talos x86_64 GNU/Linux
+Terminating sandbox...
+Terminated SandboxClaim: sandbox-claim-a71288fe
+```
+
+First sandbox on a fresh node took ~17s (image pull). Subsequent sandboxes took ~2s.
+
+---
+
+## E2E Tests
+
+K8s sandbox integration tests are in `tests/e2e/test_k8s_sandbox_e2e.py`. They are skipped unless `COGNITION_K8S_E2E=1` is set (same pattern as other e2e tests that require external infrastructure).
+
+```bash
+# Port-forward the sandbox-router and Cognition server
+kubectl port-forward svc/sandbox-router-svc -n cognition 8081:8080 &
+kubectl port-forward svc/cognition -n cognition 8000:8000 &
+
+# Run tests
+COGNITION_K8S_E2E=1 COGNITION_K8S_E2E_ROUTER_URL=http://localhost:8081 \
+    uv run pytest tests/e2e/test_k8s_sandbox_e2e.py -v
+```
+
+Test coverage:
+
+| Class | Tests | What it verifies |
+|---|---|---|
+| `TestK8sSandboxLifecycle` | 2 | API-level session create/message/delete with sandbox cleanup |
+| `TestK8sSandboxDirectBackend` | 9 | Direct `K8sSandbox` operations: execute, Python, write/read, edit, upload/download, labels, TTL, terminate, lazy init |
+| `TestK8sSandboxStartupValidation` | 2 | Cluster prerequisites: CRDs exist, SandboxTemplate exists |
+
+---
+
+## Known Gaps
+
+| Gap | Impact | Priority |
+|---|---|---|
+| Warm pool not implemented | First tool call pays cold-start latency | Low |
+| Native SDK file transfer | Base64-through-execute is v1 only | Low |
+
+---
+
+## Security Considerations
+
+The K8s sandbox provides equivalent isolation to the Docker backend, enforced by the K8s control plane:
+
+| Boundary | Mechanism |
+|---|---|
+| Process | Separate pod per session, own PID namespace |
+| Network | Pod securityContext (add NetworkPolicy for egress denial) |
+| Filesystem | `readOnlyRootFilesystem: true`, `emptyDir` for workspace |
+| Capabilities | `capabilities.drop: ["ALL"]` |
+| Resources | `resources.limits` on SandboxTemplate |
+| Auto-cleanup | TTL-based deletion via agent-sandbox controller |
+
+**Secrets**: Never placed inside the sandbox. API keys and credentials stay in the Cognition server process. If an agent needs authenticated API access, define tools that run outside the sandbox.
+
+For production, apply a NetworkPolicy to deny sandbox egress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-deny-egress
+spec:
+  podSelector:
+    matchLabels:
+      agents.x-k8s.io/sandbox: "true"
+  policyTypes:
+    - Egress
+  egress: []
+```
+
+---
+
+## Layer Assignment
+
+| Component | Layer |
+|---|---|
+| `langchain-k8s-sandbox` package | Layer 3 (Execution) |
+| `CognitionKubernetesSandboxBackend` | Layer 4 (Agent Runtime) + Layer 3 |
+| Settings fields | Layer 1 (Foundation) |
+| Helm RBAC + values | Layer 1 (Foundation) |
+| SandboxTemplate | Layer 1 (Foundation, prerequisite) |
+
+No upward imports. `langchain-k8s-sandbox` (Layer 3) has no Cognition dependency. `CognitionKubernetesSandboxBackend` (Layer 4) imports from Layer 3 only.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -223,15 +223,42 @@ COGNITION_PERSISTENCE_URI=postgresql://user:password@host:5432/dbname
 
 ## Sandbox (Execution)
 
+Cognition ships three sandbox backends:
+
+| Backend | Isolation | Works on K8s? |
+|---|---|---|
+| `local` | None — commands run as server process user | Yes, but no isolation |
+| `docker` | Container per session | No — requires Docker socket + privileged mode |
+| `kubernetes` | Sandbox pod per session | Yes — K8s-native, no special privileges needed |
+
+### Common settings
+
 | YAML key | Environment variable | Default | Description |
 |---|---|---|---|
-| `sandbox.backend` | `COGNITION_SANDBOX_BACKEND` | `local` | `local` or `docker` |
+| `sandbox.backend` | `COGNITION_SANDBOX_BACKEND` | `local` | `local`, `docker`, or `kubernetes` |
+
+### Docker settings (when `sandbox.backend = docker`)
+
+| YAML key | Environment variable | Default | Description |
+|---|---|---|---|
 | `sandbox.docker_image` | `COGNITION_DOCKER_IMAGE` | `cognition-sandbox:latest` | Docker image for the sandbox container |
 | `sandbox.docker_network` | `COGNITION_DOCKER_NETWORK` | `none` | Container network mode |
 | `sandbox.docker_timeout` | `COGNITION_DOCKER_TIMEOUT` | `300` | Command execution timeout in seconds |
 | `sandbox.docker_memory_limit` | `COGNITION_DOCKER_MEMORY_LIMIT` | `512m` | Container memory limit |
 | `sandbox.docker_cpu_limit` | `COGNITION_DOCKER_CPU_LIMIT` | `1.0` | Container CPU limit (cores) |
 | `sandbox.docker_host_workspace` | `COGNITION_DOCKER_HOST_WORKSPACE` | `null` | Host path to mount into the container |
+
+### Kubernetes settings (when `sandbox.backend = kubernetes`)
+
+| YAML key | Environment variable | Default | Description |
+|---|---|---|---|
+| `sandbox.k8s.template` | `COGNITION_K8S_SANDBOX_TEMPLATE` | `cognition-sandbox` | SandboxTemplate CR name defining the sandbox pod spec |
+| `sandbox.k8s.namespace` | `COGNITION_K8S_SANDBOX_NAMESPACE` | `default` | Kubernetes namespace for sandbox CRs |
+| `sandbox.k8s.router_url` | `COGNITION_K8S_SANDBOX_ROUTER_URL` | `http://sandbox-router-svc.default.svc.cluster.local:8080` | sandbox-router service URL |
+| `sandbox.k8s.ttl` | `COGNITION_K8S_SANDBOX_TTL` | `3600` | Auto-cleanup after N seconds (safety net for abandoned sandboxes) |
+| `sandbox.k8s.warm_pool` | `COGNITION_K8S_SANDBOX_WARM_POOL` | (none) | SandboxWarmPool CR name (reserved, not yet implemented) |
+
+See [Kubernetes Sandbox](../concepts/kubernetes-sandbox.md) for architecture, prerequisites, and deployment details.
 
 ---
 
@@ -453,6 +480,42 @@ AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ANTHROPIC_API_KEY=sk-ant-...
 COGNITION_PERSISTENCE_URI=postgresql://cognition:secret@postgres:5432/cognition
+```
+
+## Example: Kubernetes Sandbox Setup
+
+```yaml
+# .cognition/config.yaml
+server:
+  host: 0.0.0.0
+  port: 8000
+
+llm:
+  - provider: openai_compatible
+    model: google/gemini-3-flash-preview
+    base_url: https://openrouter.ai/api/v1
+
+persistence:
+  backend: postgres
+
+sandbox:
+  backend: kubernetes
+  k8s:
+    template: cognition-sandbox
+    namespace: cognition
+    router_url: http://sandbox-router-svc.cognition.svc.cluster.local:8080
+    ttl: 3600
+
+scoping:
+  enabled: true
+  scope_keys:
+    - "user"
+```
+
+```bash
+# .env
+COGNITION_OPENAI_COMPATIBLE_API_KEY=sk-or-v1-...
+COGNITION_PERSISTENCE_URI=postgresql+asyncpg://cognition:secret@cognition-db-rw:5432/cognition
 ```
 
 ---

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -296,12 +296,77 @@ spec:
                   key: database-url
 ```
 
-### Docker Sandbox in Kubernetes
+### Kubernetes Sandbox Backend
 
-The Docker sandbox backend requires Docker socket access, which is a security concern in shared clusters. Options:
-- Use `COGNITION_SANDBOX_BACKEND=local` for process-level isolation only
-- Use Docker-in-Docker (DinD) as a sidecar (not recommended for multi-tenant)
-- Implement a custom `ExecutionBackend` that creates Kubernetes `Job` resources
+When deploying Cognition on Kubernetes, the Docker sandbox backend does not work (the server pod runs with `readOnlyRootFilesystem: true`, `capabilities.drop: ["ALL"]`, and `runAsNonRoot: true`). Use the `kubernetes` sandbox backend instead, which creates isolated sandbox pods via the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD and controller.
+
+**Prerequisites** (install before deploying Cognition):
+
+| Prerequisite | Install | Purpose |
+|---|---|---|
+| agent-sandbox controller (v0.3.10+) | `kubectl apply -f .../v0.3.10/manifest.yaml` | Reconciles Sandbox CRs into pods |
+| agent-sandbox extensions | `kubectl apply -f .../v0.3.10/extensions.yaml` | SandboxTemplate, SandboxClaim CRDs |
+| sandbox-router Deployment + Service | Deploy from [agent-sandbox router](https://github.com/kubernetes-sigs/agent-sandbox) | Proxies commands to sandbox pods |
+
+These are cluster-scoped infrastructure and are **not** bundled in Cognition's Helm chart.
+
+**SandboxTemplate** — create a CR defining the sandbox pod spec:
+
+```yaml
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: cognition-sandbox
+  namespace: cognition
+spec:
+  networkPolicyManagement: Managed
+  podTemplate:
+    spec:
+      containers:
+      - name: python-runtime
+        image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main
+        ports:
+        - containerPort: 8888
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: workspace
+          mountPath: /workspace
+      volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: "128Mi"
+      - name: workspace
+        emptyDir:
+          sizeLimit: "1Gi"
+```
+
+> The `/tmp` and `/workspace` emptyDir mounts are required. The runtime image uses `readOnlyRootFilesystem: true`, so without writable mount points, file operations that write temporary data will fail.
+
+**Helm values** — enable the K8s sandbox backend:
+
+```yaml
+config:
+  sandbox:
+    backend: kubernetes
+    k8s:
+      template: cognition-sandbox
+      namespace: cognition
+      routerUrl: http://sandbox-router-svc.cognition.svc.cluster.local:8080
+      ttl: 3600
+      denyEgress: true    # Optional: deny all egress from sandbox pods
+```
+
+The Helm chart automatically creates the required RBAC (namespace-scoped Role for sandbox lifecycle + cluster-scoped ClusterRole for CRD reads) when `backend=kubernetes`.
+
+**Startup validation** — Cognition checks at startup that the agent-sandbox CRDs exist and the router is reachable. If CRDs are missing, the server fails to start with a clear error message.
+
+See [Kubernetes Sandbox](../concepts/kubernetes-sandbox.md) for architecture details, scoping labels, and the two-package design.
 
 ### Health Probes
 

--- a/packages/langchain-k8s-sandbox/DESIGN.md
+++ b/packages/langchain-k8s-sandbox/DESIGN.md
@@ -1,0 +1,286 @@
+# langchain-k8s-sandbox Design
+
+A [deepagents](https://github.com/langchain-ai/deepagents) sandbox backend that runs commands in Kubernetes Sandbox CRs managed by [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox).
+
+Follows the `langchain-<provider>` integration convention: standalone package, zero coupling to any specific agent framework or application. Any deepagents user can `pip install langchain-k8s-sandbox[k8s]` and get K8s sandboxed execution.
+
+---
+
+## Prerequisites
+
+The following must exist in the cluster before using this package:
+
+| Dependency | Purpose |
+|---|---|
+| [agent-sandbox controller](https://github.com/kubernetes-sigs/agent-sandbox) (v0.3.10+) | Reconciles Sandbox CRs into pods |
+| [agent-sandbox extensions](https://github.com/kubernetes-sigs/agent-sandbox) | SandboxTemplate, SandboxClaim, SandboxWarmPool CRDs |
+| sandbox-router Deployment + Service | Proxies HTTP commands from callers to sandbox pods via `X-Sandbox-ID` header |
+| SandboxTemplate CR | Defines the pod spec (image, resources, security context) for sandbox containers |
+| Runtime image | Container image that listens on port 8888 for command execution (e.g. `python-runtime-sandbox`) |
+
+Install controller + extensions:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/manifest.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/extensions.yaml
+```
+
+---
+
+## Architecture
+
+```
+K8sSandbox (this package)
+    │
+    │  SandboxClient.create_sandbox()
+    ▼
+K8s API Server ──▶ SandboxClaim CR ──▶ controller reconciles ──▶ Sandbox CR ──▶ Pod
+    │                                                                     │
+    │  sandbox.commands.run()                                             │
+    ▼                                                                     ▼
+sandbox-router-svc:8080 ──(X-Sandbox-ID header)──▶ sandbox pod :8888
+                                                      │
+                                                      ▼
+                                                 sh -c <command>
+                                                      │
+                                                      ▼
+                                                 Executes command
+                                                 Returns stdout/stderr/exit_code
+```
+
+**Two paths**:
+- **Lifecycle** (create/terminate): Goes through the K8s API directly. The SDK creates/deletes `SandboxClaim` CRs, which the controller reconciles into `Sandbox` CRs and pods.
+- **Execution** (run commands): Goes through the sandbox-router HTTP proxy. The router looks up the target pod by sandbox ID and forwards the request.
+
+---
+
+## Shell Interpretation (`sh -c` wrapping)
+
+The agent-sandbox SDK's `commands.run()` executes commands directly (like `exec`), not through a shell. This means shell features — heredocs, pipes, redirects, variable expansion — do not work when passed as a raw command string.
+
+Since `BaseSandbox`'s `write()`, `read()`, and `edit()` methods construct commands that use heredoc syntax (`<<'__DEEPAGENTS_EOF__'`) to pass base64-encoded payloads via stdin, a shell interpreter is required for these inherited file operations to work.
+
+`K8sSandbox.execute()` wraps every command in `sh -c` via `shlex.quote()`:
+
+```python
+sh_command = f"sh -c {shlex.quote(command)}"
+result = sandbox.commands.run(sh_command, timeout=effective_timeout)
+```
+
+This follows the same pattern as `ModalSandbox` (the reference deepagents sandbox integration), which wraps in `bash -c`. We use `sh` because it is POSIX-compliant and supports heredocs, which is sufficient for all `BaseSandbox` operations.
+
+---
+
+## API Surface
+
+```python
+class K8sSandbox(BaseSandbox):
+    def __init__(
+        self,
+        template: str = "cognition-sandbox",     # SandboxTemplate CR name
+        namespace: str = "default",              # K8s namespace for CRs
+        router_url: str = "http://sandbox-router-svc.default.svc.cluster.local:8080",
+        labels: dict[str, str] | None = None,    # Applied to the SandboxClaim CR
+        ttl: int | None = None,                  # Auto-cleanup after N seconds
+        server_port: int = 8888,                 # Sandbox runtime listen port
+        warm_pool: str | None = None,            # SandboxWarmPool CR name (reserved)
+    ): ...
+
+    @property
+    def id(self) -> str: ...                     # "k8s-<hex>" or resolved sandbox name
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse: ...
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]: ...
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]: ...
+    def terminate(self) -> None: ...
+```
+
+All other file operations (`read`, `write`, `edit`, `ls`, `grep`, `glob`) are inherited from `BaseSandbox`, which constructs shell commands and pipes them through `execute()`. These work correctly because `execute()` wraps commands in `sh -c`, enabling heredoc and pipe support.
+
+---
+
+## SandboxTemplate Requirements
+
+The SandboxTemplate CR must include writable volume mounts for `/tmp` and `/workspace`. The default runtime image uses `readOnlyRootFilesystem: true` for security, which makes the root filesystem read-only. Without writable mount points, `BaseSandbox` file operations that write temporary data (e.g., heredoc payloads) will fail.
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - name: python-runtime
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: workspace
+          mountPath: /workspace
+      volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: "128Mi"
+      - name: workspace
+        emptyDir:
+          sizeLimit: "1Gi"
+```
+
+`/tmp` is required by `BaseSandbox`'s heredoc-based file operations. `/workspace` is the default agent working directory. Both are `emptyDir` volumes — data is lost when the Sandbox CR is deleted.
+
+---
+
+## Lazy Initialization Lifecycle
+
+Sandbox CRs are not created until the first `execute()` call. This avoids paying for pods in sessions that only involve conversation.
+
+```
+__init__()          Stores config. No SDK calls, no K8s API calls.
+    │
+    ▼
+first execute()     _ensure_sandbox() called internally:
+                    1. SandboxClient(SandboxDirectConnectionConfig)
+                    2. client.create_sandbox(template, namespace, labels)
+                    3. SDK watches Sandbox CR until Ready
+                    4. If ttl set: _apply_shutdown_time() patches spec.shutdownTime
+                    │
+                    ▼
+execute()           sandbox.commands.run("sh -c <quoted-command>", timeout) → ExecuteResponse
+    │
+    ▼
+terminate()         sandbox.terminate() → deletes SandboxClaim → controller deletes Sandbox + Pod
+                    Resets internal state. Next execute() creates a new sandbox.
+```
+
+Spin-up timing observed on a Talos Linux cluster:
+- First sandbox on a node: ~15-20s (includes image pull)
+- Subsequent sandboxes on same node: ~2s (image cached)
+
+---
+
+## TTL Mechanism
+
+The SDK's `create_sandbox()` signature does not expose a TTL parameter:
+
+```python
+def create_sandbox(self, template, namespace, sandbox_ready_timeout, labels)
+```
+
+To enforce auto-cleanup, `_apply_shutdown_time()` patches the `Sandbox` CR directly after creation:
+
+```python
+from kubernetes import client as k8s_client
+from kubernetes.config import load_incluster_config
+
+load_incluster_config()
+api = k8s_client.CustomObjectsApi()
+body = {"spec": {"shutdownTime": "2026-04-09T20:16:00Z"}}
+api.patch_namespaced_custom_object(
+    group="agents.x-k8s.io", version="v1alpha1",
+    namespace=namespace, plural="sandboxes",
+    name=sandbox_name, body=body,
+)
+```
+
+This uses `load_incluster_config()` first (production), then falls back to `load_kube_config()` (reads `~/.kube/config` for local dev/CI). If neither config is available, the error is logged as a warning and execution continues — the sandbox still works, it just won't auto-clean up.
+
+**Two cleanup paths** (both are active):
+1. `terminate()` — explicit deletion when the caller shuts down
+2. `shutdownTime` — safety net for crashed/abandoned sessions where `terminate()` is never called
+
+---
+
+## File Transfer
+
+v1 uses `BaseSandbox`'s default approach: base64-encode file content and pipe through `execute()`. This works for all file types but is slow for large files.
+
+```python
+# Upload: base64 encode → pipe through sh -c
+encoded = base64.b64encode(content).decode("ascii")
+execute(f"mkdir -p $(dirname {file_path}) && echo '{encoded}' | base64 -d > {file_path}")
+
+# Download: base64 encode → read via sh -c
+result = execute(f"base64 {file_path}")
+content = base64.b64decode(result.output.strip())
+```
+
+v2 will use the SDK's native `sandbox.files.upload()` / `sandbox.files.download()` when available.
+
+---
+
+## RBAC Requirements
+
+The calling pod's ServiceAccount needs both namespace-scoped and cluster-scoped permissions.
+
+### Namespace-scoped Role (sandbox lifecycle)
+
+```yaml
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch", "patch"]       # patch for shutdownTime
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes/status"]
+    verbs: ["get"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims"]
+    verbs: ["get", "list", "watch", "create", "delete"]  # SDK creates/deletes claims
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxtemplates"]
+    verbs: ["get", "list", "watch"]                # SDK reads template on create
+```
+
+### Cluster-scoped ClusterRole (startup validation)
+
+The startup validation check reads CRDs to verify the agent-sandbox controller is installed. CRDs are cluster-scoped resources, so a ClusterRole is required:
+
+```yaml
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+    resourceNames:
+      - sandboxes.agents.x-k8s.io
+      - sandboxclaims.extensions.agents.x-k8s.io
+      - sandboxtemplates.extensions.agents.x-k8s.io
+```
+
+The `create`/`delete` on `sandboxclaims` is required because the SDK manages the claim lifecycle directly — `create_sandbox()` creates a claim, `terminate()` deletes it.
+
+---
+
+## Startup Validation
+
+When the caller configures `sandbox_backend=kubernetes`, the server validates at startup that:
+
+1. The agent-sandbox CRDs exist (fatal if missing — clear error with install commands)
+2. The sandbox-router health endpoint (`/healthz`) is reachable (warning if not — sandbox creation will fail at runtime instead)
+
+This is implemented in `validate_k8s_sandbox_config()` and called from the application lifespan. It prevents silent failures where the server starts successfully but every sandbox `execute()` call fails due to missing infrastructure.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| SDK not installed (`k8s-agent-sandbox` missing) | `RuntimeError` on first `execute()` with install instructions |
+| Sandbox creation fails (CRD missing, RBAC denied) | `RuntimeError` from `_ensure_sandbox()` |
+| Command execution fails (timeout, connection refused) | Returns `ExecuteResponse(output="Error: ...", exit_code=-1)` |
+| `terminate()` fails (already deleted, RBAC) | Logs warning, does not raise. Safe to call multiple times. |
+| `_apply_shutdown_time()` fails | Logs warning. Sandbox still works, just no auto-cleanup. |
+| `execute()` called after `terminate()` | Creates a new sandbox (lazy re-init) |
+
+---
+
+## v1 Scope
+
+**Included**: Sync `execute()` with `sh -c` wrapping, lazy init, labels passthrough, TTL via CR patch, base64 file transfer, `terminate()`, DirectConnection mode, startup validation.
+
+**Deferred to v2**:
+
+| Feature | Reason |
+|---|---|
+| `aexecute()` / async client | deepagents wraps sync `execute()` in `asyncio.to_thread()` automatically |
+| Native SDK file upload/download | SDK file API not yet stable across providers |
+| Gateway / Tunnel connection modes | DirectConnection covers in-cluster production; dev can `kubectl port-forward` |
+| Warm pool allocation | Settings field is reserved; SDK supports it but integration is deferred |

--- a/packages/langchain-k8s-sandbox/README.md
+++ b/packages/langchain-k8s-sandbox/README.md
@@ -1,0 +1,59 @@
+# langchain-k8s-sandbox
+
+[deepagents](https://github.com/langchain-ai/deepagents) sandbox backend for Kubernetes using the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD and controller.
+
+## Installation
+
+```bash
+pip install langchain-k8s-sandbox[k8s]
+```
+
+The `[k8s]` extra installs `k8s-agent-sandbox` (the agent-sandbox Python SDK) and `kubernetes` (for TTL patching).
+
+## Usage
+
+```python
+from langchain_k8s_sandbox import K8sSandbox
+
+sandbox = K8sSandbox(
+    template="cognition-sandbox",
+    namespace="default",
+    router_url="http://sandbox-router-svc.default.svc.cluster.local:8080",
+    labels={"cognition.io/user": "alice"},
+    ttl=3600,
+)
+
+result = sandbox.execute("echo hello")
+print(result.output)      # "hello\n"
+print(result.exit_code)   # 0
+
+sandbox.terminate()
+```
+
+## File Operations
+
+All standard `BaseSandbox` file operations are inherited and work through `execute()`:
+
+- `write(path, content)` — create file
+- `read(path)` — read file
+- `edit(path, old, new)` — find-and-replace in file
+- `ls_info(path)` — list directory
+- `glob_info(path, pattern)` — find files by pattern
+- `grep_raw(path, pattern, include)` — search file contents
+
+Commands are wrapped in `sh -c` so that shell features (heredocs, pipes, redirects) work correctly. The agent-sandbox SDK's `commands.run()` executes commands directly without a shell, so this wrapping is required for `BaseSandbox`'s heredoc-based file operations.
+
+## TTL (Auto-Cleanup)
+
+Set `ttl` to automatically delete the sandbox after N seconds. This is implemented by patching the Sandbox CR's `spec.shutdownTime` field via the Kubernetes API. Two cleanup paths exist: explicit `terminate()` and the TTL safety net.
+
+## Requirements
+
+- [agent-sandbox controller](https://github.com/kubernetes-sigs/agent-sandbox) v0.3.10+ installed in your Kubernetes cluster
+- [agent-sandbox extensions](https://github.com/kubernetes-sigs/agent-sandbox) (SandboxTemplate, SandboxClaim CRDs)
+- sandbox-router service running and accessible
+- SandboxTemplate CR matching the `template` parameter with writable `/tmp` and `/workspace` volume mounts
+
+## Design
+
+See [DESIGN.md](./DESIGN.md) for architecture, RBAC requirements, lifecycle details, and v1/v2 scope.

--- a/packages/langchain-k8s-sandbox/langchain_k8s_sandbox/__init__.py
+++ b/packages/langchain-k8s-sandbox/langchain_k8s_sandbox/__init__.py
@@ -1,0 +1,7 @@
+"""Deep Agents sandbox backend for Kubernetes using agent-sandbox CRD."""
+
+from __future__ import annotations
+
+from langchain_k8s_sandbox.sandbox import K8sSandbox
+
+__all__ = ["K8sSandbox"]

--- a/packages/langchain-k8s-sandbox/langchain_k8s_sandbox/sandbox.py
+++ b/packages/langchain-k8s-sandbox/langchain_k8s_sandbox/sandbox.py
@@ -1,0 +1,299 @@
+"""Kubernetes sandbox backend using kubernetes-sigs/agent-sandbox.
+
+This module provides ``K8sSandbox``, a :class:`deepagents.backends.sandbox.BaseSandbox`
+subclass that runs commands in Kubernetes Sandbox CRs managed by the agent-sandbox
+controller. It uses the ``k8s-agent-sandbox`` Python SDK for sandbox lifecycle and
+command execution.
+
+Design decisions:
+- Lazy initialization: Sandbox CR is created on first ``execute()``, not in ``__init__``.
+  This avoids paying for sandboxes in sessions that never execute code.
+- Labels: Generic dict passed through to the Sandbox CR. Callers (Cognition) populate
+  these with user/org/project/session IDs for multi-tenant scoping.
+- TTL: Applied via the Sandbox CR's ``spec.shutdownTime`` field after creation,
+  since the SDK's ``create_sandbox()`` does not expose a TTL parameter.
+- File operations: Inherited from ``BaseSandbox`` — all file ops pipe shell commands
+  through ``execute()``. Native SDK file transfer is a future optimization.
+- Sync only (v1): ``aexecute()`` is provided by ``SandboxBackendProtocol`` via
+  ``asyncio.to_thread()`` wrapping this sync ``execute()``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from datetime import UTC
+from typing import Any
+
+import structlog
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+)
+from deepagents.backends.sandbox import BaseSandbox
+
+logger = structlog.get_logger(__name__)
+
+
+class K8sSandbox(BaseSandbox):
+    """deepagents sandbox backend using kubernetes-sigs/agent-sandbox.
+
+    Each instance creates a Sandbox CR on first ``execute()`` and routes all
+    commands through the agent-sandbox router to an isolated sandbox pod.
+
+    Args:
+        template: SandboxTemplate CR name that defines the sandbox pod spec.
+        namespace: Kubernetes namespace for sandbox CRs.
+        router_url: URL of the sandbox-router service (DirectConnection mode).
+        labels: Labels applied to the Sandbox CR (e.g. scoping metadata).
+        ttl: Time-to-live in seconds. Maps to ``shutdown_after_seconds``.
+            Prevents resource leaks from abandoned sessions.
+        server_port: Port the sandbox runtime listens on inside the pod.
+        warm_pool: Optional SandboxWarmPool CR name for pre-warmed allocation.
+    """
+
+    def __init__(
+        self,
+        template: str = "cognition-sandbox",
+        namespace: str = "default",
+        router_url: str = "http://sandbox-router-svc.default.svc.cluster.local:8080",
+        labels: dict[str, str] | None = None,
+        ttl: int | None = None,
+        server_port: int = 8888,
+        warm_pool: str | None = None,
+    ) -> None:
+        self._template = template
+        self._namespace = namespace
+        self._router_url = router_url
+        self._labels = labels or {}
+        self._ttl = ttl
+        self._server_port = server_port
+        self._warm_pool = warm_pool
+
+        self._sandbox_id = f"k8s-{id(self):x}"
+        self._sandbox: Any | None = None
+        self._client: Any | None = None
+
+    @property
+    def id(self) -> str:
+        """Return the unique identifier for this sandbox."""
+        return self._sandbox_id
+
+    def _ensure_sandbox(self) -> Any:
+        """Lazily create the Sandbox CR on first use.
+
+        Returns:
+            The agent-sandbox SDK Sandbox object.
+
+        Raises:
+            RuntimeError: If the k8s-agent-sandbox SDK is not installed
+                or sandbox creation fails.
+        """
+        if self._sandbox is not None:
+            return self._sandbox
+
+        try:
+            from k8s_agent_sandbox import SandboxClient
+            from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+        except ImportError as e:
+            raise RuntimeError(
+                "k8s-agent-sandbox is required for K8sSandbox. "
+                "Install with: pip install langchain-k8s-sandbox[k8s]"
+            ) from e
+
+        connection_config = SandboxDirectConnectionConfig(
+            api_url=self._router_url,
+            server_port=self._server_port,
+        )
+        self._client = SandboxClient(connection_config=connection_config)
+
+        create_kwargs: dict[str, Any] = {
+            "template": self._template,
+            "namespace": self._namespace,
+            "labels": self._labels,
+        }
+
+        logger.info(
+            "Creating K8s sandbox",
+            template=self._template,
+            namespace=self._namespace,
+            labels=self._labels,
+            ttl=self._ttl,
+        )
+
+        self._sandbox = self._client.create_sandbox(**create_kwargs)
+
+        sandbox_name = getattr(self._sandbox, "sandbox_id", None) or getattr(
+            self._sandbox, "claim_name", None
+        )
+        if sandbox_name:
+            self._sandbox_id = str(sandbox_name)
+
+        if self._ttl is not None:
+            self._apply_shutdown_time(self._sandbox_id)
+
+        logger.info("K8s sandbox created", sandbox_id=self._sandbox_id)
+        return self._sandbox
+
+    def _apply_shutdown_time(self, sandbox_name: str) -> None:
+        """Set spec.shutdownTime on the Sandbox CR for automatic cleanup.
+
+        The SDK's ``create_sandbox()`` does not expose a TTL parameter, so we
+        patch the Sandbox CR directly using the Kubernetes API.
+
+        Tries in-cluster config first (production), then falls back to
+        ``~/.kube/config`` (local dev / CI).
+
+        Args:
+            sandbox_name: Name of the Sandbox CR to patch.
+        """
+        from datetime import datetime, timedelta
+
+        try:
+            from kubernetes import client as k8s_client
+            from kubernetes.config import ConfigException
+
+            try:
+                from kubernetes.config import load_incluster_config
+
+                load_incluster_config()
+            except ConfigException:
+                from kubernetes.config import load_kube_config
+
+                load_kube_config()
+
+            api = k8s_client.CustomObjectsApi()
+            shutdown_time = (datetime.now(UTC) + timedelta(seconds=self._ttl or 0)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            body = {"spec": {"shutdownTime": shutdown_time}}
+            api.patch_namespaced_custom_object(
+                group="agents.x-k8s.io",
+                version="v1alpha1",
+                namespace=self._namespace,
+                plural="sandboxes",
+                name=sandbox_name,
+                body=body,
+            )
+            logger.info(
+                "Set sandbox shutdownTime",
+                sandbox_id=sandbox_name,
+                shutdown_time=shutdown_time,
+            )
+        except Exception as e:
+            logger.warning("Failed to set sandbox shutdownTime", error=str(e))
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        """Execute a command inside the K8s sandbox pod.
+
+        Commands are wrapped in ``sh -c`` so that shell features (heredocs,
+        pipes, redirects, variable expansion) work correctly. The agent-sandbox
+        SDK's ``commands.run()`` executes commands directly (like ``exec``),
+        which does not interpret shell syntax.
+
+        Args:
+            command: Shell command to execute.
+            timeout: Per-command timeout in seconds. Defaults to 300.
+
+        Returns:
+            ExecuteResponse with combined stdout+stderr, exit code, and
+            truncation status.
+        """
+        sandbox = self._ensure_sandbox()
+        effective_timeout = timeout or 300
+
+        sh_command = f"sh -c {shlex.quote(command)}"
+
+        try:
+            result = sandbox.commands.run(sh_command, timeout=effective_timeout)
+        except Exception as e:
+            logger.error("K8s sandbox execute failed", error=str(e))
+            return ExecuteResponse(
+                output=f"Error: {e}",
+                exit_code=-1,
+                truncated=False,
+            )
+
+        output = result.stdout
+        if result.stderr:
+            output = f"{output}\n{result.stderr}" if output else result.stderr
+
+        return ExecuteResponse(
+            output=output,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+        output = result.stdout
+        if result.stderr:
+            output = f"{output}\n{result.stderr}" if output else result.stderr
+
+        return ExecuteResponse(
+            output=output,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload files to the sandbox via base64 encoding through execute().
+
+        v1 uses BaseSandbox's default approach of piping through execute().
+        v2 may use the SDK's native file upload API when available.
+        """
+        return self._upload_files_via_execute(files)
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download files from the sandbox via base64 encoding through execute().
+
+        v1 uses BaseSandbox's default approach of piping through execute().
+        v2 may use the SDK's native file download API when available.
+        """
+        return self._download_files_via_execute(paths)
+
+    def _upload_files_via_execute(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload files by base64-encoding and piping through execute()."""
+        import base64
+
+        results: list[FileUploadResponse] = []
+        for file_path, content in files:
+            encoded = base64.b64encode(content).decode("ascii")
+            cmd = f"mkdir -p $(dirname {file_path}) && echo '{encoded}' | base64 -d > {file_path}"
+            resp = self.execute(cmd)
+            if resp.exit_code == 0:
+                results.append(FileUploadResponse(path=file_path))
+            else:
+                results.append(FileUploadResponse(path=file_path, error="is_directory"))
+        return results
+
+    def _download_files_via_execute(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """Download files by base64-encoding through execute()."""
+        import base64
+
+        results: list[FileDownloadResponse] = []
+        for file_path in paths:
+            resp = self.execute(f"base64 {file_path}")
+            if resp.exit_code == 0 and resp.output.strip():
+                try:
+                    content = base64.b64decode(resp.output.strip())
+                    results.append(FileDownloadResponse(path=file_path, content=content))
+                except Exception:
+                    results.append(FileDownloadResponse(path=file_path, error="invalid_path"))
+            else:
+                results.append(FileDownloadResponse(path=file_path, error="file_not_found"))
+        return results
+
+    def terminate(self) -> None:
+        """Terminate the sandbox and clean up resources.
+
+        Safe to call multiple times. Subsequent ``execute()`` calls after
+        terminate will create a new sandbox.
+        """
+        if self._sandbox is not None:
+            try:
+                self._sandbox.terminate()
+                logger.info("K8s sandbox terminated", sandbox_id=self._sandbox_id)
+            except Exception as e:
+                logger.warning("K8s sandbox terminate failed", error=str(e))
+            finally:
+                self._sandbox = None
+                self._client = None

--- a/packages/langchain-k8s-sandbox/pyproject.toml
+++ b/packages/langchain-k8s-sandbox/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "langchain-k8s-sandbox"
+version = "0.1.0"
+description = "Deep Agents sandbox backend for Kubernetes using agent-sandbox CRD"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Cognition Team"},
+]
+keywords = ["ai", "agent", "kubernetes", "sandbox", "langchain", "deep-agents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dependencies = [
+    "deepagents>=0.4.12",
+]
+
+[project.optional-dependencies]
+k8s = ["k8s-agent-sandbox>=0.3.10"]
+test = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=0.24.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langchain_k8s_sandbox"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM"]
+ignore = ["E501", "E402", "B008", "SIM102", "SIM108"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true

--- a/packages/langchain-k8s-sandbox/tests/test_sandbox.py
+++ b/packages/langchain-k8s-sandbox/tests/test_sandbox.py
@@ -10,7 +10,7 @@ from langchain_k8s_sandbox.sandbox import K8sSandbox
 
 
 class TestK8sSandboxInit:
-    def test_init_stores_config(self):
+    def test_init_stores_config(self) -> None:
         sandbox = K8sSandbox(
             template="test-template",
             namespace="test-ns",
@@ -26,7 +26,7 @@ class TestK8sSandboxInit:
         assert sandbox._ttl == 1800
         assert sandbox._warm_pool == "test-pool"
 
-    def test_init_defaults(self):
+    def test_init_defaults(self) -> None:
         sandbox = K8sSandbox()
         assert sandbox._template == "cognition-sandbox"
         assert sandbox._namespace == "default"
@@ -34,11 +34,11 @@ class TestK8sSandboxInit:
         assert sandbox._warm_pool is None
         assert sandbox._labels == {}
 
-    def test_id_property(self):
+    def test_id_property(self) -> None:
         sandbox = K8sSandbox()
         assert sandbox.id.startswith("k8s-")
 
-    def test_lazy_init_no_sdk_calls(self):
+    def test_lazy_init_no_sdk_calls(self) -> None:
         sandbox = K8sSandbox()
         assert sandbox._sandbox is None
         assert sandbox._client is None
@@ -46,7 +46,7 @@ class TestK8sSandboxInit:
 
 class TestK8sSandboxEnsureSandbox:
     @patch("langchain_k8s_sandbox.sandbox.K8sSandbox._ensure_sandbox")
-    def test_execute_calls_ensure_sandbox(self, mock_ensure):
+    def test_execute_calls_ensure_sandbox(self, mock_ensure: MagicMock) -> None:
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
         mock_result.stdout = "hello"
@@ -59,7 +59,7 @@ class TestK8sSandboxEnsureSandbox:
         sb.execute("echo hello")
         mock_ensure.assert_called_once()
 
-    def test_ensure_sandbox_raises_without_sdk(self):
+    def test_ensure_sandbox_raises_without_sdk(self) -> None:
         sb = K8sSandbox()
         with (
             patch.dict(
@@ -69,7 +69,7 @@ class TestK8sSandboxEnsureSandbox:
         ):
             sb._ensure_sandbox()
 
-    def test_ensure_sandbox_creates_sandbox_once(self):
+    def test_ensure_sandbox_creates_sandbox_once(self) -> None:
         mock_sandbox_obj = MagicMock()
         mock_sandbox_obj.name = "test-sandbox-123"
 
@@ -96,7 +96,7 @@ class TestK8sSandboxEnsureSandbox:
 
 
 class TestK8sSandboxExecute:
-    def test_execute_success(self):
+    def test_execute_success(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
@@ -112,7 +112,7 @@ class TestK8sSandboxExecute:
         assert result.exit_code == 0
         assert result.truncated is False
 
-    def test_execute_with_stderr(self):
+    def test_execute_with_stderr(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
@@ -128,7 +128,7 @@ class TestK8sSandboxExecute:
         assert "err" in result.output
         assert result.exit_code == 1
 
-    def test_execute_exception_returns_error(self):
+    def test_execute_exception_returns_error(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_sandbox.commands.run.side_effect = ConnectionError("sandbox unreachable")
@@ -139,7 +139,7 @@ class TestK8sSandboxExecute:
         assert "Error:" in result.output
         assert result.exit_code == -1
 
-    def test_execute_timeout_forwarded(self):
+    def test_execute_timeout_forwarded(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
@@ -155,7 +155,7 @@ class TestK8sSandboxExecute:
 
 
 class TestK8sSandboxTerminate:
-    def test_terminate_calls_sdk(self):
+    def test_terminate_calls_sdk(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         sb._sandbox = mock_sandbox
@@ -165,11 +165,11 @@ class TestK8sSandboxTerminate:
         assert sb._sandbox is None
         assert sb._client is None
 
-    def test_terminate_idempotent(self):
+    def test_terminate_idempotent(self) -> None:
         sb = K8sSandbox()
         sb.terminate()
 
-    def test_terminate_failure_does_not_raise(self):
+    def test_terminate_failure_does_not_raise(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_sandbox.terminate.side_effect = RuntimeError("cleanup failed")
@@ -178,7 +178,7 @@ class TestK8sSandboxTerminate:
         sb.terminate()
         assert sb._sandbox is None
 
-    def test_execute_after_terminate_creates_new(self):
+    def test_execute_after_terminate_creates_new(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         sb._sandbox = mock_sandbox
@@ -188,7 +188,7 @@ class TestK8sSandboxTerminate:
 
 
 class TestK8sSandboxUploadDownload:
-    def test_upload_files_success(self):
+    def test_upload_files_success(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
@@ -204,7 +204,7 @@ class TestK8sSandboxUploadDownload:
         assert results[0].path == "/tmp/test.py"
         assert results[0].error is None
 
-    def test_upload_files_failure(self):
+    def test_upload_files_failure(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()
@@ -219,7 +219,7 @@ class TestK8sSandboxUploadDownload:
         assert len(results) == 1
         assert results[0].error is not None
 
-    def test_download_files_success(self):
+    def test_download_files_success(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         import base64
@@ -236,7 +236,7 @@ class TestK8sSandboxUploadDownload:
         assert len(results) == 1
         assert results[0].content == b"file content"
 
-    def test_download_files_not_found(self):
+    def test_download_files_not_found(self) -> None:
         sb = K8sSandbox()
         mock_sandbox = MagicMock()
         mock_result = MagicMock()

--- a/packages/langchain-k8s-sandbox/tests/test_sandbox.py
+++ b/packages/langchain-k8s-sandbox/tests/test_sandbox.py
@@ -1,0 +1,252 @@
+"""Unit tests for K8sSandbox with mocked agent-sandbox SDK."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_k8s_sandbox.sandbox import K8sSandbox
+
+
+class TestK8sSandboxInit:
+    def test_init_stores_config(self):
+        sandbox = K8sSandbox(
+            template="test-template",
+            namespace="test-ns",
+            router_url="http://router:8080",
+            labels={"cognition.io/user": "alice"},
+            ttl=1800,
+            warm_pool="test-pool",
+        )
+        assert sandbox._template == "test-template"
+        assert sandbox._namespace == "test-ns"
+        assert sandbox._router_url == "http://router:8080"
+        assert sandbox._labels == {"cognition.io/user": "alice"}
+        assert sandbox._ttl == 1800
+        assert sandbox._warm_pool == "test-pool"
+
+    def test_init_defaults(self):
+        sandbox = K8sSandbox()
+        assert sandbox._template == "cognition-sandbox"
+        assert sandbox._namespace == "default"
+        assert sandbox._ttl is None
+        assert sandbox._warm_pool is None
+        assert sandbox._labels == {}
+
+    def test_id_property(self):
+        sandbox = K8sSandbox()
+        assert sandbox.id.startswith("k8s-")
+
+    def test_lazy_init_no_sdk_calls(self):
+        sandbox = K8sSandbox()
+        assert sandbox._sandbox is None
+        assert sandbox._client is None
+
+
+class TestK8sSandboxEnsureSandbox:
+    @patch("langchain_k8s_sandbox.sandbox.K8sSandbox._ensure_sandbox")
+    def test_execute_calls_ensure_sandbox(self, mock_ensure):
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = "hello"
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_sandbox.commands.run.return_value = mock_result
+        mock_ensure.return_value = mock_sandbox
+
+        sb = K8sSandbox()
+        sb.execute("echo hello")
+        mock_ensure.assert_called_once()
+
+    def test_ensure_sandbox_raises_without_sdk(self):
+        sb = K8sSandbox()
+        with (
+            patch.dict(
+                "sys.modules", {"k8s_agent_sandbox": None, "k8s_agent_sandbox.models": None}
+            ),
+            pytest.raises(RuntimeError, match="k8s-agent-sandbox is required"),
+        ):
+            sb._ensure_sandbox()
+
+    def test_ensure_sandbox_creates_sandbox_once(self):
+        mock_sandbox_obj = MagicMock()
+        mock_sandbox_obj.name = "test-sandbox-123"
+
+        mock_client = MagicMock()
+        mock_client.create_sandbox.return_value = mock_sandbox_obj
+
+        with patch("langchain_k8s_sandbox.sandbox.K8sSandbox._ensure_sandbox"):
+            pass
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "k8s_agent_sandbox": MagicMock(SandboxClient=MagicMock(return_value=mock_client)),
+                "k8s_agent_sandbox.models": MagicMock(
+                    SandboxDirectConnectionConfig=MagicMock(return_value=MagicMock())
+                ),
+            },
+        ):
+            sb = K8sSandbox(template="test-tpl", namespace="test-ns", labels={"k": "v"}, ttl=600)
+
+            with patch.object(sb, "_ensure_sandbox", return_value=mock_sandbox_obj):
+                sb._ensure_sandbox()
+                sb._ensure_sandbox()
+
+
+class TestK8sSandboxExecute:
+    def test_execute_success(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = "hello world"
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        result = sb.execute("echo hello")
+        assert result.output == "hello world"
+        assert result.exit_code == 0
+        assert result.truncated is False
+
+    def test_execute_with_stderr(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = "out"
+        mock_result.stderr = "err"
+        mock_result.exit_code = 1
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        result = sb.execute("bad-command")
+        assert "out" in result.output
+        assert "err" in result.output
+        assert result.exit_code == 1
+
+    def test_execute_exception_returns_error(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_sandbox.commands.run.side_effect = ConnectionError("sandbox unreachable")
+
+        sb._sandbox = mock_sandbox
+
+        result = sb.execute("echo hello")
+        assert "Error:" in result.output
+        assert result.exit_code == -1
+
+    def test_execute_timeout_forwarded(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        sb.execute("long-command", timeout=120)
+        mock_sandbox.commands.run.assert_called_once_with("sh -c long-command", timeout=120)
+
+
+class TestK8sSandboxTerminate:
+    def test_terminate_calls_sdk(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        sb._sandbox = mock_sandbox
+
+        sb.terminate()
+        mock_sandbox.terminate.assert_called_once()
+        assert sb._sandbox is None
+        assert sb._client is None
+
+    def test_terminate_idempotent(self):
+        sb = K8sSandbox()
+        sb.terminate()
+
+    def test_terminate_failure_does_not_raise(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_sandbox.terminate.side_effect = RuntimeError("cleanup failed")
+        sb._sandbox = mock_sandbox
+
+        sb.terminate()
+        assert sb._sandbox is None
+
+    def test_execute_after_terminate_creates_new(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        sb._sandbox = mock_sandbox
+
+        sb.terminate()
+        assert sb._sandbox is None
+
+
+class TestK8sSandboxUploadDownload:
+    def test_upload_files_success(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        results = sb.upload_files([("/tmp/test.py", b"print('hello')")])
+        assert len(results) == 1
+        assert results[0].path == "/tmp/test.py"
+        assert results[0].error is None
+
+    def test_upload_files_failure(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "permission denied"
+        mock_result.exit_code = 1
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        results = sb.upload_files([("/root/secret.py", b"secret")])
+        assert len(results) == 1
+        assert results[0].error is not None
+
+    def test_download_files_success(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        import base64
+
+        mock_result = MagicMock()
+        mock_result.stdout = base64.b64encode(b"file content").decode()
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        results = sb.download_files(["/workspace/main.py"])
+        assert len(results) == 1
+        assert results[0].content == b"file content"
+
+    def test_download_files_not_found(self):
+        sb = K8sSandbox()
+        mock_sandbox = MagicMock()
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "No such file"
+        mock_result.exit_code = 1
+        mock_sandbox.commands.run.return_value = mock_result
+
+        sb._sandbox = mock_sandbox
+
+        results = sb.download_files(["/nonexistent.py"])
+        assert len(results) == 1
+        assert results[0].error == "file_not_found"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,10 +227,16 @@ ignore_missing_imports = true
 module = ["k8s_agent_sandbox", "k8s_agent_sandbox.*"]
 ignore_missing_imports = true
 
+# kubernetes client has no stubs
+[[tool.mypy.overrides]]
+module = ["kubernetes", "kubernetes.*"]
+ignore_missing_imports = true
+
 # langchain-k8s-sandbox workspace package (optional dep, not always installed)
 [[tool.mypy.overrides]]
 module = ["langchain_k8s_sandbox", "langchain_k8s_sandbox.*"]
 ignore_missing_imports = true
+disallow_untyped_defs = false
 
 # boto3 has no bundled stubs (boto3-stubs is optional)
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,14 @@ deploy = [
     "langgraph-checkpoint-postgres>=2.0.0",
 ]
 
+# Kubernetes sandbox backend
+k8s = [
+    "langchain-k8s-sandbox[k8s]",
+]
+
 # All extras
 all = [
-    "cognition[openai,bedrock,test,deploy]",
+    "cognition[openai,bedrock,test,deploy,k8s]",
 ]
 
 [project.scripts]
@@ -102,8 +107,14 @@ cognition-client = "client.tui.app:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.uv.sources]
+langchain-k8s-sandbox = { workspace = true }
+
 [tool.hatch.build.targets.wheel]
-packages = ["server", "client", "shared"]
+packages = ["server", "client", "shared", "packages"]
 
 [tool.ruff]
 target-version = "py311"
@@ -157,7 +168,7 @@ line-ending = "auto"
 convention = "google"
 
 [tool.ruff.lint.isort]
-known-first-party = ["server", "client", "shared"]
+known-first-party = ["server", "client", "shared", "langchain_k8s_sandbox"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -209,6 +220,16 @@ ignore_missing_imports = true
 # asyncpg has no stubs on Python 3.11 CI env
 [[tool.mypy.overrides]]
 module = ["asyncpg", "asyncpg.*"]
+ignore_missing_imports = true
+
+# k8s-agent-sandbox SDK has no stubs
+[[tool.mypy.overrides]]
+module = ["k8s_agent_sandbox", "k8s_agent_sandbox.*"]
+ignore_missing_imports = true
+
+# langchain-k8s-sandbox workspace package (optional dep, not always installed)
+[[tool.mypy.overrides]]
+module = ["langchain_k8s_sandbox", "langchain_k8s_sandbox.*"]
 ignore_missing_imports = true
 
 # boto3 has no bundled stubs (boto3-stubs is optional)

--- a/server/app/agent/__init__.py
+++ b/server/app/agent/__init__.py
@@ -8,7 +8,7 @@ from server.app.agent.agent_definition_registry import (
     get_agent_definition_registry,
     initialize_agent_definition_registry,
 )
-from server.app.agent.cognition_agent import create_cognition_agent
+from server.app.agent.cognition_agent import CognitionAgentResult, create_cognition_agent
 from server.app.agent.definition import (
     AgentConfig,
     AgentDefinition,
@@ -36,6 +36,7 @@ from server.app.agent.tools import BrowserTool, InspectPackageTool, SearchTool
 __all__ = [
     # Agent creation
     "create_cognition_agent",
+    "CognitionAgentResult",
     "CognitionLocalSandboxBackend",
     # Tools
     "BrowserTool",

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -343,7 +343,7 @@ async def create_cognition_agent(
     # Check if we have a cached agent for this configuration
     cached_agent = get_cached_agent(cache_key)
     if cached_agent is not None:
-        return cached_agent
+        return cast(CognitionAgentResult, cached_agent)
 
     # Create the sandbox backend using settings-driven factory
     sandbox_id = f"cognition-{project_path.name}"

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -23,7 +23,7 @@ import importlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import structlog
 from deepagents import create_deep_agent as _create_deep_agent
@@ -252,11 +252,25 @@ Best practices:
 The current working directory is the project root. All file paths are relative to this root."""
 
 
+class CognitionAgentResult(NamedTuple):
+    """Result of creating a Cognition agent.
+
+    Attributes:
+        agent: The compiled LangGraph agent.
+        sandbox_backend: The sandbox backend used by the agent, if any.
+            Callers should register this with SessionAgentManager for
+            lifecycle tracking (terminate on session deletion).
+    """
+
+    agent: Any
+    sandbox_backend: Any | None = None
+
+
 async def create_cognition_agent(
     project_path: str | Path,
     model: Any = None,
-    store: Any = None,  # LangGraph store
-    checkpointer: Any = None,  # LangGraph checkpointer
+    store: Any = None,
+    checkpointer: Any = None,
     system_prompt: str | None = None,
     memory: Sequence[str] | None = None,
     skills: Sequence[str] | None = None,
@@ -269,7 +283,7 @@ async def create_cognition_agent(
     settings: Settings | None = None,
     mcp_configs: Sequence[McpServerConfig] | None = None,
     scope: dict[str, str] | None = None,
-) -> Any:
+) -> CognitionAgentResult:
     """Create a Deep Agent for the Cognition system.
 
     This factory creates an agent with:
@@ -333,6 +347,19 @@ async def create_cognition_agent(
 
     # Create the sandbox backend using settings-driven factory
     sandbox_id = f"cognition-{project_path.name}"
+
+    # Build K8s scoping labels from session scope when available
+    k8s_labels: dict[str, str] | None = None
+    if scope:
+        k8s_labels = {}
+        if "user" in scope:
+            k8s_labels["cognition.io/user"] = scope["user"]
+        if "org" in scope:
+            k8s_labels["cognition.io/org"] = scope["org"]
+        if "project" in scope:
+            k8s_labels["cognition.io/project"] = scope["project"]
+        k8s_labels["cognition.io/session"] = sandbox_id
+
     sandbox_backend = create_sandbox_backend(
         root_dir=project_path,
         sandbox_id=sandbox_id,
@@ -341,7 +368,13 @@ async def create_cognition_agent(
         docker_network=settings.docker_network,
         docker_memory_limit=settings.docker_memory_limit,
         docker_cpu_limit=settings.docker_cpu_limit,
-        docker_host_workspace="",  # docker_host_workspace removed from Settings (niche Docker-in-Docker only)
+        docker_host_workspace="",
+        k8s_template=settings.k8s_sandbox_template,
+        k8s_namespace=settings.k8s_sandbox_namespace,
+        k8s_router_url=settings.k8s_sandbox_router_url,
+        k8s_ttl=settings.k8s_sandbox_ttl,
+        k8s_warm_pool=settings.k8s_sandbox_warm_pool,
+        labels=k8s_labels or None,
     )
 
     # Resolve agent defaults from ConfigRegistry (falls back to hardcoded defaults)
@@ -522,10 +555,12 @@ async def create_cognition_agent(
 
     agent = cast(Any, create_deep_agent)(**create_kwargs)
 
-    # Cache the compiled agent
-    cache_agent(cache_key, agent)
+    result = CognitionAgentResult(agent=agent, sandbox_backend=sandbox_backend)
 
-    return agent
+    # Cache the full result so cache hits return CognitionAgentResult, not raw agent
+    cache_agent(cache_key, result)
+
+    return result
 
 
 def _resolve_response_format(response_format: str | type[Any] | None) -> type[Any] | None:

--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -1022,7 +1022,7 @@ async def create_agent_runtime(
             resolved_middleware.append(mw_instance)
 
     # Create the Deep Agent
-    agent = await create_cognition_agent(
+    result = await create_cognition_agent(
         project_path=workspace_path,
         system_prompt=definition.system_prompt,
         tools=tools if tools else None,
@@ -1039,7 +1039,7 @@ async def create_agent_runtime(
         definition.config.recursion_limit if definition.config.recursion_limit is not None else 1000
     )
     return DeepAgentRuntime(
-        agent=agent,
+        agent=result.agent,
         checkpointer=checkpointer,
         thread_id=thread_id,
         recursion_limit=effective_recursion_limit,

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -3,9 +3,11 @@
 This module provides sandbox backends that combine:
 1. Native filesystem operations via deepagents.backends.FilesystemBackend
 2. Command execution via LocalShellBackend (local) or DockerExecutionBackend (Docker)
+3. Kubernetes sandbox execution via agent-sandbox CRD (Kubernetes)
 
 The local backend is used for development; the Docker backend provides
-kernel-level isolation per session for production.
+kernel-level isolation per session for production; the Kubernetes backend
+provides K8s-native isolation for production deployments on Kubernetes.
 """
 
 from __future__ import annotations
@@ -214,6 +216,238 @@ class CognitionDockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):
         )
 
 
+class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
+    """Kubernetes sandbox backend with Cognition policy enforcement.
+
+    Wraps ``langchain_k8s_sandbox.K8sSandbox`` (a ``BaseSandbox`` subclass)
+    with Cognition-specific policy:
+
+    - Protected path enforcement (same as CognitionLocalSandboxBackend)
+    - User/org/project labels derived from CognitionContext for multi-tenant scoping
+    - Session-scoped lifecycle tied to Cognition session creation/destruction
+
+    The K8sSandbox is lazily initialized on first ``execute()`` — no Sandbox CR
+    is created until code actually needs to run.
+    """
+
+    def __init__(
+        self,
+        root_dir: str | Path,
+        sandbox_id: str | None = None,
+        template: str = "cognition-sandbox",
+        namespace: str = "default",
+        router_url: str = "http://sandbox-router-svc.default.svc.cluster.local:8080",
+        labels: dict[str, str] | None = None,
+        ttl: int | None = 3600,
+        protected_paths: list[str] | None = None,
+        warm_pool: str | None = None,
+    ):
+        """Initialize the Kubernetes sandbox backend.
+
+        Args:
+            root_dir: Workspace directory (used for protected path resolution).
+            sandbox_id: Unique identifier for this sandbox.
+            template: SandboxTemplate CR name for the sandbox pod spec.
+            namespace: Kubernetes namespace for sandbox CRs.
+            router_url: URL of the sandbox-router service.
+            labels: Labels applied to the Sandbox CR (scoping metadata).
+            ttl: Time-to-live in seconds for sandbox auto-cleanup.
+            protected_paths: List of protected path prefixes.
+                Defaults to [".cognition"].
+            warm_pool: Optional SandboxWarmPool CR name.
+        """
+        self._root_dir = Path(root_dir).resolve()
+        self._id = sandbox_id or f"cognition-k8s-{id(self)}"
+        self._template = template
+        self._namespace = namespace
+        self._router_url = router_url
+        self._labels = labels or {}
+        self._ttl = ttl
+        self._protected_paths = protected_paths or [".cognition"]
+        self._warm_pool = warm_pool
+
+        self._backend: Any | None = None
+
+    @property
+    def id(self) -> str:
+        """Return the unique identifier for this sandbox."""
+        return self._id
+
+    def _get_backend(self) -> Any:
+        """Lazily initialize the K8sSandbox backend.
+
+        Returns:
+            K8sSandbox instance from langchain-k8s-sandbox.
+
+        Raises:
+            RuntimeError: If langchain-k8s-sandbox is not installed.
+        """
+        if self._backend is None:
+            try:
+                from langchain_k8s_sandbox import K8sSandbox
+            except ImportError as e:
+                raise RuntimeError(
+                    "langchain-k8s-sandbox is required for the kubernetes sandbox backend. "
+                    "Install with: pip install cognition[k8s]"
+                ) from e
+
+            self._backend = K8sSandbox(
+                template=self._template,
+                namespace=self._namespace,
+                router_url=self._router_url,
+                labels=self._labels,
+                ttl=self._ttl,
+                warm_pool=self._warm_pool,
+            )
+            logger.info(
+                "K8s sandbox backend initialized",
+                sandbox_id=self._id,
+                template=self._template,
+                namespace=self._namespace,
+            )
+        return self._backend
+
+    def _is_protected_path(self, path: str) -> bool:
+        """Check if a path is protected.
+
+        Args:
+            path: The path to check (relative or absolute).
+
+        Returns:
+            True if the path is protected, False otherwise.
+        """
+        try:
+            resolved = (self._root_dir / path).resolve()
+            resolved_str = str(resolved)
+            for protected in self._protected_paths:
+                protected_full = (self._root_dir / protected).resolve()
+                if resolved_str.startswith(str(protected_full)):
+                    return True
+        except (ValueError, OSError):
+            pass
+        return False
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        """Execute a command inside the K8s sandbox pod.
+
+        Args:
+            command: Shell command to execute.
+            timeout: Optional per-command timeout override in seconds.
+        """
+        backend = self._get_backend()
+        result: ExecuteResponse = backend.execute(command, timeout=timeout)
+        return result
+
+    def write(self, file_path: str, content: str) -> Any:
+        """Write content to file with protected path check.
+
+        Args:
+            file_path: File path to write to.
+            content: Content to write.
+
+        Returns:
+            WriteResult from the backend.
+
+        Raises:
+            PermissionError: If the path is protected.
+        """
+        if self._is_protected_path(file_path):
+            raise PermissionError(f"Writing to protected path is not allowed: {file_path}")
+        backend = self._get_backend()
+        return backend.write(file_path, content)
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+        """Read file content from the sandbox.
+
+        Args:
+            file_path: File path to read.
+            offset: Line offset to start reading from.
+            limit: Maximum number of lines to read.
+
+        Returns:
+            File content as string.
+        """
+        backend = self._get_backend()
+        result: str = backend.read(file_path, offset=offset, limit=limit)
+        return result
+
+    def ls_info(self, path: str) -> Any:
+        """List files and directories in the sandbox.
+
+        Args:
+            path: Directory path to list.
+
+        Returns:
+            List of FileInfo objects.
+        """
+        backend = self._get_backend()
+        return backend.ls_info(path)
+
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None) -> Any:
+        """Search for a pattern in sandbox files.
+
+        Args:
+            pattern: Regex pattern to search for.
+            path: Directory path to search in.
+            glob: File glob pattern to filter.
+
+        Returns:
+            List of GrepMatch objects or string.
+        """
+        backend = self._get_backend()
+        return backend.grep_raw(pattern, path=path, glob=glob)
+
+    def glob_info(self, pattern: str, path: str = "/") -> Any:
+        """Find files matching a glob pattern in the sandbox.
+
+        Args:
+            pattern: Glob pattern to match.
+            path: Directory path to search in.
+
+        Returns:
+            List of FileInfo objects.
+        """
+        backend = self._get_backend()
+        return backend.glob_info(pattern, path=path)
+
+    def edit(
+        self, file_path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> Any:
+        """Edit a file in the sandbox with protected path check.
+
+        Args:
+            file_path: File path to edit.
+            old_string: String to find.
+            new_string: Replacement string.
+            replace_all: Replace all occurrences.
+
+        Returns:
+            EditResult from the backend.
+
+        Raises:
+            PermissionError: If the path is protected.
+        """
+        if self._is_protected_path(file_path):
+            raise PermissionError(f"Editing protected path is not allowed: {file_path}")
+        backend = self._get_backend()
+        return backend.edit(file_path, old_string, new_string, replace_all=replace_all)
+
+    def terminate(self) -> None:
+        """Terminate the K8s sandbox and clean up resources.
+
+        Safe to call multiple times. Subsequent ``execute()`` calls after
+        terminate will create a new sandbox.
+        """
+        if self._backend is not None:
+            try:
+                self._backend.terminate()
+                logger.info("K8s sandbox terminated", sandbox_id=self._id)
+            except Exception as e:
+                logger.warning("K8s sandbox terminate failed", error=str(e))
+            finally:
+                self._backend = None
+
+
 def create_sandbox_backend(
     root_dir: str | Path,
     sandbox_id: str | None = None,
@@ -223,25 +457,38 @@ def create_sandbox_backend(
     docker_memory_limit: str = "512m",
     docker_cpu_limit: float = 1.0,
     docker_host_workspace: str = "",
-) -> FilesystemBackend:
+    k8s_template: str = "cognition-sandbox",
+    k8s_namespace: str = "default",
+    k8s_router_url: str = "http://sandbox-router-svc.default.svc.cluster.local:8080",
+    k8s_ttl: int = 3600,
+    k8s_warm_pool: str | None = None,
+    labels: dict[str, str] | None = None,
+) -> FilesystemBackend | CognitionKubernetesSandboxBackend:
     """Factory for creating sandbox backends from settings.
 
     Args:
         root_dir: Workspace root directory.
         sandbox_id: Unique identifier for the sandbox.
-        sandbox_backend: Backend type - "local" or "docker".
+        sandbox_backend: Backend type - "local", "docker", or "kubernetes".
         docker_image: Docker image for sandbox containers.
         docker_network: Docker network mode.
         docker_memory_limit: Container memory limit.
         docker_cpu_limit: Container CPU limit.
         docker_host_workspace: Host filesystem path for Docker volume mount.
+        k8s_template: SandboxTemplate CR name for K8s sandbox pods.
+        k8s_namespace: Kubernetes namespace for sandbox CRs.
+        k8s_router_url: URL of the sandbox-router service.
+        k8s_ttl: Time-to-live in seconds for K8s sandbox auto-cleanup.
+        k8s_warm_pool: Optional SandboxWarmPool CR name.
+        labels: Labels applied to the Sandbox CR (K8s only).
 
     Returns:
         A sandbox backend implementing both FilesystemBackend and
-        SandboxBackendProtocol.
+        SandboxBackendProtocol (for local/docker), or
+        CognitionKubernetesSandboxBackend (for kubernetes).
 
     Raises:
-        ValueError: If sandbox_backend is not "local" or "docker".
+        ValueError: If sandbox_backend is not "local", "docker", or "kubernetes".
     """
     if sandbox_backend == "local":
         return CognitionLocalSandboxBackend(
@@ -258,7 +505,93 @@ def create_sandbox_backend(
             cpu_limit=docker_cpu_limit,
             host_workspace=docker_host_workspace,
         )
+    elif sandbox_backend == "kubernetes":
+        return CognitionKubernetesSandboxBackend(
+            root_dir=root_dir,
+            sandbox_id=sandbox_id,
+            template=k8s_template,
+            namespace=k8s_namespace,
+            router_url=k8s_router_url,
+            ttl=k8s_ttl,
+            labels=labels,
+            warm_pool=k8s_warm_pool,
+        )
     else:
         raise ValueError(
-            f"Unknown sandbox_backend: {sandbox_backend!r}. Must be 'local' or 'docker'."
+            f"Unknown sandbox_backend: {sandbox_backend!r}. "
+            "Must be 'local', 'docker', or 'kubernetes'."
         )
+
+
+def validate_k8s_sandbox_config(
+    namespace: str = "default",
+    router_url: str = "http://sandbox-router-svc.default.svc.cluster.local:8080",
+) -> list[str]:
+    """Validate K8s sandbox prerequisites at startup.
+
+    Checks that the Sandbox CRD is installed and the router is reachable.
+    Returns a list of warning messages for issues that are not fatal.
+
+    Raises:
+        RuntimeError: If the Sandbox CRD is not installed (fatal misconfiguration).
+    """
+    warnings: list[str] = []
+
+    try:
+        from kubernetes import client as k8s_client
+        from kubernetes.config import load_incluster_config
+
+        try:
+            load_incluster_config()
+        except Exception:
+            from kubernetes.config import load_kube_config
+
+            try:
+                load_kube_config()
+            except Exception:
+                warnings.append("No K8s config available (not in cluster, no kubeconfig)")
+                return warnings
+
+        api = k8s_client.ApiextensionsV1Api()
+        try:
+            api.read_custom_resource_definition(name="sandboxes.agents.x-k8s.io")
+        except k8s_client.rest.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    "Sandbox CRD 'sandboxes.agents.x-k8s.io' not found. "
+                    "Install the agent-sandbox controller: "
+                    "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/manifest.yaml"
+                ) from e
+            warnings.append(f"Could not verify Sandbox CRD: {e}")
+
+        try:
+            api.read_custom_resource_definition(name="sandboxclaims.extensions.agents.x-k8s.io")
+        except k8s_client.rest.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    "SandboxClaim CRD 'sandboxclaims.extensions.agents.x-k8s.io' not found. "
+                    "Install agent-sandbox extensions: "
+                    "kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.3.10/extensions.yaml"
+                ) from e
+            warnings.append(f"Could not verify SandboxClaim CRD: {e}")
+
+    except ImportError:
+        warnings.append("kubernetes Python package not installed; skipping CRD validation")
+
+    import httpx
+
+    try:
+        resp = httpx.get(f"{router_url}/healthz", timeout=5)
+        if resp.status_code != 200:
+            warnings.append(
+                f"Router health check returned {resp.status_code}: {router_url}/healthz"
+            )
+    except Exception as e:
+        warnings.append(f"Router not reachable at {router_url}: {e}")
+
+    if warnings:
+        logger.warning("K8s sandbox validation warnings", warnings=warnings)
+    else:
+        logger.info("K8s sandbox validation passed")
+
+    return warnings

--- a/server/app/agent_registry.py
+++ b/server/app/agent_registry.py
@@ -599,7 +599,7 @@ class AgentRegistry:
 
         # Create the agent
         effective_settings = settings or self._settings
-        agent = create_cognition_agent(
+        result = create_cognition_agent(
             project_path=project_path,
             model=model,
             checkpointer=checkpointer,
@@ -607,8 +607,9 @@ class AgentRegistry:
             tools=tools if tools else None,
             middleware=middleware if middleware else None,
             settings=effective_settings,
-            mcp_configs=None,  # MCP configs resolved from ConfigRegistry in deep_agent_service
+            mcp_configs=None,
         )
+        agent = result.agent
 
         # If session_id provided, associate agent with session
         if session_id and self._session_manager:

--- a/server/app/agent_registry.py
+++ b/server/app/agent_registry.py
@@ -599,7 +599,7 @@ class AgentRegistry:
 
         # Create the agent
         effective_settings = settings or self._settings
-        result = create_cognition_agent(
+        result = await create_cognition_agent(
             project_path=project_path,
             model=model,
             checkpointer=checkpointer,

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -597,8 +597,11 @@ class DeepAgentStreamingService:
                 scope=scope,
             )
 
+            if manager and agent.sandbox_backend is not None:
+                manager.register_sandbox_backend(session_id, agent.sandbox_backend)
+
             runtime = DeepAgentRuntime(
-                agent=agent,
+                agent=agent.agent,
                 checkpointer=checkpointer,
                 thread_id=thread_id,
                 recursion_limit=recursion_limit,
@@ -801,7 +804,7 @@ class DeepAgentStreamingService:
                 }
 
             runtime = DeepAgentRuntime(
-                agent=agent,
+                agent=agent.agent,
                 checkpointer=checkpointer,
                 thread_id=thread_id,
                 recursion_limit=recursion_limit,
@@ -1221,6 +1224,7 @@ class SessionAgentManager:
         self._services: dict[str, DeepAgentStreamingService] = {}
         self._project_paths: dict[str, str] = {}
         self._active_runtimes: dict[str, Any] = {}
+        self._sandbox_backends: dict[str, Any] = {}
 
     def register_session(
         self,
@@ -1282,11 +1286,35 @@ class SessionAgentManager:
         logger.warning("No active runtime to abort", session_id=session_id)
         return False
 
+    def register_sandbox_backend(self, session_id: str, backend: Any) -> None:
+        """Register a sandbox backend for lifecycle tracking.
+
+        The backend's ``terminate()`` method will be called when the session
+        is unregistered, cleaning up any K8s Sandbox CRs or Docker containers.
+
+        Args:
+            session_id: Unique session identifier.
+            backend: The sandbox backend instance (must have a ``terminate()`` method).
+        """
+        self._sandbox_backends[session_id] = backend
+        logger.debug("Sandbox backend registered", session_id=session_id)
+
     def unregister_session(self, session_id: str) -> None:
         """Unregister a session and clean up resources."""
         self._services.pop(session_id, None)
         self._project_paths.pop(session_id, None)
         self._active_runtimes.pop(session_id, None)
+
+        backend = self._sandbox_backends.pop(session_id, None)
+        if backend is not None and hasattr(backend, "terminate"):
+            try:
+                backend.terminate()
+                logger.info("Sandbox backend terminated", session_id=session_id)
+            except Exception as e:
+                logger.warning(
+                    "Sandbox backend terminate failed", session_id=session_id, error=str(e)
+                )
+
         logger.info("Session unregistered", session_id=session_id)
 
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -85,6 +85,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     initialize_agent_registry(settings=settings)
     logger.info("Agent registry initialized")
 
+    # Validate K8s sandbox prerequisites if backend is kubernetes
+    if settings.sandbox_backend == "kubernetes":
+        from server.app.agent.sandbox_backend import validate_k8s_sandbox_config
+
+        try:
+            validate_k8s_sandbox_config(
+                namespace=settings.k8s_sandbox_namespace,
+                router_url=settings.k8s_sandbox_router_url,
+            )
+        except RuntimeError as e:
+            logger.error("K8s sandbox validation failed", error=str(e))
+            raise
+
     # Set up file watcher for hot-reload
     try:
         from server.app.agent_registry import get_agent_registry

--- a/server/app/session_manager.py
+++ b/server/app/session_manager.py
@@ -430,14 +430,14 @@ class SessionManager:
         storage = get_storage_backend()
         checkpointer = await storage.get_checkpointer()
 
-        agent = await create_cognition_agent(
+        result = await create_cognition_agent(
             project_path=managed.session.workspace_path,
             model=model,
             checkpointer=checkpointer,
             settings=self._settings,
         )
 
-        managed.agent = agent
+        managed.agent = result.agent
         managed.last_accessed = datetime.now(UTC)
 
         logger.info(
@@ -446,7 +446,7 @@ class SessionManager:
             thread_id=managed.session.thread_id,
         )
 
-        return agent
+        return result.agent
 
     def invalidate_agent(self, session_id: str) -> None:
         """Invalidate the cached agent for a session.

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -134,7 +134,7 @@ class Settings(BaseSettings):
     )
 
     # Sandbox / Execution backend settings
-    sandbox_backend: Literal["local", "docker"] = Field(
+    sandbox_backend: Literal["local", "docker", "kubernetes"] = Field(
         default="local",
         alias="COGNITION_SANDBOX_BACKEND",
     )
@@ -153,6 +153,33 @@ class Settings(BaseSettings):
     docker_cpu_limit: float = Field(
         default=1.0,
         alias="COGNITION_DOCKER_CPU_LIMIT",
+    )
+
+    # Kubernetes sandbox settings (only used when sandbox_backend="kubernetes")
+    k8s_sandbox_template: str = Field(
+        default="cognition-sandbox",
+        alias="COGNITION_K8S_SANDBOX_TEMPLATE",
+        description="SandboxTemplate CR name for creating K8s sandbox pods.",
+    )
+    k8s_sandbox_namespace: str = Field(
+        default="default",
+        alias="COGNITION_K8S_SANDBOX_NAMESPACE",
+        description="Kubernetes namespace for sandbox CRs.",
+    )
+    k8s_sandbox_router_url: str = Field(
+        default="http://sandbox-router-svc.default.svc.cluster.local:8080",
+        alias="COGNITION_K8S_SANDBOX_ROUTER_URL",
+        description="URL of the sandbox-router service for in-cluster communication.",
+    )
+    k8s_sandbox_ttl: int = Field(
+        default=3600,
+        alias="COGNITION_K8S_SANDBOX_TTL",
+        description="Time-to-live in seconds for K8s sandbox CRs.",
+    )
+    k8s_sandbox_warm_pool: str | None = Field(
+        default=None,
+        alias="COGNITION_K8S_SANDBOX_WARM_POOL",
+        description="Optional SandboxWarmPool CR name for pre-warmed sandbox allocation.",
     )
 
     blocked_tools: list[str] = Field(

--- a/tests/e2e/test_k8s_sandbox_e2e.py
+++ b/tests/e2e/test_k8s_sandbox_e2e.py
@@ -1,0 +1,402 @@
+"""E2E tests for Cognition K8s sandbox backend.
+
+These tests verify the K8s sandbox integration against a live Kubernetes cluster
+running the agent-sandbox controller, sandbox-router, and Cognition server.
+
+Requirements:
+- A K8s cluster with agent-sandbox controller + extensions installed
+- A running sandbox-router service
+- A SandboxTemplate named ``cognition-sandbox`` in the target namespace
+- Cognition server deployed with ``COGNITION_SANDBOX_BACKEND=kubernetes``
+- ``COGNITION_K8S_E2E=1`` environment variable set
+
+Usage:
+    # Against a cluster with port-forwarded Cognition server
+    COGNITION_K8S_E2E=1 uv run pytest tests/e2e/test_k8s_sandbox_e2e.py -v
+
+    # Against a specific server URL
+    COGNITION_K8S_E2E=1 COGNITION_K8S_E2E_URL=http://localhost:8000 \
+        uv run pytest tests/e2e/test_k8s_sandbox_e2e.py -v
+
+    # Single test
+    COGNITION_K8S_E2E=1 uv run pytest \
+        tests/e2e/test_k8s_sandbox_e2e.py::TestK8sSandboxLifecycle::test_execute_returns_output -v
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from kubernetes import client as k8s_client
+from kubernetes.config import load_kube_config
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.timeout(120),
+    pytest.mark.skipif(
+        not os.environ.get("COGNITION_K8S_E2E"),
+        reason="Requires COGNITION_K8S_E2E=1 (live K8s cluster with agent-sandbox)",
+    ),
+]
+
+BASE_URL = os.environ.get("COGNITION_K8S_E2E_URL", "http://localhost:8000")
+K8S_NAMESPACE = os.environ.get("COGNITION_K8S_E2E_NAMESPACE", "cognition")
+K8S_ROUTER_URL = os.environ.get(
+    "COGNITION_K8S_E2E_ROUTER_URL",
+    f"http://sandbox-router-svc.{K8S_NAMESPACE}.svc.cluster.local:8080",
+)
+SCOPE_USER = "k8s-e2e-test-user"
+SCOPE_HEADER = {"X-Cognition-Scope-User": SCOPE_USER}
+
+
+def _k8s_custom_objects_api() -> k8s_client.CustomObjectsApi:
+    try:
+        from kubernetes.config import load_incluster_config
+
+        load_incluster_config()
+    except Exception:
+        load_kube_config()
+    return k8s_client.CustomObjectsApi()
+
+
+def _get_sandbox_cr(name: str) -> dict[str, Any] | None:
+    api = _k8s_custom_objects_api()
+    try:
+        return api.get_namespaced_custom_object(
+            group="agents.x-k8s.io",
+            version="v1alpha1",
+            namespace=K8S_NAMESPACE,
+            plural="sandboxes",
+            name=name,
+        )
+    except Exception:
+        return None
+
+
+def _get_sandbox_claim_cr(name: str) -> dict[str, Any] | None:
+    api = _k8s_custom_objects_api()
+    try:
+        return api.get_namespaced_custom_object(
+            group="extensions.agents.x-k8s.io",
+            version="v1alpha1",
+            namespace=K8S_NAMESPACE,
+            plural="sandboxclaims",
+            name=name,
+        )
+    except Exception:
+        return None
+
+
+def _list_sandbox_claims() -> list[dict[str, Any]]:
+    api = _k8s_custom_objects_api()
+    try:
+        resp = api.list_namespaced_custom_object(
+            group="extensions.agents.x-k8s.io",
+            version="v1alpha1",
+            namespace=K8S_NAMESPACE,
+            plural="sandboxclaims",
+        )
+        return resp.get("items", [])
+    except Exception:
+        return []
+
+
+@pytest.mark.asyncio
+class TestK8sSandboxLifecycle:
+    """Test sandbox creation, execution, and termination via Cognition API."""
+
+    @pytest_asyncio.fixture
+    async def http_client(self):
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+            yield client
+
+    @pytest_asyncio.fixture
+    async def session_id(self, http_client: httpx.AsyncClient) -> str:
+        response = await http_client.post(
+            f"{BASE_URL}/sessions",
+            json={"title": "K8s E2E Test"},
+            headers=SCOPE_HEADER,
+        )
+        assert response.status_code == 201
+        sid = response.json()["id"]
+        yield sid
+        await http_client.delete(f"{BASE_URL}/sessions/{sid}", headers=SCOPE_HEADER)
+
+    async def test_execute_returns_output(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        """Execute a simple command and verify the API responds."""
+        response = await http_client.post(
+            f"{BASE_URL}/sessions/{session_id}/messages",
+            json={"content": "Run echo k8s-e2e-test in a shell"},
+            headers=SCOPE_HEADER,
+        )
+        assert response.status_code == 200
+        text = response.text
+        assert "event:" in text or "data:" in text
+
+    async def test_session_delete_cleans_up_sandbox(self, http_client: httpx.AsyncClient) -> None:
+        """Session deletion terminates the sandbox backend."""
+        response = await http_client.post(
+            f"{BASE_URL}/sessions",
+            json={"title": "K8s E2E Terminate Test"},
+            headers=SCOPE_HEADER,
+        )
+        assert response.status_code == 201
+        sid = response.json()["id"]
+
+        await http_client.post(
+            f"{BASE_URL}/sessions/{sid}/messages",
+            json={"content": "Run echo alive"},
+            headers={**SCOPE_HEADER, "Accept": "application/json"},
+        )
+
+        claims_before = _list_sandbox_claims()
+        claim_names_before = {c["metadata"]["name"] for c in claims_before}
+
+        response = await http_client.delete(f"{BASE_URL}/sessions/{sid}", headers=SCOPE_HEADER)
+        assert response.status_code == 204
+
+        time.sleep(3)
+
+        claims_after = _list_sandbox_claims()
+        claim_names_after = {c["metadata"]["name"] for c in claims_after}
+
+        new_claims = claim_names_after - claim_names_before
+        assert len(new_claims) == 0, (
+            f"Sandbox claims not cleaned up after session delete: {new_claims}"
+        )
+
+
+class TestK8sSandboxDirectBackend:
+    """Test K8sSandbox backend directly without LLM involvement.
+
+    These tests create K8sSandbox instances directly and verify file ops,
+    labels, and TTL against live K8s CRs.
+    """
+
+    def test_execute_command(self) -> None:
+        """execute() runs a command and returns output."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            result = sandbox.execute("echo hello-k8s")
+            assert result.exit_code == 0
+            assert "hello-k8s" in result.output
+        finally:
+            sandbox.terminate()
+
+    def test_execute_python(self) -> None:
+        """execute() runs Python code inside the sandbox."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            result = sandbox.execute('python3 -c "import sys; print(sys.version)"')
+            assert result.exit_code == 0
+            assert "3.1" in result.output
+        finally:
+            sandbox.terminate()
+
+    def test_base_sandbox_write_and_read(self) -> None:
+        """BaseSandbox.write() and read() work via heredoc through sh -c."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            sandbox.write("/workspace/e2e_test.txt", "Hello from K8s e2e!")
+            content = sandbox.read("/workspace/e2e_test.txt")
+            assert "Hello from K8s e2e!" in content
+        finally:
+            sandbox.terminate()
+
+    def test_base_sandbox_edit(self) -> None:
+        """BaseSandbox.edit() modifies file content."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            sandbox.write("/workspace/edit_test.txt", "original content")
+            sandbox.edit("/workspace/edit_test.txt", "original", "modified")
+            content = sandbox.read("/workspace/edit_test.txt")
+            assert "modified content" in content
+            assert "original" not in content or "modified" in content
+        finally:
+            sandbox.terminate()
+
+    def test_upload_and_download_files(self) -> None:
+        """upload_files() and download_files() transfer binary data."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            upload_data = b"name,value\ntest,42\n"
+            results = sandbox.upload_files([("/workspace/data.csv", upload_data)])
+            assert results[0].error is None
+
+            dl = sandbox.download_files(["/workspace/data.csv"])
+            assert dl[0].content is not None
+            assert dl[0].content == upload_data
+        finally:
+            sandbox.terminate()
+
+    def test_labels_on_sandbox_claim(self) -> None:
+        """Labels are applied to the SandboxClaim CR."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        labels = {
+            "cognition.io/user": "e2e-test-user",
+            "cognition.io/session": "label-test",
+        }
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+            labels=labels,
+        )
+        try:
+            sandbox.execute("echo label-test")
+
+            claim_name = sandbox._sandbox_id
+            claim_cr = _get_sandbox_claim_cr(claim_name)
+            assert claim_cr is not None, f"SandboxClaim {claim_name} not found"
+
+            claim_labels = claim_cr["metadata"].get("labels", {})
+            assert claim_labels.get("cognition.io/user") == "e2e-test-user"
+            assert claim_labels.get("cognition.io/session") == "label-test"
+        finally:
+            sandbox.terminate()
+
+    def test_shutdown_time_on_sandbox_cr(self) -> None:
+        """TTL patches spec.shutdownTime on the Sandbox CR."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=600,
+        )
+        try:
+            sandbox.execute("echo ttl-test")
+
+            sandbox_name = sandbox._sandbox_id
+            sandbox_cr = _get_sandbox_cr(sandbox_name)
+            assert sandbox_cr is not None, f"Sandbox {sandbox_name} not found"
+
+            shutdown_time = sandbox_cr.get("spec", {}).get("shutdownTime")
+            assert shutdown_time is not None, "shutdownTime not set on Sandbox CR"
+            assert shutdown_time.endswith("Z"), (
+                f"shutdownTime should be ISO format: {shutdown_time}"
+            )
+        finally:
+            sandbox.terminate()
+
+    def test_terminate_removes_claim(self) -> None:
+        """terminate() deletes the SandboxClaim."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        sandbox.execute("echo terminate-test")
+        claim_name = sandbox._sandbox_id
+
+        claim_before = _get_sandbox_claim_cr(claim_name)
+        assert claim_before is not None, "Claim should exist before terminate"
+
+        sandbox.terminate()
+
+        time.sleep(3)
+
+        claim_after = _get_sandbox_claim_cr(claim_name)
+        assert claim_after is None, f"Claim {claim_name} should be deleted after terminate"
+
+    def test_lazy_init_no_cr_before_execute(self) -> None:
+        """No Sandbox CR is created until execute() is called."""
+        from langchain_k8s_sandbox import K8sSandbox
+
+        sandbox = K8sSandbox(
+            template="cognition-sandbox",
+            namespace=K8S_NAMESPACE,
+            router_url=K8S_ROUTER_URL,
+            ttl=300,
+        )
+        try:
+            assert sandbox._sandbox is None, "Sandbox should not exist before execute"
+            claims_before = _list_sandbox_claims()
+
+            sandbox.execute("echo lazy-init-test")
+
+            assert sandbox._sandbox is not None, "Sandbox should exist after execute"
+        finally:
+            sandbox.terminate()
+
+
+@pytest.mark.asyncio
+class TestK8sSandboxStartupValidation:
+    """Test startup validation checks for K8s sandbox."""
+
+    async def test_crd_exists(self) -> None:
+        """Agent-sandbox CRDs are installed on the cluster."""
+        load_kube_config()
+        api = k8s_client.ApiextensionsV1Api()
+        crd_names = [
+            "sandboxes.agents.x-k8s.io",
+            "sandboxclaims.extensions.agents.x-k8s.io",
+            "sandboxtemplates.extensions.agents.x-k8s.io",
+        ]
+        for crd_name in crd_names:
+            try:
+                api.read_custom_resource_definition(name=crd_name)
+            except Exception as e:
+                pytest.fail(f"CRD {crd_name} not found: {e}")
+
+    async def test_sandbox_template_exists(self) -> None:
+        """The cognition-sandbox SandboxTemplate exists."""
+        api = _k8s_custom_objects_api()
+        try:
+            api.get_namespaced_custom_object(
+                group="extensions.agents.x-k8s.io",
+                version="v1alpha1",
+                namespace=K8S_NAMESPACE,
+                plural="sandboxtemplates",
+                name="cognition-sandbox",
+            )
+        except Exception as e:
+            pytest.fail(f"SandboxTemplate cognition-sandbox not found: {e}")

--- a/tests/unit/test_k8s_sandbox_backend.py
+++ b/tests/unit/test_k8s_sandbox_backend.py
@@ -1,0 +1,192 @@
+"""Unit tests for CognitionKubernetesSandboxBackend."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from server.app.agent.sandbox_backend import (
+    CognitionKubernetesSandboxBackend,
+    create_sandbox_backend,
+)
+
+
+class TestCognitionKubernetesSandboxBackendInit:
+    def test_init_stores_config(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(
+            root_dir=tmp_path,
+            sandbox_id="test-sandbox",
+            template="gpu-sandbox",
+            namespace="ml-team",
+            router_url="http://router:8080",
+            labels={"cognition.io/user": "alice"},
+            ttl=7200,
+            warm_pool="gpu-pool",
+        )
+        assert backend.id == "test-sandbox"
+        assert backend._template == "gpu-sandbox"
+        assert backend._namespace == "ml-team"
+        assert backend._labels == {"cognition.io/user": "alice"}
+        assert backend._ttl == 7200
+        assert backend._warm_pool == "gpu-pool"
+        assert backend._backend is None
+
+    def test_init_defaults(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        assert backend.id.startswith("cognition-k8s-")
+        assert backend._template == "cognition-sandbox"
+        assert backend._namespace == "default"
+        assert backend._ttl == 3600
+        assert backend._labels == {}
+        assert backend._protected_paths == [".cognition"]
+
+
+class TestCognitionKubernetesSandboxBackendProtectedPaths:
+    def test_write_to_protected_path_raises(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        with pytest.raises(PermissionError, match="protected path"):
+            backend.write(".cognition/config.yaml", "forbidden")
+
+    def test_edit_to_protected_path_raises(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        with pytest.raises(PermissionError, match="protected path"):
+            backend.edit(".cognition/config.yaml", "old", "new")
+
+    def test_write_to_normal_path_delegates(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        mock_inner = MagicMock()
+        mock_inner.write.return_value = MagicMock(error=None, path="main.py")
+        backend._backend = mock_inner
+
+        result = backend.write("main.py", "print('hello')")
+        mock_inner.write.assert_called_once_with("main.py", "print('hello')")
+
+
+class TestCognitionKubernetesSandboxBackendExecute:
+    def test_execute_delegates_to_inner(self, tmp_path):
+        from deepagents.backends.protocol import ExecuteResponse
+
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        mock_inner = MagicMock()
+        mock_inner.execute.return_value = ExecuteResponse(
+            output="hello", exit_code=0, truncated=False
+        )
+        backend._backend = mock_inner
+
+        result = backend.execute("echo hello")
+        mock_inner.execute.assert_called_once_with("echo hello", timeout=None)
+        assert result.output == "hello"
+        assert result.exit_code == 0
+
+    def test_execute_with_timeout(self, tmp_path):
+        from deepagents.backends.protocol import ExecuteResponse
+
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        mock_inner = MagicMock()
+        mock_inner.execute.return_value = ExecuteResponse(output="", exit_code=0, truncated=False)
+        backend._backend = mock_inner
+
+        backend.execute("long-cmd", timeout=120)
+        mock_inner.execute.assert_called_once_with("long-cmd", timeout=120)
+
+
+class TestCognitionKubernetesSandboxBackendTerminate:
+    def test_terminate_delegates(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        mock_inner = MagicMock()
+        backend._backend = mock_inner
+
+        backend.terminate()
+        mock_inner.terminate.assert_called_once()
+        assert backend._backend is None
+
+    def test_terminate_when_not_initialized(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        backend.terminate()
+
+
+class TestCognitionKubernetesSandboxBackendLazyInit:
+    def test_get_backend_raises_without_package(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        with patch(
+            "builtins.__import__",
+            side_effect=ImportError("No module named 'langchain_k8s_sandbox'"),
+        ):
+            with pytest.raises(RuntimeError, match="langchain-k8s-sandbox is required"):
+                backend._get_backend()
+
+    def test_get_backend_creates_k8s_sandbox(self, tmp_path):
+        mock_k8s_sandbox = MagicMock()
+        mock_k8s_class = MagicMock(return_value=mock_k8s_sandbox)
+        mock_module = MagicMock(K8sSandbox=mock_k8s_class)
+
+        backend = CognitionKubernetesSandboxBackend(
+            root_dir=tmp_path,
+            template="test-tpl",
+            namespace="test-ns",
+            labels={"k": "v"},
+            ttl=600,
+        )
+
+        with patch.dict("sys.modules", {"langchain_k8s_sandbox": mock_module}):
+            result = backend._get_backend()
+            assert result is mock_k8s_sandbox
+            mock_k8s_class.assert_called_once_with(
+                template="test-tpl",
+                namespace="test-ns",
+                router_url="http://sandbox-router-svc.default.svc.cluster.local:8080",
+                labels={"k": "v"},
+                ttl=600,
+                warm_pool=None,
+            )
+
+    def test_get_backend_cached(self, tmp_path):
+        backend = CognitionKubernetesSandboxBackend(root_dir=tmp_path)
+        mock_k8s_sandbox = MagicMock()
+        mock_k8s_class = MagicMock(return_value=mock_k8s_sandbox)
+        mock_module = MagicMock(K8sSandbox=mock_k8s_class)
+
+        with patch.dict("sys.modules", {"langchain_k8s_sandbox": mock_module}):
+            backend._get_backend()
+            backend._get_backend()
+            assert mock_k8s_class.call_count == 1
+
+
+class TestCreateSandboxBackendFactory:
+    def test_kubernetes_branch(self, tmp_path):
+        backend = create_sandbox_backend(
+            root_dir=tmp_path,
+            sandbox_id="test",
+            sandbox_backend="kubernetes",
+            k8s_template="test-tpl",
+            k8s_namespace="test-ns",
+            k8s_router_url="http://router:8080",
+            k8s_ttl=1800,
+            labels={"cognition.io/user": "bob"},
+        )
+        assert isinstance(backend, CognitionKubernetesSandboxBackend)
+        assert backend._template == "test-tpl"
+        assert backend._namespace == "test-ns"
+        assert backend._labels == {"cognition.io/user": "bob"}
+
+    def test_unknown_backend_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown sandbox_backend"):
+            create_sandbox_backend(
+                root_dir=tmp_path,
+                sandbox_backend="invalid",
+            )
+
+    def test_local_backend_still_works(self, tmp_path):
+        backend = create_sandbox_backend(
+            root_dir=tmp_path,
+            sandbox_backend="local",
+        )
+        assert backend.id.startswith("cognition-local-")
+
+    def test_docker_backend_still_works(self, tmp_path):
+        backend = create_sandbox_backend(
+            root_dir=tmp_path,
+            sandbox_backend="docker",
+        )
+        assert backend.id.startswith("cognition-docker-")

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,12 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[manifest]
+members = [
+    "cognition",
+    "langchain-k8s-sandbox",
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -548,6 +554,7 @@ all = [
     { name = "docker" },
     { name = "httpx" },
     { name = "langchain-aws" },
+    { name = "langchain-k8s-sandbox", extra = ["k8s"] },
     { name = "langchain-openai" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "mlflow", extra = ["genai"] },
@@ -581,6 +588,9 @@ dev = [
     { name = "pytest-timeout" },
     { name = "ruff" },
 ]
+k8s = [
+    { name = "langchain-k8s-sandbox", extra = ["k8s"] },
+]
 openai = [
     { name = "langchain-openai" },
     { name = "openai" },
@@ -602,7 +612,7 @@ dev = [
 requires-dist = [
     { name = "asyncpg", marker = "extra == 'deploy'", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "cognition", extras = ["openai", "bedrock", "test", "deploy"], marker = "extra == 'all'" },
+    { name = "cognition", extras = ["openai", "bedrock", "test", "deploy", "k8s"], marker = "extra == 'all'" },
     { name = "cognition", extras = ["test", "openai"], marker = "extra == 'dev'" },
     { name = "deepagents", specifier = ">=0.1.0" },
     { name = "docker", marker = "extra == 'deploy'", specifier = ">=7.0.0" },
@@ -612,6 +622,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.2.13" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=0.2.0" },
     { name = "langchain-core", specifier = ">=0.3.0,<1.3.0" },
+    { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'k8s'", editable = "packages/langchain-k8s-sandbox" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'deploy'", specifier = ">=2.0.0" },
@@ -647,7 +658,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["openai", "bedrock", "test", "dev", "deploy", "all"]
+provides-extras = ["openai", "bedrock", "test", "dev", "deploy", "k8s", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
@@ -996,6 +1007,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -1857,6 +1877,20 @@ wheels = [
 ]
 
 [[package]]
+name = "k8s-agent-sandbox"
+version = "0.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kubernetes" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/39/33aaabac58e47edb29488ce24413c29109740903edb10218cc15977f17cc/k8s_agent_sandbox-0.3.10.tar.gz", hash = "sha256:6c2ab22b2af17ff91ec7361452a65ab5163cccbd28e8dc0780fead4d5f8ce4ad", size = 66667, upload-time = "2026-04-08T02:13:29.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/96/579c0e1f56f54cc64a4c4455ecd78f9285d1a823d223e35261bb0c6b1250/k8s_agent_sandbox-0.3.10-py3-none-any.whl", hash = "sha256:a40db010a8f7ae78c043185ee0e501b1cc7c7c890759995aade7f5d3e94c0385", size = 41777, upload-time = "2026-04-08T02:13:28.78Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1947,6 +1981,26 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+]
+
+[[package]]
 name = "langchain"
 version = "1.2.13"
 source = { registry = "https://pypi.org/simple" }
@@ -2022,6 +2076,32 @@ sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/eae2305e207574dc6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/51/39942c0083139652494bb354dddf0ed397703a4882302f7b48aeca531c96/langchain_google_genai-4.2.0-py3-none-any.whl", hash = "sha256:856041aaafceff65a4ef0d5acf5731f2db95229ff041132af011aec51e8279d9", size = 66452, upload-time = "2026-01-13T20:41:16.296Z" },
 ]
+
+[[package]]
+name = "langchain-k8s-sandbox"
+version = "0.1.0"
+source = { editable = "packages/langchain-k8s-sandbox" }
+dependencies = [
+    { name = "deepagents" },
+]
+
+[package.optional-dependencies]
+k8s = [
+    { name = "k8s-agent-sandbox" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "deepagents", specifier = ">=0.4.12" },
+    { name = "k8s-agent-sandbox", marker = "extra == 'k8s'", specifier = ">=0.3.10" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+]
+provides-extras = ["k8s", "test"]
 
 [[package]]
 name = "langchain-openai"
@@ -2787,6 +2867,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/da/643aad274e29ccbdf42ecd94dafe524b81c87bcb56b83872d54827f10543/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04ae107ac591763a47398bb45b568fc38f02dbc4aa44c063f67a131f99346cb", size = 15797142, upload-time = "2026-01-31T23:13:02.219Z" },
     { url = "https://files.pythonhosted.org/packages/66/27/965b8525e9cb5dc16481b30a1b3c21e50c7ebf6e9dbd48d0c4d0d5089c7e/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:602f65afdef699cda27ec0b9224ae5dc43e328f4c24c689deaf77133dbee74d0", size = 16727979, upload-time = "2026-01-31T23:13:04.62Z" },
     { url = "https://files.pythonhosted.org/packages/de/e5/b7d20451657664b07986c2f6e3be564433f5dcaf3482d68eaecd79afaf03/numpy-2.4.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be71bf1edb48ebbbf7f6337b5bfd2f895d1902f6335a5830b20141fc126ffba0", size = 12502577, upload-time = "2026-01-31T23:13:07.08Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -4081,6 +4170,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5038,6 +5140,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a K8s-native sandbox backend (`CognitionKubernetesSandboxBackend`) that runs agent commands in isolated Sandbox pods via the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD and controller
- Introduces a standalone `langchain-k8s-sandbox` workspace package following the `langchain-<provider>` convention (zero Cognition imports)
- Fixes agent cache bug where cache hits returned raw `CompiledStateGraph` instead of `CognitionAgentResult`

## Why

The Docker sandbox backend cannot work when Cognition is deployed on Kubernetes — the server pod runs with `readOnlyRootFilesystem: true`, `capabilities.drop: ["ALL"]`, and `runAsNonRoot: true`, which prevents Docker socket access. The K8s backend uses the agent-sandbox CRD + controller + router to provide isolated sandbox pods without requiring any privileged access.

## What's included

### `langchain-k8s-sandbox` workspace package
- `K8sSandbox(BaseSandbox)` with lazy init, `sh -c` wrapping (heredoc support for BaseSandbox file ops), TTL via `spec.shutdownTime` patch, labels on SandboxClaim CRs
- 19 unit tests with mocked SDK

### Cognition integration
- `CognitionKubernetesSandboxBackend` wrapping K8sSandbox with protected path enforcement, scoping labels (`cognition.io/user`, `cognition.io/session`), session-scoped lifecycle
- `create_cognition_agent()` now returns `CognitionAgentResult(agent=..., sandbox_backend=...)` NamedTuple
- Session deletion triggers `backend.terminate()` via `SessionAgentManager.unregister_session()`
- Startup validation: CRD existence (fatal) + router health (warning)
- 16 Cognition unit tests

### Helm chart
- RBAC: namespace-scoped Role + cluster-scoped ClusterRole (conditional on `backend=kubernetes`)
- K8s sandbox env vars in deployment template
- Optional NetworkPolicy for egress denial (`config.sandbox.k8s.denyEgress`)
- SandboxTemplate example with `/tmp` and `/workspace` emptyDir volumes

### Bug fix
- Agent cache returned raw `CompiledStateGraph` on cache hit instead of `CognitionAgentResult`, causing `AttributeError: 'CompiledStateGraph' object has no attribute 'sandbox_backend'` in streaming service

### Testing
- 35 new unit tests (all pass, 673 total with 0 regressions)
- 13 e2e tests (skip unless `COGNITION_K8S_E2E=1`) — live-verified on Talos Linux cluster

### Documentation
- `docs/concepts/kubernetes-sandbox.md` — architecture, two-package design, execution flow, scoping labels, session lifecycle, RBAC, security
- `packages/langchain-k8s-sandbox/DESIGN.md` — standalone package design, `sh -c` wrapping rationale, SandboxTemplate requirements, lazy init lifecycle, TTL mechanism, error handling
- `packages/langchain-k8s-sandbox/README.md` — usage, file operations, TTL, requirements
- `docs/guides/configuration.md` — K8s sandbox settings, backend comparison table, example config
- `docs/guides/deployment.md` — K8s sandbox deployment section with prerequisites, SandboxTemplate YAML, Helm values
- `docs/README.md` — index updated with kubernetes-sandbox concept doc
- `CHANGELOG.md` — v0.7.0 entry
- `ROADMAP.md` — P1 feature entry

## Test plan

- [x] 673 unit tests pass, ruff clean, mypy clean
- [x] 13 e2e tests pass against live Talos Linux cluster (COGNITION_K8S_E2E=1)
- [x] Direct sandbox operations verified: execute, write, read, edit, upload, download
- [x] Labels verified on SandboxClaim CRs
- [x] TTL shutdownTime verified on Sandbox CR
- [x] Session deletion triggers sandbox termination
- [x] Startup validation passes (CRD check + router health)
- [x] Docker image built and deployed to dubaimetal cluster (0.6.7-k8s-sandbox)