### PR TITLE
fix: remove unused backend variable in cache-hit branch (mypy no-redef)

### DIFF
--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -391,23 +391,6 @@ async def create_cognition_agent(
             labels=k8s_labels or None,
         )
 
-        # Wrap sandbox backend with CompositeBackend for DB-backed skills
-        from deepagents.backends.protocol import BackendProtocol
-
-        backend: BackendProtocol
-        if reg:
-            from deepagents.backends.composite import CompositeBackend
-
-            from server.app.agent.skills_backend import ConfigRegistrySkillsBackend
-
-            db_skills_backend = ConfigRegistrySkillsBackend(registry=reg, scope=scope)
-            backend = CompositeBackend(
-                default=sandbox_backend,
-                routes={"/skills/api/": db_skills_backend},
-            )
-        else:
-            backend = sandbox_backend
-
         return CognitionAgentResult(agent=cached_agent, sandbox_backend=sandbox_backend)
 
     # Create the sandbox backend using settings-driven factory


### PR DESCRIPTION
## Summary

Fixes mypy `no-redef` error introduced in #76. The cache-hit branch had an unused `backend: BackendProtocol` variable that conflicted with the later definition in the non-cache-hit branch. The CompositeBackend wrapping in the cache-hit branch was unnecessary — the cached agent graph already has it baked in, and `CognitionAgentResult.sandbox_backend` stores the raw backend (for `terminate()`), not the composite.