### PR TITLE
refactor: unify scoping API across all routes

### DIFF
--- a/server/app/api/dependencies.py
+++ b/server/app/api/dependencies.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import Depends, Header
+from fastapi import Depends, Request
 
 from server.app.agent.resolver import RuntimeResolver
 from server.app.api.scoping import SessionScope, create_scope_dependency
@@ -133,29 +133,16 @@ def get_rate_limiter_dep() -> RateLimiter:
     return get_rate_limiter()
 
 
-async def get_scope_dep(
+def get_scope_dep(
+    request: Request,
     settings: Settings = Depends(get_settings_dep),  # noqa: B008
-    user: str | None = Header(None, alias="x-cognition-scope-user"),
-    project: str | None = Header(None, alias="x-cognition-scope-project"),
 ) -> SessionScope:
-    return await create_scope_dependency(settings)(user=user, project=project)
+    headers: dict[str, str | None] = {}
+    for key in settings.scope_keys:
+        header_name = f"x-cognition-scope-{key.replace('_', '-')}"
+        headers[key] = request.headers.get(header_name)
 
-
-def get_scope_headers_dep(
-    user: str | None = Header(None, alias="x-cognition-scope-user"),
-    project: str | None = Header(None, alias="x-cognition-scope-project"),
-) -> dict[str, str] | None:
-    """Extract optional scope dict from request headers.
-
-    Returns None when no scope headers are present, otherwise a dict
-    like {"user": "...", "project": "..."}.
-    """
-    scope: dict[str, str] = {}
-    if user:
-        scope["user"] = user
-    if project:
-        scope["project"] = project
-    return scope if scope else None
+    return create_scope_dependency(settings)(**headers)
 
 
 __all__ = [
@@ -167,7 +154,6 @@ __all__ = [
     "get_rate_limiter_dep",
     "get_runtime_resolver",
     "get_scope_dep",
-    "get_scope_headers_dep",
     "get_session_agent_manager_dep",
     "get_settings_dep",
     "get_storage_backend_dep",

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 
 from server.app.agent.definition import AgentDefinition
-from server.app.api.dependencies import get_config_store
+from server.app.api.dependencies import get_config_store, get_scope_dep
 from server.app.api.models import (
     AgentConfigResponse,
     AgentCreate,
@@ -13,13 +13,10 @@ from server.app.api.models import (
     AgentResponse,
     AgentUpdate,
 )
+from server.app.api.scoping import SessionScope
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/agents", tags=["agents"])
-
-
-def _registry_or_503(config_store: ConfigStore = Depends(get_config_store)) -> ConfigStore:  # noqa: B008
-    return config_store
 
 
 def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
@@ -50,20 +47,25 @@ def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
 
 @router.get("", response_model=AgentList)
 async def list_agents(
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> AgentList:
     """List all available agents (excluding hidden ones)."""
-    agents = await config_store.list_agent_definitions(include_hidden=False)
+    agents = await config_store.list_agent_definitions(
+        include_hidden=False,
+        scope=scope.get_all() or None,
+    )
     return AgentList(agents=[_agent_to_response(a) for a in agents])
 
 
 @router.get("/{name}", response_model=AgentResponse)
 async def get_agent(
     name: str,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> AgentResponse:
     """Get a specific agent by name."""
-    agent = await config_store.get_agent_definition(name)
+    agent = await config_store.get_agent_definition(name, scope.get_all() or None)
     if agent is None or agent.hidden:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
     return _agent_to_response(agent)
@@ -72,13 +74,14 @@ async def get_agent(
 @router.post("", response_model=AgentResponse, status_code=201)
 async def create_agent(
     body: AgentCreate,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> AgentResponse:
     """Create or replace an agent definition in the ConfigStore.
 
     Built-in (native) agents cannot be replaced.
     """
-    existing = await config_store.get_agent_definition(body.name)
+    existing = await config_store.get_agent_definition(body.name, scope.get_all() or None)
     if existing and existing.native:
         raise HTTPException(
             status_code=409,
@@ -110,9 +113,10 @@ async def create_agent(
                 "timeout_seconds": body.timeout_seconds,
             },
         }
-        await config_store.upsert_agent(body.name, body.scope, definition_data, "api")
+        effective_scope = scope.get_all() or body.scope
+        await config_store.upsert_agent(body.name, effective_scope, definition_data, "api")
 
-        agent_def = await config_store.get_agent_definition(body.name)
+        agent_def = await config_store.get_agent_definition(body.name, effective_scope or None)
         if agent_def is None:
             raise HTTPException(status_code=500, detail="Agent not found after creation")
         return _agent_to_response(agent_def)
@@ -124,10 +128,11 @@ async def create_agent(
 async def replace_agent(
     name: str,
     body: AgentCreate,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> AgentResponse:
     """Replace an agent definition (full update)."""
-    existing = await config_store.get_agent_definition(name)
+    existing = await config_store.get_agent_definition(name, scope.get_all() or None)
     if existing and existing.native:
         raise HTTPException(
             status_code=409,
@@ -135,17 +140,19 @@ async def replace_agent(
         )
 
     body.name = name
-    return await create_agent(body, config_store=config_store)
+    return await create_agent(body, scope=scope, config_store=config_store)
 
 
 @router.patch("/{name}", response_model=AgentResponse)
 async def update_agent(
     name: str,
     body: AgentUpdate,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> AgentResponse:
     """Partially update an agent definition."""
-    existing = await config_store.get_agent_definition(name)
+    scope_dict = scope.get_all() or None
+    existing = await config_store.get_agent_definition(name, scope_dict)
     if existing is None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
     if existing.native:
@@ -155,7 +162,7 @@ async def update_agent(
         )
 
     try:
-        data = await config_store.get_agent_raw(name, None)
+        data = await config_store.get_agent_raw(name, scope_dict)
         if data is None:
             raise HTTPException(status_code=404, detail=f"Agent '{name}' not found in registry")
 
@@ -194,10 +201,12 @@ async def update_agent(
 @router.delete("/{name}", status_code=204)
 async def delete_agent(
     name: str,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> None:
     """Delete a user-defined agent definition."""
-    existing = await config_store.get_agent_definition(name)
+    scope_dict = scope.get_all() or None
+    existing = await config_store.get_agent_definition(name, scope_dict)
     if existing is None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
     if existing.native:
@@ -207,6 +216,6 @@ async def delete_agent(
         )
 
     try:
-        await config_store.delete_agent(name, None)
+        await config_store.delete_agent(name, scope_dict)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -185,8 +185,8 @@ async def update_agent(
             data["response_format"] = updates.pop("response_format")
         data.update(updates)
 
-        scope: dict[str, Any] = data.get("scope", {})
-        await config_store.upsert_agent(name, scope, data, "api")
+        agent_scope: dict[str, Any] = data.get("scope", {})
+        await config_store.upsert_agent(name, agent_scope, data, "api")
 
         agent_def = await config_store.get_agent_definition(name)
         if agent_def is None:

--- a/server/app/api/routes/models.py
+++ b/server/app/api/routes/models.py
@@ -19,7 +19,7 @@ from server.app.api.dependencies import (
     get_config_store,
     get_model_catalog_dep,
     get_runtime_resolver,
-    get_scope_headers_dep,
+    get_scope_dep,
     get_settings_dep,
 )
 from server.app.api.models import (
@@ -31,6 +31,7 @@ from server.app.api.models import (
     ProviderTestResponse,
     ProviderUpdate,
 )
+from server.app.api.scoping import SessionScope
 from server.app.llm.model_catalog import ModelCatalog
 from server.app.settings import Settings
 from server.app.storage.config_store import ConfigStore
@@ -133,12 +134,12 @@ async def list_models(
 
 @router.get("/providers", response_model=ProviderConfigList)
 async def list_providers(
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> ProviderConfigList:
     """List all provider configs from the ConfigStore visible in the given scope."""
     try:
-        providers = await config_store.list_providers(scope=scope)
+        providers = await config_store.list_providers(scope=scope.get_all() or None)
         return ProviderConfigList(
             providers=[
                 ProviderResponse(
@@ -172,7 +173,7 @@ async def list_providers(
 @router.get("/providers/{provider_id}/models", response_model=ModelList)
 async def list_models_for_provider(
     provider_id: str,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
     catalog: ModelCatalog = Depends(get_model_catalog_dep),  # noqa: B008
 ) -> ModelList:
@@ -184,7 +185,7 @@ async def list_models_for_provider(
     For ``openai_compatible`` providers, returns an empty model list since
     the available models depend on the upstream service (OpenRouter, vLLM, etc.).
     """
-    provider_config = await config_store.get_provider(provider_id, scope=scope)
+    provider_config = await config_store.get_provider(provider_id, scope=scope.get_all() or None)
     if provider_config is None:
         raise HTTPException(
             status_code=404,
@@ -202,12 +203,12 @@ async def list_models_for_provider(
 @router.post("/providers", response_model=ProviderResponse, status_code=201)
 async def create_provider(
     body: ProviderCreate,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> ProviderResponse:
     """Create or replace a provider config in the ConfigStore."""
     try:
-        effective_scope = scope if scope is not None else (body.scope or {})
+        effective_scope = scope.get_all() or (body.scope or {})
         provider_data: dict[str, Any] = {
             "id": body.id,
             "provider": body.provider,
@@ -254,12 +255,13 @@ async def create_provider(
 async def update_provider(
     provider_id: str,
     body: ProviderUpdate,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> ProviderResponse:
     """Partially update a provider config."""
     try:
-        provider = await config_store.get_provider(provider_id, scope=scope)
+        scope_dict = scope.get_all() or None
+        provider = await config_store.get_provider(provider_id, scope=scope_dict)
         if provider is None:
             raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
 
@@ -293,12 +295,12 @@ async def update_provider(
 @router.delete("/providers/{provider_id}", status_code=204)
 async def delete_provider(
     provider_id: str,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> None:
     """Delete a provider config from the ConfigStore."""
     try:
-        deleted = await config_store.delete_provider(provider_id, scope=scope)
+        deleted = await config_store.delete_provider(provider_id, scope=scope.get_all() or None)
         if not deleted:
             raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
     except HTTPException:
@@ -310,7 +312,7 @@ async def delete_provider(
 @router.post("/providers/{provider_id}/test", response_model=ProviderTestResponse)
 async def test_provider(
     provider_id: str,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     settings: Settings = Depends(get_settings_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
     runtime_resolver: RuntimeResolver = Depends(get_runtime_resolver),  # noqa: B008
@@ -338,7 +340,7 @@ async def test_provider(
     from server.app.exceptions import LLMProviderConfigError
 
     # 1. Fetch the provider config
-    provider_config = await config_store.get_provider(provider_id, scope=scope)
+    provider_config = await config_store.get_provider(provider_id, scope=scope.get_all() or None)
     if provider_config is None:
         raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
 

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -48,7 +48,6 @@ from server.app.llm.deep_agent_service import (
 from server.app.llm.deep_agent_service import (
     ErrorEvent as ResumeErrorEvent,
 )
-from server.app.llm.discovery import DiscoveryEngine
 from server.app.models import SessionConfig, SessionStatus
 from server.app.session_manager import build_session_workspace_path, ensure_session_workspace_path
 from server.app.settings import Settings
@@ -56,6 +55,20 @@ from server.app.storage.backend import StorageBackend
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+async def _get_scoped_session(
+    session_id: str,
+    store: StorageBackend,
+    scope: SessionScope,
+) -> Any:
+    session = await store.get_session(session_id)
+    if session is None or (not scope.is_empty() and not scope.matches(session.scopes)):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session not found: {session_id}",
+        )
+    return session
 
 
 @router.post(
@@ -132,7 +145,6 @@ async def list_sessions(
     Sessions are isolated per workspace - they don't appear in other workspaces.
     If scoping is enabled, only returns sessions matching the current scope.
     """
-    _ = str(settings.workspace_path)
     del metadata_filters
 
     resolved_metadata_filters: dict[str, str] = {
@@ -171,20 +183,7 @@ async def get_session(
     Returns detailed information about a specific session.
     Only returns sessions from the server's current workspace.
     """
-    _workspace_path = str(settings.workspace_path)
-    session = await store.get_session(session_id)
-
-    if session is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
-
-    if not scope.is_empty() and not scope.matches(session.scopes):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
+    session = await _get_scoped_session(session_id, store, scope)
 
     return SessionResponse.from_core(session)
 
@@ -208,24 +207,15 @@ async def update_session(
 
     Updates session metadata (title) or configuration (model, temperature, etc.).
     """
-    _workspace_path = str(settings.workspace_path)
-
-    existing_session = await store.get_session(session_id)
-    if existing_session is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
-
-    if not scope.is_empty() and not scope.matches(existing_session.scopes):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
+    await _get_scoped_session(session_id, store, scope)
 
     if request.config and request.config.model and not request.config.provider:
-        discovery = DiscoveryEngine(settings)
-        provider = await discovery.get_provider_for_model(request.config.model)
+        provider = None
+        providers = await config_store.list_providers(scope=scope.get_all() or None)
+        for config in providers:
+            if config.model == request.config.model:
+                provider = config.provider
+                break
         if provider:
             request.config.provider = provider  # type: ignore[assignment]
 
@@ -271,20 +261,7 @@ async def delete_session(
 
     Deletes a session and all associated messages.
     """
-    _workspace_path = str(settings.workspace_path)
-
-    session = await store.get_session(session_id)
-    if session is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
-
-    if not scope.is_empty() and not scope.matches(session.scopes):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
+    await _get_scoped_session(session_id, store, scope)
 
     agent_manager.unregister_session(session_id)
 
@@ -309,20 +286,7 @@ async def abort_session(
 
     Cancels any in-progress agent operation.
     """
-    _workspace_path = str(settings.workspace_path)
-
-    session = await store.get_session(session_id)
-    if session is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
-
-    if not scope.is_empty() and not scope.matches(session.scopes):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
+    session = await _get_scoped_session(session_id, store, scope)
 
     await agent_manager.abort_session(session_id, session.thread_id)
 
@@ -347,20 +311,7 @@ async def resume_session(
     store: StorageBackend = Depends(get_storage_backend_dep),  # noqa: B008
 ) -> dict[str, str | bool] | StreamingResponse:
     """Resume an interrupted Deep Agents session using native Command(resume=...)."""
-    _workspace_path = str(settings.workspace_path)
-
-    session = await store.get_session(session_id)
-    if session is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
-
-    if not scope.is_empty() and not scope.matches(session.scopes):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
-        )
+    session = await _get_scoped_session(session_id, store, scope)
 
     if session.status != SessionStatus.WAITING_FOR_APPROVAL.value:
         raise HTTPException(

--- a/server/app/api/routes/skills.py
+++ b/server/app/api/routes/skills.py
@@ -12,8 +12,9 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
 
-from server.app.api.dependencies import get_config_store, get_scope_headers_dep
+from server.app.api.dependencies import get_config_store, get_scope_dep
 from server.app.api.models import SkillCreate, SkillList, SkillResponse, SkillUpdate
+from server.app.api.scoping import SessionScope
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/skills", tags=["skills"])
@@ -33,28 +34,24 @@ def _to_response(skill: Any) -> SkillResponse:
     )
 
 
-def _get_store(config_store: ConfigStore = Depends(get_config_store)) -> ConfigStore:  # noqa: B008
-    return config_store
-
-
 @router.get("", response_model=SkillList)
 async def list_skills(
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> SkillList:
     """List all registered skills visible in the given scope."""
-    skills = await config_store.list_skills(scope=scope)
+    skills = await config_store.list_skills(scope=scope.get_all() or None)
     return SkillList(skills=[_to_response(s) for s in skills], count=len(skills))
 
 
 @router.get("/{name}", response_model=SkillResponse)
 async def get_skill(
     name: str,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> SkillResponse:
     """Get a skill by name."""
-    skill = await config_store.get_skill(name, scope=scope)
+    skill = await config_store.get_skill(name, scope=scope.get_all() or None)
     if skill is None:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
     return _to_response(skill)
@@ -63,11 +60,11 @@ async def get_skill(
 @router.post("", response_model=SkillResponse, status_code=201)
 async def create_skill(
     body: SkillCreate,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> SkillResponse:
     """Create or replace a skill in the ConfigStore."""
-    effective_scope = scope if scope is not None else (body.scope or {})
+    effective_scope = scope.get_all() or (body.scope or {})
 
     # Auto-generate path if content is provided, otherwise use provided path
     if body.content:
@@ -99,7 +96,7 @@ async def create_skill(
 async def replace_skill(
     name: str,
     body: SkillCreate,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> SkillResponse:
     """Replace a skill definition (full update)."""
@@ -111,11 +108,12 @@ async def replace_skill(
 async def update_skill(
     name: str,
     body: SkillUpdate,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> SkillResponse:
     """Partially update a skill definition."""
-    skill = await config_store.get_skill(name, scope=scope)
+    scope_dict = scope.get_all() or None
+    skill = await config_store.get_skill(name, scope=scope_dict)
     if skill is None:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
 
@@ -126,18 +124,19 @@ async def update_skill(
 
     updated = skill.model_copy(update=updates)
     await config_store.upsert_skill(updated)
-    logger.info("skill_updated", name=name, scope=scope, fields=list(updates.keys()))
+    logger.info("skill_updated", name=name, scope=scope_dict, fields=list(updates.keys()))
     return _to_response(updated)
 
 
 @router.delete("/{name}", status_code=204)
 async def delete_skill(
     name: str,
-    scope: dict[str, str] | None = Depends(get_scope_headers_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
 ) -> None:
     """Delete a skill from the ConfigStore."""
-    deleted = await config_store.delete_skill(name, scope=scope)
+    scope_dict = scope.get_all() or None
+    deleted = await config_store.delete_skill(name, scope=scope_dict)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
-    logger.info("skill_deleted", name=name, scope=scope)
+    logger.info("skill_deleted", name=name, scope=scope_dict)

--- a/server/app/api/routes/tools.py
+++ b/server/app/api/routes/tools.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from server.app.agent_registry import AgentRegistry
-from server.app.api.dependencies import get_agent_registry_dep, get_config_store
+from server.app.api.dependencies import get_config_store, get_scope_dep
 from server.app.api.models import ToolCreate, ToolList, ToolResponse, ToolUpdate
+from server.app.api.scoping import SessionScope
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/tools", tags=["tools"])
@@ -15,78 +15,25 @@ router = APIRouter(prefix="/tools", tags=["tools"])
 @router.get("", response_model=ToolList)
 async def list_tools(
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
-    registry: AgentRegistry = Depends(get_agent_registry_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
 ) -> ToolList:
-    """List all registered tools from both AgentRegistry and ConfigStore.
-
-    Returns tools from two sources:
-    - File-discovered tools (``source_type="file"``) from AgentRegistry
-    - API-registered tools (``source_type="api_code"`` or ``source_type="api_path"``)
-      from ConfigStore
-    """
-    tool_responses: list[ToolResponse] = []
-
-    for t in registry.list_tools():
+    """List all registered tools visible in the given scope."""
+    tool_responses = []
+    api_tools = await config_store.list_tools(scope=scope.get_all() or None)
+    for ct in api_tools:
+        source_type = "api_code" if ct.code else "api_path"
         tool_responses.append(
             ToolResponse(
-                name=t.name,
-                source_type="file",
-                source="file",
-                module=t.module,
-                description=None,
-                enabled=True,
-                interrupt_on=False,
+                name=ct.name,
+                source_type=source_type,
+                source=source_type,
+                module=ct.path,
+                description=ct.description,
+                enabled=ct.enabled,
+                interrupt_on=ct.interrupt_on,
             )
         )
-
-    try:
-        api_tools = await config_store.list_tools()
-        known_names = {t.name for t in tool_responses}
-        for ct in api_tools:
-            if ct.name in known_names:
-                continue  # file-discovered wins, don't duplicate
-            source_type = "api_code" if ct.code else "api_path"
-            tool_responses.append(
-                ToolResponse(
-                    name=ct.name,
-                    source_type=source_type,
-                    source=source_type,
-                    module=ct.path,
-                    description=ct.description,
-                    enabled=ct.enabled,
-                    interrupt_on=ct.interrupt_on,
-                )
-            )
-    except RuntimeError:
-        pass  # ConfigStore not initialized
-
     return ToolList(tools=tool_responses, count=len(tool_responses))
-
-
-@router.get("/errors")
-async def get_tool_errors(
-    registry: AgentRegistry = Depends(get_agent_registry_dep),  # noqa: B008
-) -> list[dict[str, Any]]:
-    """Get accumulated tool load errors.
-
-    Returns a list of error records from the most recent tool discovery/reload.
-    Errors are cleared when a file is successfully reloaded.
-    """
-    errors = registry.get_load_errors()
-    return [e.to_dict() for e in errors]
-
-
-@router.post("/reload")
-async def reload_tools(
-    registry: AgentRegistry = Depends(get_agent_registry_dep),  # noqa: B008
-) -> dict[str, Any]:
-    """Trigger a reload of tools from the discovery path.
-
-    Clears existing file-based tools and re-discovers them.
-    Returns the count of tools loaded and any errors encountered.
-    """
-    result = registry.reload_tools()
-    return result
 
 
 @router.post("", response_model=ToolResponse, status_code=201)
@@ -161,39 +108,21 @@ async def unregister_tool(
 async def get_tool(
     name: str,
     config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
-    registry: AgentRegistry = Depends(get_agent_registry_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
 ) -> ToolResponse:
-    """Get a specific tool by name.
-
-    Checks AgentRegistry (file-discovered) first, then ConfigStore (API-registered).
-    """
-    tool = registry.get_tool(name)
-    if tool is not None:
+    """Get a specific tool by name."""
+    api_tool = await config_store.get_tool(name, scope=scope.get_all() or None)
+    if api_tool is not None:
+        source_type = "api_code" if api_tool.code else "api_path"
         return ToolResponse(
-            name=tool.name,
-            source_type="file",
-            source="file",
-            module=tool.module,
-            description=None,
-            enabled=True,
-            interrupt_on=False,
+            name=api_tool.name,
+            source_type=source_type,
+            source=source_type,
+            module=api_tool.path,
+            description=api_tool.description,
+            enabled=api_tool.enabled,
+            interrupt_on=api_tool.interrupt_on,
         )
-
-    try:
-        api_tool = await config_store.get_tool(name)
-        if api_tool is not None:
-            source_type = "api_code" if api_tool.code else "api_path"
-            return ToolResponse(
-                name=api_tool.name,
-                source_type=source_type,
-                source=source_type,
-                module=api_tool.path,
-                description=api_tool.description,
-                enabled=api_tool.enabled,
-                interrupt_on=api_tool.interrupt_on,
-            )
-    except RuntimeError:
-        pass
 
     raise HTTPException(status_code=404, detail=f"Tool '{name}' not found")
 

--- a/server/app/api/scoping.py
+++ b/server/app/api/scoping.py
@@ -6,7 +6,7 @@ Sessions can be scoped by any number of dimensions (user, project, team, etc.).
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from typing import Any
 
 from fastapi import Header, HTTPException, status
@@ -75,7 +75,7 @@ def extract_scope_from_headers(settings: Settings, **header_values: str | None) 
     return SessionScope(scopes)
 
 
-def create_scope_dependency(settings: Settings) -> Callable[..., Coroutine[Any, Any, SessionScope]]:
+def create_scope_dependency(settings: Settings) -> Callable[..., SessionScope]:
     """Create a FastAPI dependency for extracting session scope.
 
     Returns a dependency function that:
@@ -94,7 +94,7 @@ def create_scope_dependency(settings: Settings) -> Callable[..., Coroutine[Any, 
         header_name = f"x-cognition-scope-{key.replace('_', '-')}"
         header_params[key] = Header(None, alias=header_name)
 
-    async def scope_dependency(**headers: Any) -> SessionScope:
+    def scope_dependency(**headers: Any) -> SessionScope:
         """Extract scope from headers with fail-closed validation."""
         scope = extract_scope_from_headers(settings, **headers)
 

--- a/tests/unit/api/test_tools_crud.py
+++ b/tests/unit/api/test_tools_crud.py
@@ -9,11 +9,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from server.app.agent.agent_definition_registry import initialize_agent_definition_registry
-from server.app.agent_registry import initialize_agent_registry
-from server.app.api.dependencies import set_agent_registry_dep, set_config_store
+from server.app.api.dependencies import set_config_store
 from server.app.main import app
-from server.app.session_manager import initialize_session_manager
-from server.app.storage import set_storage_backend
 from server.app.storage.config_store import DefaultConfigStore
 from server.app.storage.sqlite import SqliteStorageBackend
 
@@ -23,7 +20,7 @@ client = TestClient(app)
 @pytest.fixture(scope="module", autouse=True)
 def setup_registry(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("workspace")
-    from server.app.storage.config_registry import MemoryConfigRegistry, set_config_registry
+    from server.app.storage.config_registry import MemoryConfigRegistry
 
     with tempfile.TemporaryDirectory() as db_tmpdir:
         storage = SqliteStorageBackend(
@@ -34,20 +31,14 @@ def setup_registry(tmp_path_factory):
 
         loop = asyncio.new_event_loop()
         loop.run_until_complete(storage.initialize())
-        set_storage_backend(storage)
 
         def_registry = initialize_agent_definition_registry(Path(tmpdir))
         config_registry = MemoryConfigRegistry()
-        set_config_registry(config_registry)
         config_store = DefaultConfigStore(
             config_registry=config_registry,
             agent_definition_registry=def_registry,
         )
         set_config_store(config_store)
-
-        initialize_session_manager(storage, None)
-        registry = initialize_agent_registry(settings=None)
-        set_agent_registry_dep(registry)
         yield
 
         loop.run_until_complete(storage.close())
@@ -117,13 +108,3 @@ class TestUpdateTool:
         response = client.patch("/tools/test-tool-patch", json={"interrupt_on": True})
         assert response.status_code == 200
         assert response.json()["interrupt_on"] is True
-
-
-class TestReloadTools:
-    def test_reload_endpoint_returns_200(self):
-        response = client.post("/tools/reload")
-        assert response.status_code == 200
-
-    def test_errors_endpoint_returns_200(self):
-        response = client.get("/tools/errors")
-        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Remove `get_scope_headers_dep()` (hardcoded user/project header path)
- Make `get_scope_dep` the single scoping dependency, used by ALL routes
- CRUD routes (skills, models, agents, tools) switch from raw `dict[str, str] | None` scope to `SessionScope`
- Extract `_get_scoped_session()` helper in sessions.py
- Remove dead `/tools/reload` and `/tools/errors` endpoints
- Replace `DiscoveryEngine` with `ConfigStore.list_providers()` in sessions.py

## Verification
- `uv run pytest tests/unit/test_scoping.py tests/unit/api/ -q`
- `uv run ruff check server/app/api/`