### PR TITLE
refactor: remove dead config registry globals

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -35,7 +35,7 @@ from server.app.observability.mlflow_config import setup_mlflow_tracing
 from server.app.rate_limiter import RateLimitConfig, get_rate_limiter
 from server.app.session_manager import initialize_session_manager
 from server.app.settings import get_settings
-from server.app.storage import create_storage_backend, set_storage_backend
+from server.app.storage import create_storage_backend
 from server.app.storage.backend import StorageBackend
 from server.app.storage.config_store import DefaultConfigStore, set_default_config_store
 
@@ -56,18 +56,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize storage backend
     storage_backend = create_storage_backend(settings)
     await storage_backend.initialize()
-    set_storage_backend(storage_backend)
     set_storage_backend_dep(storage_backend)
     logger.info("Storage backend initialized")
 
-    # Initialize ConfigRegistry and wire it globally
-    from server.app.storage.config_registry import set_config_registry
+    # Initialize ConfigRegistry
     from server.app.storage.factory import create_config_dispatcher, create_config_registry
 
     config_registry = create_config_registry(settings)
     if hasattr(config_registry, "initialize_schema"):
         await config_registry.initialize_schema()
-    set_config_registry(config_registry)
     logger.info("ConfigRegistry initialized")
 
     # Initialize agent definition registry (file-based agents)

--- a/server/app/session_manager.py
+++ b/server/app/session_manager.py
@@ -425,10 +425,8 @@ class SessionManager:
 
         # Create new agent via create_cognition_agent
         from server.app.agent.cognition_agent import CognitionAgentParams, create_cognition_agent
-        from server.app.storage import get_storage_backend
 
-        storage = get_storage_backend()
-        checkpointer = await storage.get_checkpointer()
+        checkpointer = await self._storage.get_checkpointer()
 
         result = await create_cognition_agent(
             CognitionAgentParams(

--- a/server/app/storage/__init__.py
+++ b/server/app/storage/__init__.py
@@ -13,44 +13,11 @@ from server.app.storage.backend import (
     SessionStore,
     StorageBackend,
 )
-from server.app.storage.config_registry import get_config_registry, set_config_registry
 from server.app.storage.factory import (
     create_config_dispatcher,
     create_config_registry,
     create_storage_backend,
 )
-
-# Global storage backend instance (initialized in main.py lifespan)
-_storage_backend: StorageBackend | None = None
-
-
-def get_storage_backend() -> StorageBackend:
-    """Get the global storage backend instance.
-
-    Must be initialized by calling initialize_storage_backend() first.
-
-    Returns:
-        Configured StorageBackend instance.
-
-    Raises:
-        RuntimeError: If storage backend has not been initialized.
-    """
-    if _storage_backend is None:
-        raise RuntimeError(
-            "Storage backend not initialized. Call initialize_storage_backend() first."
-        )
-    return _storage_backend
-
-
-def set_storage_backend(backend: StorageBackend) -> None:
-    """Set the global storage backend instance.
-
-    Args:
-        backend: Configured StorageBackend instance.
-    """
-    global _storage_backend
-    _storage_backend = backend
-
 
 __all__ = [
     "CheckpointerStore",
@@ -60,8 +27,4 @@ __all__ = [
     "create_config_dispatcher",
     "create_config_registry",
     "create_storage_backend",
-    "get_config_registry",
-    "get_storage_backend",
-    "set_config_registry",
-    "set_storage_backend",
 ]

--- a/server/app/storage/config_registry.py
+++ b/server/app/storage/config_registry.py
@@ -1296,37 +1296,9 @@ class MemoryConfigRegistry:
         pass  # No-op for in-memory
 
 
-# ---------------------------------------------------------------------------
-# Global registry instance
-# ---------------------------------------------------------------------------
-
-_config_registry: ConfigRegistry | None = None
-
-
-def get_config_registry() -> ConfigRegistry:
-    """Get the global ConfigRegistry instance.
-
-    Raises:
-        RuntimeError: If registry has not been initialized.
-    """
-    if _config_registry is None:
-        raise RuntimeError(
-            "ConfigRegistry not initialized. Call set_config_registry() during startup."
-        )
-    return _config_registry
-
-
-def set_config_registry(registry: ConfigRegistry) -> None:
-    """Set the global ConfigRegistry instance."""
-    global _config_registry
-    _config_registry = registry
-
-
 __all__ = [
     "ConfigRegistry",
     "MemoryConfigRegistry",
     "PostgresConfigRegistry",
     "SqliteConfigRegistry",
-    "get_config_registry",
-    "set_config_registry",
 ]

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -22,12 +22,11 @@ def setup_registry(tmp_path_factory):
     """Initialize agent registry and ConfigStore for the test module."""
     from pathlib import Path
 
-    from server.app.storage.config_registry import MemoryConfigRegistry, set_config_registry
+    from server.app.storage.config_registry import MemoryConfigRegistry
 
     tmpdir = tmp_path_factory.mktemp("workspace")
     def_registry = initialize_agent_definition_registry(Path(tmpdir))
     config_registry = MemoryConfigRegistry()
-    set_config_registry(config_registry)
     config_store = DefaultConfigStore(
         config_registry=config_registry,
         agent_definition_registry=def_registry,

--- a/tests/unit/api/test_config_defaults.py
+++ b/tests/unit/api/test_config_defaults.py
@@ -17,12 +17,11 @@ client = TestClient(app)
 def setup_registry(tmp_path_factory):
     from pathlib import Path
 
-    from server.app.storage.config_registry import MemoryConfigRegistry, set_config_registry
+    from server.app.storage.config_registry import MemoryConfigRegistry
 
     tmpdir = tmp_path_factory.mktemp("workspace")
     def_registry = initialize_agent_definition_registry(Path(tmpdir))
     config_registry = MemoryConfigRegistry()
-    set_config_registry(config_registry)
     config_store = DefaultConfigStore(
         config_registry=config_registry,
         agent_definition_registry=def_registry,

--- a/tests/unit/api/test_providers_crud.py
+++ b/tests/unit/api/test_providers_crud.py
@@ -18,11 +18,10 @@ def setup_registry(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("workspace")
     from pathlib import Path
 
-    from server.app.storage.config_registry import MemoryConfigRegistry, set_config_registry
+    from server.app.storage.config_registry import MemoryConfigRegistry
 
     def_registry = initialize_agent_definition_registry(Path(tmpdir))
     config_registry = MemoryConfigRegistry()
-    set_config_registry(config_registry)
     config_store = DefaultConfigStore(
         config_registry=config_registry,
         agent_definition_registry=def_registry,

--- a/tests/unit/api/test_skills_crud.py
+++ b/tests/unit/api/test_skills_crud.py
@@ -18,11 +18,10 @@ def setup_registry(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("workspace")
     from pathlib import Path
 
-    from server.app.storage.config_registry import MemoryConfigRegistry, set_config_registry
+    from server.app.storage.config_registry import MemoryConfigRegistry
 
     def_registry = initialize_agent_definition_registry(Path(tmpdir))
     config_registry = MemoryConfigRegistry()
-    set_config_registry(config_registry)
     config_store = DefaultConfigStore(
         config_registry=config_registry,
         agent_definition_registry=def_registry,

--- a/tests/unit/test_config_registry.py
+++ b/tests/unit/test_config_registry.py
@@ -20,12 +20,7 @@ from server.app.storage.config_models import (
     SkillDefinition,
     ToolRegistration,
 )
-from server.app.storage.config_registry import (
-    MemoryConfigRegistry,
-    SqliteConfigRegistry,
-    get_config_registry,
-    set_config_registry,
-)
+from server.app.storage.config_registry import MemoryConfigRegistry, SqliteConfigRegistry
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -458,20 +453,3 @@ class TestSqliteConfigRegistry:
             assert result.model == "claude-3"
         finally:
             await reg.close()
-
-
-# ---------------------------------------------------------------------------
-# Global registry accessor
-# ---------------------------------------------------------------------------
-
-
-class TestGlobalRegistryAccessor:
-    def test_get_config_registry_raises_when_uninitialized(self):
-        set_config_registry(None)  # type: ignore[arg-type]
-        with pytest.raises(RuntimeError, match="ConfigRegistry not initialized"):
-            get_config_registry()
-
-    def test_set_and_get_config_registry(self, mem_reg: MemoryConfigRegistry):
-        set_config_registry(mem_reg)
-        result = get_config_registry()
-        assert result is mem_reg

--- a/tests/unit/test_config_registry_tools.py
+++ b/tests/unit/test_config_registry_tools.py
@@ -310,13 +310,13 @@ class TestPostToolsAPI:
         from server.app.agent.agent_definition_registry import (
             initialize_agent_definition_registry,
         )
-        from server.app.storage.config_registry import (
-            MemoryConfigRegistry,
-            set_config_registry,
-        )
+        from server.app.api.dependencies import set_config_store
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
 
-        initialize_agent_definition_registry(tmp_path)
-        set_config_registry(MemoryConfigRegistry())
+        def_registry = initialize_agent_definition_registry(tmp_path)
+        config_registry = MemoryConfigRegistry()
+        set_config_store(DefaultConfigStore(config_registry, def_registry))
 
     def _client(self) -> Any:
         from fastapi.testclient import TestClient
@@ -380,13 +380,13 @@ class TestGetToolsAPI:
         from server.app.agent.agent_definition_registry import (
             initialize_agent_definition_registry,
         )
-        from server.app.storage.config_registry import (
-            MemoryConfigRegistry,
-            set_config_registry,
-        )
+        from server.app.api.dependencies import set_config_store
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
 
-        initialize_agent_definition_registry(tmp_path)
-        set_config_registry(MemoryConfigRegistry())
+        def_registry = initialize_agent_definition_registry(tmp_path)
+        config_registry = MemoryConfigRegistry()
+        set_config_store(DefaultConfigStore(config_registry, def_registry))
 
     def _client(self) -> Any:
         from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- remove dead `get_config_registry()` and `set_config_registry()` globals
- update startup and session management to use injected/configured instances only
- update tests to build `DefaultConfigStore(...)` directly instead of relying on registry globals

## Verification
- `uv run pytest tests/unit/test_config_registry.py tests/unit/test_config_registry_tools.py tests/unit/api/test_config_defaults.py tests/unit/api/test_providers_crud.py tests/unit/api/test_skills_crud.py tests/unit/api/test_agents_crud.py -q`
- `uv run pytest tests/unit/ -q --timeout=30`
- `uv run ruff check server/app/main.py server/app/session_manager.py server/app/storage/__init__.py server/app/storage/config_registry.py tests/unit/test_config_registry.py tests/unit/test_config_registry_tools.py tests/unit/api/test_config_defaults.py tests/unit/api/test_providers_crud.py tests/unit/api/test_skills_crud.py tests/unit/api/test_agents_crud.py`