### PR TITLE
refactor: simplify runtime resolution and remove streaming shims

### DIFF
--- a/server/app/agent/resolver.py
+++ b/server/app/agent/resolver.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import os
+from dataclasses import dataclass
 from typing import Any, cast
 
 import structlog
@@ -36,6 +37,35 @@ from server.app.storage.config_store import ConfigStore
 logger = structlog.get_logger(__name__)
 
 _TEST_ONLY_PROVIDERS = {"mock"}
+
+
+@dataclass(frozen=True)
+class ResolvedModelConfig:
+    provider: str
+    model_id: str
+    api_key: str | None = None
+    base_url: str | None = None
+    region: str | None = None
+    role_arn: str | None = None
+    recursion_limit: int = 1000
+    temperature: float | None = None
+    max_tokens: int | None = None
+    max_retries: int | None = None
+    timeout: int | None = None
+
+    def build_model(self, resolver: RuntimeResolver) -> BaseChatModel:
+        return resolver.build_model(
+            provider=self.provider,
+            model_id=self.model_id,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            region=self.region,
+            role_arn=self.role_arn,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            max_retries=self.max_retries,
+            timeout=self.timeout,
+        )
 
 
 class RuntimeResolver:
@@ -509,55 +539,52 @@ class RuntimeResolver:
         Raises:
             LLMProviderConfigError: If the provider is misconfigured.
         """
-        (
-            provider,
-            model_id,
-            api_key,
-            base_url,
-            region,
-            role_arn,
-            recursion_limit,
-            max_retries,
-            timeout,
-        ) = await self._resolve_provider_config_for_session(
-            session=session, scope=scope, agent_def=agent_def
+        resolved = await self.resolve_model_config_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
         )
 
-        if provider in _TEST_ONLY_PROVIDERS:
+        if resolved.provider in _TEST_ONLY_PROVIDERS:
             raise LLMProviderConfigError(
-                provider=provider,
+                provider=resolved.provider,
                 reason=(
-                    f"Provider '{provider}' is reserved for testing and cannot be used in "
+                    f"Provider '{resolved.provider}' is reserved for testing and cannot be used in "
                     "production. Configure a real provider via POST /models/providers."
                 ),
             )
 
-        temperature: float | None = None
-        if agent_def and agent_def.config and agent_def.config.temperature is not None:
-            temperature = agent_def.config.temperature
+        model = resolved.build_model(self)
+        await self._warn_if_no_tool_call_support(resolved.provider, resolved.model_id)
 
-        max_tokens: int | None = None
-        if agent_def and agent_def.config and agent_def.config.max_tokens is not None:
-            max_tokens = agent_def.config.max_tokens
+        return model, resolved.provider, resolved.model_id, resolved.recursion_limit
 
-        model = self.build_model(
-            provider=provider,
-            model_id=model_id,
-            api_key=api_key,
-            base_url=base_url,
-            region=region,
-            role_arn=role_arn,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            max_retries=max_retries,
-            timeout=timeout,
+    async def resolve_model_config_for_session(
+        self,
+        session: Any,
+        scope: dict[str, str] | None = None,
+        agent_def: Any | None = None,
+    ) -> ResolvedModelConfig:
+        raw = await self._resolve_provider_config_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
+        )
+        return ResolvedModelConfig(
+            provider=raw[0],
+            model_id=raw[1],
+            api_key=raw[2],
+            base_url=raw[3],
+            region=raw[4],
+            role_arn=raw[5],
+            recursion_limit=raw[6],
+            max_retries=raw[7],
+            timeout=raw[8],
+            temperature=(agent_def.config.temperature if agent_def and agent_def.config else None),
+            max_tokens=(agent_def.config.max_tokens if agent_def and agent_def.config else None),
         )
 
-        await self._warn_if_no_tool_call_support(provider, model_id)
-
-        return model, provider, model_id, recursion_limit
-
-    async def _resolve_provider_config_for_session(
+    async def resolve_provider_tuple_for_session(
         self,
         session: Any,
         scope: dict[str, str] | None,
@@ -574,8 +601,7 @@ class RuntimeResolver:
         4. First enabled ProviderConfig from ConfigStore (global default)
 
         Returns:
-            (provider, model_id, api_key, base_url, region, role_arn,
-             recursion_limit, max_retries, timeout)
+            Legacy provider tuple for compatibility with older tests.
 
         Raises:
             LLMProviderConfigError: If no provider can be resolved.
@@ -718,6 +744,20 @@ class RuntimeResolver:
                 "Create a provider via POST /models/providers. "
                 "Providers with an empty scope are visible to all users."
             ),
+        )
+
+    async def _resolve_provider_config_for_session(
+        self,
+        session: Any,
+        scope: dict[str, str] | None,
+        agent_def: Any | None = None,
+    ) -> tuple[
+        str, str, str | None, str | None, str | None, str | None, int, int | None, int | None
+    ]:
+        return await self.resolve_provider_tuple_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
         )
 
     async def _warn_if_no_tool_call_support(self, provider: str, model_id: str) -> None:

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -42,49 +42,10 @@ from server.app.agent.runtime import (
 )
 from server.app.exceptions import LLMProviderConfigError
 from server.app.settings import Settings
-from server.app.storage import StorageBackend
 from server.app.storage.config_store import ConfigStore
 from server.app.storage.factory import create_storage_backend
 
 logger = structlog.get_logger(__name__)
-
-
-def get_storage_backend() -> StorageBackend:
-    """Compatibility shim for older unit tests patching this symbol.
-
-    The service now reads from ``self.storage_backend`` directly. This function
-    remains only so test patches targeting ``server.app.llm.deep_agent_service
-    .get_storage_backend`` do not fail during collection.
-    """
-    raise RuntimeError("Compatibility shim only; patch in tests instead of calling directly")
-
-
-async def _get_session_for_service(
-    storage_backend: Any,
-    session_id: str,
-) -> Any:
-    """Compatibility helper for tests that patch get_storage_backend()."""
-    try:
-        return await storage_backend.get_session(session_id)
-    except Exception:
-        fallback = get_storage_backend()
-        return await fallback.get_session(session_id)
-
-
-async def _load_config_registry_tools(scope: dict[str, str] | None) -> list[Any]:
-    """Load tools registered via POST /tools from ConfigStore.
-
-    .. deprecated:: Use RuntimeResolver.build_tools() instead.
-    """
-    try:
-        from server.app.api.dependencies import get_config_store
-
-        config_store = get_config_store()
-        resolver = RuntimeResolver(config_store=config_store, settings=Settings())
-        return await resolver.build_tools(scope=scope)
-    except RuntimeError:
-        logger.debug("ConfigStore not initialized — skipping API-registered tools")
-        return []
 
 
 def _resolve_middleware(specs: list[str | dict[str, Any]]) -> list[Any]:
@@ -337,7 +298,7 @@ class DeepAgentStreamingService:
         runtime: DeepAgentRuntime | None = None
         try:
             # Get session for config / agent_name resolution
-            session = await _get_session_for_service(self.storage_backend, session_id)
+            session = await self.storage_backend.get_session(session_id)
 
             agent_cfg, custom_tools = await self._resolve_agent_config(
                 session=session,
@@ -487,7 +448,7 @@ class DeepAgentStreamingService:
     ) -> AsyncGenerator[StreamEvent, None]:
         """Resume an interrupted Deep Agents run from persisted checkpoint state."""
         try:
-            session = await _get_session_for_service(self.storage_backend, session_id)
+            session = await self.storage_backend.get_session(session_id)
             if session is None:
                 yield ErrorEvent(message=f"Session not found: {session_id}", code="NOT_FOUND")
                 return

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -93,7 +93,7 @@ def _base_patches(mock_runtime: MagicMock, session: Session) -> tuple:
             return_value=MagicMock(),
         ),
         patch(
-            "server.app.llm.deep_agent_service.get_storage_backend",
+            "server.app.storage.factory.create_storage_backend",
             return_value=mock_storage,
         ),
     )
@@ -111,6 +111,11 @@ async def _run(
     s = MagicMock(spec=Settings)
     s.trusted_tool_namespaces = ["server.app.tools"]
     service = DeepAgentStreamingService(s)
+    mock_storage = MagicMock()
+    mock_storage.get_session = AsyncMock(return_value=session)
+    mock_storage.get_checkpointer = AsyncMock(return_value=MagicMock())
+    mock_storage.get_store = AsyncMock(return_value=MagicMock())
+    service.storage_backend = mock_storage
 
     p1, p2, p3, p4 = patches
 
@@ -442,6 +447,8 @@ class TestToolsWiring:
         mock_storage = MagicMock()
         mock_storage.get_session = AsyncMock(return_value=session)
         mock_storage.get_checkpointer = AsyncMock(return_value=MagicMock())
+        mock_storage.get_store = AsyncMock(return_value=MagicMock())
+        service.storage_backend = mock_storage
 
         resolve_tools_calls: list[Any] = []
 
@@ -466,7 +473,7 @@ class TestToolsWiring:
                 return_value=MagicMock(),
             ) as create_agent_mock,
             patch(
-                "server.app.llm.deep_agent_service.get_storage_backend",
+                "server.app.storage.factory.create_storage_backend",
                 return_value=mock_storage,
             ),
             patch(

--- a/tests/unit/test_config_registry_tools.py
+++ b/tests/unit/test_config_registry_tools.py
@@ -2,7 +2,7 @@
 
 Covers:
 - ToolRegistration model: path XOR code validation
-- _load_config_registry_tools(): code-based and path-based loading
+- RuntimeResolver.build_tools(): code-based and path-based loading
 - GET /tools: returns tools from ConfigStore
 - POST /tools: accepts code and path, validates XOR
 - Disabled tools are skipped
@@ -66,7 +66,7 @@ class TestToolRegistrationModel:
 
 
 # ---------------------------------------------------------------------------
-# _load_config_registry_tools: code-based tools
+# RuntimeResolver.build_tools(): code-based tools
 # ---------------------------------------------------------------------------
 
 
@@ -74,7 +74,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_code_tool_loaded_as_base_tool(self):
         """A @tool-decorated function in code is loaded as a BaseTool."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -91,11 +91,8 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="say-hello", code=code, enabled=True)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert isinstance(tools[0], BaseTool)
@@ -104,7 +101,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_multiple_tools_in_one_code_block(self):
         """Multiple @tool functions in one code block all get loaded."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -126,11 +123,8 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="multi-tools", code=code, enabled=True)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 2
         names = {t.name for t in tools}
@@ -139,7 +133,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_disabled_tool_is_skipped(self):
         """Disabled ToolRegistration entries are not loaded."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -156,18 +150,15 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="disabled", code=code, enabled=False)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 0
 
     @pytest.mark.asyncio
     async def test_code_with_syntax_error_is_skipped(self):
         """A tool with invalid Python source is skipped without crashing."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         mock_store = MagicMock()
@@ -181,11 +172,8 @@ class TestLoadCodeTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         # Should not raise — just returns empty
         assert len(tools) == 0
@@ -193,7 +181,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_one_bad_tool_does_not_block_others(self):
         """An error loading one tool doesn't prevent other tools from loading."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         good_code = textwrap.dedent("""\
@@ -213,31 +201,25 @@ class TestLoadCodeTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert tools[0].name == "good_tool"
 
     @pytest.mark.asyncio
-    async def test_config_registry_not_initialized_returns_empty(self):
-        """If ConfigRegistry is not initialized, returns empty list gracefully."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+    async def test_missing_config_store_returns_empty(self):
+        """If ConfigStore is not initialized, returns empty list gracefully."""
+        from server.app.agent.resolver import RuntimeResolver
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            side_effect=RuntimeError("not initialized"),
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=None, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert tools == []
 
 
 # ---------------------------------------------------------------------------
-# _load_config_registry_tools: path-based tools
+# RuntimeResolver.build_tools(): path-based tools
 # ---------------------------------------------------------------------------
 
 
@@ -245,7 +227,7 @@ class TestLoadPathTools:
     @pytest.mark.asyncio
     async def test_path_tool_loaded_via_importlib(self):
         """A path-based tool is loaded via importlib and BaseTool instances collected."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         # Create a real minimal BaseTool subclass so isinstance() works
@@ -265,14 +247,9 @@ class TestLoadPathTools:
             return_value=[ToolRegistration(name="path-tool", path="mypackage.tools", enabled=True)]
         )
 
-        with (
-            patch(
-                "server.app.api.dependencies.get_config_store",
-                return_value=mock_store,
-            ),
-            patch("importlib.import_module", return_value=fake_module),
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        with patch("importlib.import_module", return_value=fake_module):
+            tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert isinstance(tools[0], BaseTool)
@@ -280,7 +257,7 @@ class TestLoadPathTools:
     @pytest.mark.asyncio
     async def test_path_import_error_is_skipped(self):
         """An ImportError on a path-based tool is skipped without crashing."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         mock_store = MagicMock()
@@ -290,11 +267,8 @@ class TestLoadPathTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert tools == []
 

--- a/tests/unit/test_store_wiring.py
+++ b/tests/unit/test_store_wiring.py
@@ -298,11 +298,12 @@ class TestServiceStoreWiring:
         mock_global_storage.get_session = AsyncMock(return_value=session)
 
         # The service has its own storage_backend (from create_storage_backend in __init__)
-        # We patch get_storage_backend for session lookup and patch the service's
-        # storage_backend directly for get_checkpointer and get_store
+        # We patch the service's storage_backend directly for session lookup,
+        # get_checkpointer, and get_store.
         s = MagicMock(spec=Settings)
         service = DeepAgentStreamingService(s)
         service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
         service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
         service.storage_backend.get_store = AsyncMock(return_value=mock_store)
 
@@ -327,10 +328,6 @@ class TestServiceStoreWiring:
                 "server.app.llm.deep_agent_service.create_cognition_agent",
                 new_callable=AsyncMock,
                 return_value=MagicMock(),
-            ),
-            patch(
-                "server.app.llm.deep_agent_service.get_storage_backend",
-                return_value=mock_global_storage,
             ),
         ):
             async for _ in service.stream_response(

--- a/tests/unit/test_streaming_bugs.py
+++ b/tests/unit/test_streaming_bugs.py
@@ -129,7 +129,7 @@ def _stream_patches(mock_runtime: MagicMock, session: Any = None) -> tuple:
             return_value=MagicMock(),
         ),
         patch(
-            "server.app.llm.deep_agent_service.get_storage_backend",
+            "server.app.storage.factory.create_storage_backend",
             return_value=mock_storage,
         ),
     )
@@ -170,6 +170,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="hello"), DoneEvent())
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -189,6 +193,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="world"))
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -205,6 +213,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -235,6 +247,10 @@ class TestContentNotDoubled:
             DoneEvent(),
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -262,6 +278,10 @@ class TestContentNotDoubled:
             DoneEvent(),
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -293,6 +313,10 @@ class TestUsageEventModelField:
         session = _make_session(provider="mock", model=custom_model)
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(settings)
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -314,6 +338,10 @@ class TestUsageEventModelField:
         session = _make_session(provider="mock", model="gpt-4o-mini")
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(settings)
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -337,6 +365,10 @@ class TestRuntimeErrorsSurface:
             return_value=_runtime_raises(RuntimeError("graph blew up"))
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:


### PR DESCRIPTION
## Summary
- remove deprecated streaming-service compatibility shims and read sessions directly from the injected storage backend
- introduce `ResolvedModelConfig` and route runtime model construction through structured resolver state
- update runtime-focused unit tests to patch current seams instead of deleted helpers

## Verification
- `uv run pytest tests/unit/test_provider_resolution.py tests/unit/test_store_wiring.py tests/unit/test_streaming_bugs.py tests/unit/test_agent_def_field_wiring.py tests/unit/test_config_registry_tools.py -q`
- `uv run pytest tests/unit/ -q --timeout=30`
- `uv run ruff check server/app/agent/resolver.py server/app/llm/deep_agent_service.py tests/unit/test_provider_resolution.py tests/unit/test_store_wiring.py tests/unit/test_streaming_bugs.py tests/unit/test_agent_def_field_wiring.py tests/unit/test_config_registry_tools.py`