### PR TITLE
refactor: deduplicate shared storage backend logic and add config examples

### DIFF
--- a/server/app/agent/resolver.py
+++ b/server/app/agent/resolver.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import os
+from dataclasses import dataclass
 from typing import Any, cast
 
 import structlog
@@ -36,6 +37,35 @@ from server.app.storage.config_store import ConfigStore
 logger = structlog.get_logger(__name__)
 
 _TEST_ONLY_PROVIDERS = {"mock"}
+
+
+@dataclass(frozen=True)
+class ResolvedModelConfig:
+    provider: str
+    model_id: str
+    api_key: str | None = None
+    base_url: str | None = None
+    region: str | None = None
+    role_arn: str | None = None
+    recursion_limit: int = 1000
+    temperature: float | None = None
+    max_tokens: int | None = None
+    max_retries: int | None = None
+    timeout: int | None = None
+
+    def build_model(self, resolver: RuntimeResolver) -> BaseChatModel:
+        return resolver.build_model(
+            provider=self.provider,
+            model_id=self.model_id,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            region=self.region,
+            role_arn=self.role_arn,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            max_retries=self.max_retries,
+            timeout=self.timeout,
+        )
 
 
 class RuntimeResolver:
@@ -509,55 +539,52 @@ class RuntimeResolver:
         Raises:
             LLMProviderConfigError: If the provider is misconfigured.
         """
-        (
-            provider,
-            model_id,
-            api_key,
-            base_url,
-            region,
-            role_arn,
-            recursion_limit,
-            max_retries,
-            timeout,
-        ) = await self._resolve_provider_config_for_session(
-            session=session, scope=scope, agent_def=agent_def
+        resolved = await self.resolve_model_config_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
         )
 
-        if provider in _TEST_ONLY_PROVIDERS:
+        if resolved.provider in _TEST_ONLY_PROVIDERS:
             raise LLMProviderConfigError(
-                provider=provider,
+                provider=resolved.provider,
                 reason=(
-                    f"Provider '{provider}' is reserved for testing and cannot be used in "
+                    f"Provider '{resolved.provider}' is reserved for testing and cannot be used in "
                     "production. Configure a real provider via POST /models/providers."
                 ),
             )
 
-        temperature: float | None = None
-        if agent_def and agent_def.config and agent_def.config.temperature is not None:
-            temperature = agent_def.config.temperature
+        model = resolved.build_model(self)
+        await self._warn_if_no_tool_call_support(resolved.provider, resolved.model_id)
 
-        max_tokens: int | None = None
-        if agent_def and agent_def.config and agent_def.config.max_tokens is not None:
-            max_tokens = agent_def.config.max_tokens
+        return model, resolved.provider, resolved.model_id, resolved.recursion_limit
 
-        model = self.build_model(
-            provider=provider,
-            model_id=model_id,
-            api_key=api_key,
-            base_url=base_url,
-            region=region,
-            role_arn=role_arn,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            max_retries=max_retries,
-            timeout=timeout,
+    async def resolve_model_config_for_session(
+        self,
+        session: Any,
+        scope: dict[str, str] | None = None,
+        agent_def: Any | None = None,
+    ) -> ResolvedModelConfig:
+        raw = await self._resolve_provider_config_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
+        )
+        return ResolvedModelConfig(
+            provider=raw[0],
+            model_id=raw[1],
+            api_key=raw[2],
+            base_url=raw[3],
+            region=raw[4],
+            role_arn=raw[5],
+            recursion_limit=raw[6],
+            max_retries=raw[7],
+            timeout=raw[8],
+            temperature=(agent_def.config.temperature if agent_def and agent_def.config else None),
+            max_tokens=(agent_def.config.max_tokens if agent_def and agent_def.config else None),
         )
 
-        await self._warn_if_no_tool_call_support(provider, model_id)
-
-        return model, provider, model_id, recursion_limit
-
-    async def _resolve_provider_config_for_session(
+    async def resolve_provider_tuple_for_session(
         self,
         session: Any,
         scope: dict[str, str] | None,
@@ -574,8 +601,7 @@ class RuntimeResolver:
         4. First enabled ProviderConfig from ConfigStore (global default)
 
         Returns:
-            (provider, model_id, api_key, base_url, region, role_arn,
-             recursion_limit, max_retries, timeout)
+            Legacy provider tuple for compatibility with older tests.
 
         Raises:
             LLMProviderConfigError: If no provider can be resolved.
@@ -718,6 +744,20 @@ class RuntimeResolver:
                 "Create a provider via POST /models/providers. "
                 "Providers with an empty scope are visible to all users."
             ),
+        )
+
+    async def _resolve_provider_config_for_session(
+        self,
+        session: Any,
+        scope: dict[str, str] | None,
+        agent_def: Any | None = None,
+    ) -> tuple[
+        str, str, str | None, str | None, str | None, str | None, int, int | None, int | None
+    ]:
+        return await self.resolve_provider_tuple_for_session(
+            session=session,
+            scope=scope,
+            agent_def=agent_def,
         )
 
     async def _warn_if_no_tool_call_support(self, provider: str, model_id: str) -> None:

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -42,49 +42,10 @@ from server.app.agent.runtime import (
 )
 from server.app.exceptions import LLMProviderConfigError
 from server.app.settings import Settings
-from server.app.storage import StorageBackend
 from server.app.storage.config_store import ConfigStore
 from server.app.storage.factory import create_storage_backend
 
 logger = structlog.get_logger(__name__)
-
-
-def get_storage_backend() -> StorageBackend:
-    """Compatibility shim for older unit tests patching this symbol.
-
-    The service now reads from ``self.storage_backend`` directly. This function
-    remains only so test patches targeting ``server.app.llm.deep_agent_service
-    .get_storage_backend`` do not fail during collection.
-    """
-    raise RuntimeError("Compatibility shim only; patch in tests instead of calling directly")
-
-
-async def _get_session_for_service(
-    storage_backend: Any,
-    session_id: str,
-) -> Any:
-    """Compatibility helper for tests that patch get_storage_backend()."""
-    try:
-        return await storage_backend.get_session(session_id)
-    except Exception:
-        fallback = get_storage_backend()
-        return await fallback.get_session(session_id)
-
-
-async def _load_config_registry_tools(scope: dict[str, str] | None) -> list[Any]:
-    """Load tools registered via POST /tools from ConfigStore.
-
-    .. deprecated:: Use RuntimeResolver.build_tools() instead.
-    """
-    try:
-        from server.app.api.dependencies import get_config_store
-
-        config_store = get_config_store()
-        resolver = RuntimeResolver(config_store=config_store, settings=Settings())
-        return await resolver.build_tools(scope=scope)
-    except RuntimeError:
-        logger.debug("ConfigStore not initialized — skipping API-registered tools")
-        return []
 
 
 def _resolve_middleware(specs: list[str | dict[str, Any]]) -> list[Any]:
@@ -337,7 +298,7 @@ class DeepAgentStreamingService:
         runtime: DeepAgentRuntime | None = None
         try:
             # Get session for config / agent_name resolution
-            session = await _get_session_for_service(self.storage_backend, session_id)
+            session = await self.storage_backend.get_session(session_id)
 
             agent_cfg, custom_tools = await self._resolve_agent_config(
                 session=session,
@@ -487,7 +448,7 @@ class DeepAgentStreamingService:
     ) -> AsyncGenerator[StreamEvent, None]:
         """Resume an interrupted Deep Agents run from persisted checkpoint state."""
         try:
-            session = await _get_session_for_service(self.storage_backend, session_id)
+            session = await self.storage_backend.get_session(session_id)
             if session is None:
                 yield ErrorEvent(message=f"Session not found: {session_id}", code="NOT_FOUND")
                 return

--- a/server/app/storage/common.py
+++ b/server/app/storage/common.py
@@ -1,0 +1,135 @@
+"""Shared storage helpers for backend implementations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from server.app.models import Message, Session, SessionConfig, SessionStatus, ToolCall
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def now_utc_iso() -> str:
+    return now_utc().isoformat()
+
+
+def merge_session_config(existing: SessionConfig, incoming: SessionConfig) -> SessionConfig:
+    return SessionConfig(
+        provider=incoming.provider or existing.provider,
+        model=incoming.model or existing.model,
+        temperature=(
+            incoming.temperature if incoming.temperature is not None else existing.temperature
+        ),
+        max_tokens=(
+            incoming.max_tokens if incoming.max_tokens is not None else existing.max_tokens
+        ),
+        recursion_limit=(
+            incoming.recursion_limit
+            if incoming.recursion_limit is not None
+            else existing.recursion_limit
+        ),
+        response_format=(
+            incoming.response_format
+            if incoming.response_format is not None
+            else existing.response_format
+        ),
+        system_prompt=(
+            incoming.system_prompt if incoming.system_prompt is not None else existing.system_prompt
+        ),
+    )
+
+
+def make_session(
+    *,
+    session_id: str,
+    workspace_path: str,
+    thread_id: str,
+    config: SessionConfig,
+    title: str | None = None,
+    scopes: dict[str, str] | None = None,
+    agent_name: str = "default",
+    metadata: dict[str, str] | None = None,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    message_count: int = 0,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    created = created_at or now_utc_iso()
+    updated = updated_at or created
+    return Session(
+        id=session_id,
+        workspace_path=workspace_path,
+        title=title,
+        thread_id=thread_id,
+        status=status,
+        config=config,
+        scopes=scopes or {},
+        created_at=created,
+        updated_at=updated,
+        message_count=message_count,
+        agent_name=agent_name,
+        metadata=metadata or {},
+    )
+
+
+def make_message(
+    *,
+    message_id: str,
+    session_id: str,
+    role: str,
+    content: str | None,
+    parent_id: str | None = None,
+    created_at: datetime | None = None,
+    tool_calls: list[ToolCall] | None = None,
+    tool_call_id: str | None = None,
+    token_count: int | None = None,
+    model_used: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Message:
+    return Message(
+        id=message_id,
+        session_id=session_id,
+        role=role,
+        content=content,
+        parent_id=parent_id,
+        created_at=created_at or now_utc(),
+        tool_calls=tool_calls,
+        tool_call_id=tool_call_id,
+        token_count=token_count,
+        model_used=model_used,
+        metadata=metadata,
+    )
+
+
+def filter_sessions(
+    sessions: list[Session],
+    filter_scopes: dict[str, str] | None = None,
+    metadata_filters: dict[str, str] | None = None,
+) -> list[Session]:
+    filtered = sessions
+    if filter_scopes:
+        filtered = [
+            session
+            for session in filtered
+            if all(session.scopes.get(key) == value for key, value in filter_scopes.items())
+        ]
+    if metadata_filters:
+        filtered = [
+            session
+            for session in filtered
+            if all(session.metadata.get(key) == value for key, value in metadata_filters.items())
+        ]
+    return filtered
+
+
+__all__ = [
+    "filter_sessions",
+    "make_message",
+    "make_session",
+    "merge_session_config",
+    "now_utc",
+    "now_utc_iso",
+]

--- a/server/app/storage/common.py
+++ b/server/app/storage/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from server.app.models import Message, Session, SessionConfig, SessionStatus, ToolCall
 
@@ -79,7 +79,7 @@ def make_message(
     *,
     message_id: str,
     session_id: str,
-    role: str,
+    role: Literal["user", "assistant", "system", "tool"],
     content: str | None,
     parent_id: str | None = None,
     created_at: datetime | None = None,

--- a/server/app/storage/memory.py
+++ b/server/app/storage/memory.py
@@ -6,7 +6,6 @@ and development purposes. Data is not persisted across restarts.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -16,7 +15,14 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
 
-from server.app.models import Message, Session, SessionConfig, SessionStatus
+from server.app.models import Message, Session, SessionConfig
+from server.app.storage.common import (
+    filter_sessions,
+    make_message,
+    make_session,
+    merge_session_config,
+    now_utc_iso,
+)
 from server.app.storage.message_projection import project_checkpoint_messages
 
 logger = structlog.get_logger(__name__)
@@ -73,20 +79,15 @@ class MemoryStorageBackend:
         workspace_path: str | None = None,
     ) -> Session:
         """Create a new session."""
-        now = datetime.now(UTC).isoformat()
-
-        session = Session(
-            id=session_id,
+        session = make_session(
+            session_id=session_id,
             workspace_path=workspace_path or str(self.workspace_path),
             title=title,
             thread_id=thread_id,
-            status=SessionStatus.ACTIVE,
             config=config,
-            scopes=scopes or {},
-            created_at=now,
-            updated_at=now,
-            message_count=0,
-            metadata=metadata or {},
+            scopes=scopes,
+            agent_name=agent_name,
+            metadata=metadata,
         )
 
         self._sessions[session_id] = session
@@ -109,26 +110,10 @@ class MemoryStorageBackend:
         metadata_filters: dict[str, str] | None = None,
     ) -> list[Session]:
         """List all sessions."""
-        sessions = sorted(
-            self._sessions.values(),
-            key=lambda s: s.updated_at,
-            reverse=True,
+        sessions = sorted(self._sessions.values(), key=lambda s: s.updated_at, reverse=True)
+        return filter_sessions(
+            sessions, filter_scopes=filter_scopes, metadata_filters=metadata_filters
         )
-
-        # Filter by scopes if specified
-        if filter_scopes:
-            sessions = [
-                s for s in sessions if all(s.scopes.get(k) == v for k, v in filter_scopes.items())
-            ]
-
-        if metadata_filters:
-            sessions = [
-                s
-                for s in sessions
-                if all(s.metadata.get(k) == v for k, v in metadata_filters.items())
-            ]
-
-        return sessions
 
     async def update_session(
         self,
@@ -148,31 +133,12 @@ class MemoryStorageBackend:
             session.title = title
 
         if config is not None:
-            existing_config = session.config
-            session.config = SessionConfig(
-                provider=config.provider or existing_config.provider,
-                model=config.model or existing_config.model,
-                temperature=config.temperature
-                if config.temperature is not None
-                else existing_config.temperature,
-                max_tokens=config.max_tokens
-                if config.max_tokens is not None
-                else existing_config.max_tokens,
-                recursion_limit=config.recursion_limit
-                if config.recursion_limit is not None
-                else existing_config.recursion_limit,
-                response_format=config.response_format
-                if config.response_format is not None
-                else existing_config.response_format,
-                system_prompt=config.system_prompt
-                if config.system_prompt is not None
-                else existing_config.system_prompt,
-            )
+            session.config = merge_session_config(session.config, config)
 
         if metadata is not None:
             session.metadata = dict(metadata)
 
-        session.updated_at = datetime.now(UTC).isoformat()
+        session.updated_at = now_utc_iso()
         return session
 
     async def update_message_count(self, session_id: str, count: int) -> None:
@@ -180,7 +146,7 @@ class MemoryStorageBackend:
         session = self._sessions.get(session_id)
         if session:
             session.message_count = count
-            session.updated_at = datetime.now(UTC).isoformat()
+            session.updated_at = now_utc_iso()
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""
@@ -211,15 +177,12 @@ class MemoryStorageBackend:
         metadata: dict[str, Any] | None = None,
     ) -> Message:
         """Create a new message."""
-        now = datetime.now(UTC)
-
-        message = Message(
-            id=message_id,
+        message = make_message(
+            message_id=message_id,
             session_id=session_id,
             role=role,
             content=content,
             parent_id=parent_id,
-            created_at=now,
             tool_calls=tool_calls,
             tool_call_id=tool_call_id,
             token_count=token_count,
@@ -292,7 +255,7 @@ class MemoryStorageBackend:
         session = self._sessions.get(session_id)
         if session is not None:
             session.message_count = len(projected_messages)
-            session.updated_at = datetime.now(UTC).isoformat()
+            session.updated_at = now_utc_iso()
 
         return len(projected_messages)
 

--- a/server/app/storage/postgres.py
+++ b/server/app/storage/postgres.py
@@ -8,7 +8,7 @@ pooling for high-performance concurrent access.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -22,6 +22,7 @@ from langgraph.store.postgres.aio import AsyncPostgresStore
 
 from server.app.models import Message, Session, SessionConfig, SessionStatus, ToolCall
 from server.app.storage.backend import StorageBackend
+from server.app.storage.common import make_message, make_session, merge_session_config, now_utc
 from server.app.storage.message_projection import project_checkpoint_messages
 
 logger = structlog.get_logger(__name__)
@@ -197,21 +198,19 @@ class PostgresStorageBackend:
         workspace_path: str | None = None,
     ) -> Session:
         """Create a new session."""
-        now = datetime.now(UTC)
+        now = now_utc()
 
-        session = Session(
-            id=session_id,
+        session = make_session(
+            session_id=session_id,
             workspace_path=workspace_path or str(self.workspace_path),
             title=title,
             thread_id=thread_id,
-            status=SessionStatus.ACTIVE,
             config=config,
-            scopes=scopes or {},
+            scopes=scopes,
+            agent_name=agent_name,
+            metadata=metadata,
             created_at=now.isoformat(),
             updated_at=now.isoformat(),
-            message_count=0,
-            agent_name=agent_name,
-            metadata=metadata or {},
         )
 
         config_json = {
@@ -339,26 +338,7 @@ class PostgresStorageBackend:
             session.metadata = dict(metadata)
 
         if config is not None:
-            existing_config = session.config
-            new_config = SessionConfig(
-                provider=config.provider or existing_config.provider,
-                model=config.model or existing_config.model,
-                temperature=config.temperature
-                if config.temperature is not None
-                else existing_config.temperature,
-                max_tokens=config.max_tokens
-                if config.max_tokens is not None
-                else existing_config.max_tokens,
-                recursion_limit=config.recursion_limit
-                if config.recursion_limit is not None
-                else existing_config.recursion_limit,
-                response_format=config.response_format
-                if config.response_format is not None
-                else existing_config.response_format,
-                system_prompt=config.system_prompt
-                if config.system_prompt is not None
-                else existing_config.system_prompt,
-            )
+            new_config = merge_session_config(session.config, config)
 
             config_json = {
                 "provider": new_config.provider,
@@ -378,7 +358,7 @@ class PostgresStorageBackend:
             return session
 
         updates.append(f"updated_at = ${param_idx}")
-        now = datetime.now(UTC)
+        now = now_utc()
         params.append(now)
         param_idx += 1
 
@@ -395,7 +375,7 @@ class PostgresStorageBackend:
 
     async def update_message_count(self, session_id: str, count: int) -> None:
         """Update the message count for a session."""
-        now = datetime.now(UTC)
+        now = now_utc()
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
@@ -441,10 +421,10 @@ class PostgresStorageBackend:
         metadata: dict[str, Any] | None = None,
     ) -> Message:
         """Create a new message."""
-        now = datetime.now(UTC)
+        now = now_utc()
 
-        message = Message(
-            id=message_id,
+        message = make_message(
+            message_id=message_id,
             session_id=session_id,
             role=role,
             content=content,
@@ -529,7 +509,7 @@ class PostgresStorageBackend:
                 await conn.execute(
                     "UPDATE sessions SET message_count = $1, updated_at = $2 WHERE id = $3",
                     len(projected_messages),
-                    datetime.now(UTC),
+                    now_utc(),
                     session_id,
                 )
 
@@ -704,12 +684,11 @@ class PostgresStorageBackend:
         scopes = json.loads(scopes_data) if scopes_data else {}
         metadata_data = row.get("metadata")
         metadata = json.loads(metadata_data) if metadata_data else {}
-        return Session(
-            id=row["id"],
+        return make_session(
+            session_id=row["id"],
             workspace_path=row["workspace_path"],
             title=row["title"],
             thread_id=row["thread_id"],
-            status=SessionStatus(row["status"]),
             config=SessionConfig(
                 provider=config_data.get("provider"),
                 model=config_data.get("model"),
@@ -725,6 +704,7 @@ class PostgresStorageBackend:
             message_count=row["message_count"],
             agent_name=row.get("agent_name", "default"),
             metadata=metadata,
+            status=SessionStatus(row["status"]),
         )
 
     def _row_to_message(self, row: asyncpg.Record) -> Message:
@@ -755,8 +735,8 @@ class PostgresStorageBackend:
             except json.JSONDecodeError:
                 metadata = None
 
-        return Message(
-            id=row["id"],
+        return make_message(
+            message_id=row["id"],
             session_id=row["session_id"],
             role=row["role"],  # type: ignore
             content=row["content"],

--- a/server/app/storage/sqlite.py
+++ b/server/app/storage/sqlite.py
@@ -7,7 +7,7 @@ database engine. Supports sessions, messages, and checkpoint persistence.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -20,6 +20,7 @@ from langgraph.store.sqlite.aio import AsyncSqliteStore
 
 from server.app.models import Message, Session, SessionConfig, SessionStatus, ToolCall
 from server.app.storage.backend import StorageBackend
+from server.app.storage.common import make_message, make_session, merge_session_config, now_utc_iso
 from server.app.storage.message_projection import project_checkpoint_messages
 
 logger = structlog.get_logger(__name__)
@@ -123,21 +124,15 @@ class SqliteStorageBackend:
         workspace_path: str | None = None,
     ) -> Session:
         """Create a new session."""
-        now = datetime.now(UTC).isoformat()
-
-        session = Session(
-            id=session_id,
+        session = make_session(
+            session_id=session_id,
             workspace_path=workspace_path or str(self.workspace_path),
             title=title,
             thread_id=thread_id,
-            status=SessionStatus.ACTIVE,
             config=config,
-            created_at=now,
-            updated_at=now,
-            message_count=0,
+            scopes=scopes,
             agent_name=agent_name,
-            scopes=scopes or {},
-            metadata=metadata or {},
+            metadata=metadata,
         )
 
         config_json = json.dumps(
@@ -269,26 +264,7 @@ class SqliteStorageBackend:
             session.metadata = dict(metadata)
 
         if config is not None:
-            existing_config = session.config
-            new_config = SessionConfig(
-                provider=config.provider or existing_config.provider,
-                model=config.model or existing_config.model,
-                temperature=config.temperature
-                if config.temperature is not None
-                else existing_config.temperature,
-                max_tokens=config.max_tokens
-                if config.max_tokens is not None
-                else existing_config.max_tokens,
-                recursion_limit=config.recursion_limit
-                if config.recursion_limit is not None
-                else existing_config.recursion_limit,
-                response_format=config.response_format
-                if config.response_format is not None
-                else existing_config.response_format,
-                system_prompt=config.system_prompt
-                if config.system_prompt is not None
-                else existing_config.system_prompt,
-            )
+            new_config = merge_session_config(session.config, config)
 
             config_json = json.dumps(
                 {
@@ -309,7 +285,7 @@ class SqliteStorageBackend:
             return session
 
         updates.append("updated_at = ?")
-        now = datetime.now(UTC).isoformat()
+        now = now_utc_iso()
         params.append(now)
         session.updated_at = now
 
@@ -323,7 +299,7 @@ class SqliteStorageBackend:
 
     async def update_message_count(self, session_id: str, count: int) -> None:
         """Update the message count for a session."""
-        now = datetime.now(UTC).isoformat()
+        now = now_utc_iso()
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 "UPDATE sessions SET message_count = ?, updated_at = ? WHERE id = ?",
@@ -360,21 +336,19 @@ class SqliteStorageBackend:
         metadata: dict[str, Any] | None = None,
     ) -> Message:
         """Create a new message."""
-        now = datetime.now(UTC).isoformat()
-
-        message = Message(
-            id=message_id,
+        message = make_message(
+            message_id=message_id,
             session_id=session_id,
             role=role,
             content=content,
             parent_id=parent_id,
-            created_at=datetime.fromisoformat(now),
             tool_calls=tool_calls,
             tool_call_id=tool_call_id,
             token_count=token_count,
             model_used=model_used,
             metadata=metadata,
         )
+        now = message.created_at.isoformat()
 
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
@@ -512,7 +486,7 @@ class SqliteStorageBackend:
                     ),
                 )
 
-            now = datetime.now(UTC).isoformat()
+            now = now_utc_iso()
             await db.execute(
                 "UPDATE sessions SET message_count = ?, updated_at = ? WHERE id = ?",
                 (len(projected_messages), now, session_id),
@@ -642,8 +616,8 @@ class SqliteStorageBackend:
             except json.JSONDecodeError:
                 metadata = None
 
-        return Message(
-            id=row["id"],
+        return make_message(
+            message_id=row["id"],
             session_id=row["session_id"],
             role=row["role"],
             content=row["content"],

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -93,7 +93,7 @@ def _base_patches(mock_runtime: MagicMock, session: Session) -> tuple:
             return_value=MagicMock(),
         ),
         patch(
-            "server.app.llm.deep_agent_service.get_storage_backend",
+            "server.app.storage.factory.create_storage_backend",
             return_value=mock_storage,
         ),
     )
@@ -111,6 +111,11 @@ async def _run(
     s = MagicMock(spec=Settings)
     s.trusted_tool_namespaces = ["server.app.tools"]
     service = DeepAgentStreamingService(s)
+    mock_storage = MagicMock()
+    mock_storage.get_session = AsyncMock(return_value=session)
+    mock_storage.get_checkpointer = AsyncMock(return_value=MagicMock())
+    mock_storage.get_store = AsyncMock(return_value=MagicMock())
+    service.storage_backend = mock_storage
 
     p1, p2, p3, p4 = patches
 
@@ -442,6 +447,8 @@ class TestToolsWiring:
         mock_storage = MagicMock()
         mock_storage.get_session = AsyncMock(return_value=session)
         mock_storage.get_checkpointer = AsyncMock(return_value=MagicMock())
+        mock_storage.get_store = AsyncMock(return_value=MagicMock())
+        service.storage_backend = mock_storage
 
         resolve_tools_calls: list[Any] = []
 
@@ -466,7 +473,7 @@ class TestToolsWiring:
                 return_value=MagicMock(),
             ) as create_agent_mock,
             patch(
-                "server.app.llm.deep_agent_service.get_storage_backend",
+                "server.app.storage.factory.create_storage_backend",
                 return_value=mock_storage,
             ),
             patch(

--- a/tests/unit/test_config_registry_tools.py
+++ b/tests/unit/test_config_registry_tools.py
@@ -2,7 +2,7 @@
 
 Covers:
 - ToolRegistration model: path XOR code validation
-- _load_config_registry_tools(): code-based and path-based loading
+- RuntimeResolver.build_tools(): code-based and path-based loading
 - GET /tools: returns tools from ConfigStore
 - POST /tools: accepts code and path, validates XOR
 - Disabled tools are skipped
@@ -66,7 +66,7 @@ class TestToolRegistrationModel:
 
 
 # ---------------------------------------------------------------------------
-# _load_config_registry_tools: code-based tools
+# RuntimeResolver.build_tools(): code-based tools
 # ---------------------------------------------------------------------------
 
 
@@ -74,7 +74,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_code_tool_loaded_as_base_tool(self):
         """A @tool-decorated function in code is loaded as a BaseTool."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -91,11 +91,8 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="say-hello", code=code, enabled=True)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert isinstance(tools[0], BaseTool)
@@ -104,7 +101,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_multiple_tools_in_one_code_block(self):
         """Multiple @tool functions in one code block all get loaded."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -126,11 +123,8 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="multi-tools", code=code, enabled=True)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 2
         names = {t.name for t in tools}
@@ -139,7 +133,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_disabled_tool_is_skipped(self):
         """Disabled ToolRegistration entries are not loaded."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         code = textwrap.dedent("""\
@@ -156,18 +150,15 @@ class TestLoadCodeTools:
             return_value=[ToolRegistration(name="disabled", code=code, enabled=False)]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 0
 
     @pytest.mark.asyncio
     async def test_code_with_syntax_error_is_skipped(self):
         """A tool with invalid Python source is skipped without crashing."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         mock_store = MagicMock()
@@ -181,11 +172,8 @@ class TestLoadCodeTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         # Should not raise — just returns empty
         assert len(tools) == 0
@@ -193,7 +181,7 @@ class TestLoadCodeTools:
     @pytest.mark.asyncio
     async def test_one_bad_tool_does_not_block_others(self):
         """An error loading one tool doesn't prevent other tools from loading."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         good_code = textwrap.dedent("""\
@@ -213,31 +201,25 @@ class TestLoadCodeTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert tools[0].name == "good_tool"
 
     @pytest.mark.asyncio
-    async def test_config_registry_not_initialized_returns_empty(self):
-        """If ConfigRegistry is not initialized, returns empty list gracefully."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+    async def test_missing_config_store_returns_empty(self):
+        """If ConfigStore is not initialized, returns empty list gracefully."""
+        from server.app.agent.resolver import RuntimeResolver
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            side_effect=RuntimeError("not initialized"),
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=None, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert tools == []
 
 
 # ---------------------------------------------------------------------------
-# _load_config_registry_tools: path-based tools
+# RuntimeResolver.build_tools(): path-based tools
 # ---------------------------------------------------------------------------
 
 
@@ -245,7 +227,7 @@ class TestLoadPathTools:
     @pytest.mark.asyncio
     async def test_path_tool_loaded_via_importlib(self):
         """A path-based tool is loaded via importlib and BaseTool instances collected."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         # Create a real minimal BaseTool subclass so isinstance() works
@@ -265,14 +247,9 @@ class TestLoadPathTools:
             return_value=[ToolRegistration(name="path-tool", path="mypackage.tools", enabled=True)]
         )
 
-        with (
-            patch(
-                "server.app.api.dependencies.get_config_store",
-                return_value=mock_store,
-            ),
-            patch("importlib.import_module", return_value=fake_module),
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        with patch("importlib.import_module", return_value=fake_module):
+            tools = await resolver.build_tools(scope=None)
 
         assert len(tools) == 1
         assert isinstance(tools[0], BaseTool)
@@ -280,7 +257,7 @@ class TestLoadPathTools:
     @pytest.mark.asyncio
     async def test_path_import_error_is_skipped(self):
         """An ImportError on a path-based tool is skipped without crashing."""
-        from server.app.llm.deep_agent_service import _load_config_registry_tools
+        from server.app.agent.resolver import RuntimeResolver
         from server.app.storage.config_models import ToolRegistration
 
         mock_store = MagicMock()
@@ -290,11 +267,8 @@ class TestLoadPathTools:
             ]
         )
 
-        with patch(
-            "server.app.api.dependencies.get_config_store",
-            return_value=mock_store,
-        ):
-            tools = await _load_config_registry_tools(scope=None)
+        resolver = RuntimeResolver(config_store=mock_store, settings=MagicMock())
+        tools = await resolver.build_tools(scope=None)
 
         assert tools == []
 

--- a/tests/unit/test_store_wiring.py
+++ b/tests/unit/test_store_wiring.py
@@ -298,11 +298,12 @@ class TestServiceStoreWiring:
         mock_global_storage.get_session = AsyncMock(return_value=session)
 
         # The service has its own storage_backend (from create_storage_backend in __init__)
-        # We patch get_storage_backend for session lookup and patch the service's
-        # storage_backend directly for get_checkpointer and get_store
+        # We patch the service's storage_backend directly for session lookup,
+        # get_checkpointer, and get_store.
         s = MagicMock(spec=Settings)
         service = DeepAgentStreamingService(s)
         service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
         service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
         service.storage_backend.get_store = AsyncMock(return_value=mock_store)
 
@@ -327,10 +328,6 @@ class TestServiceStoreWiring:
                 "server.app.llm.deep_agent_service.create_cognition_agent",
                 new_callable=AsyncMock,
                 return_value=MagicMock(),
-            ),
-            patch(
-                "server.app.llm.deep_agent_service.get_storage_backend",
-                return_value=mock_global_storage,
             ),
         ):
             async for _ in service.stream_response(

--- a/tests/unit/test_streaming_bugs.py
+++ b/tests/unit/test_streaming_bugs.py
@@ -129,7 +129,7 @@ def _stream_patches(mock_runtime: MagicMock, session: Any = None) -> tuple:
             return_value=MagicMock(),
         ),
         patch(
-            "server.app.llm.deep_agent_service.get_storage_backend",
+            "server.app.storage.factory.create_storage_backend",
             return_value=mock_storage,
         ),
     )
@@ -170,6 +170,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="hello"), DoneEvent())
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -189,6 +193,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="world"))
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -205,6 +213,10 @@ class TestExactlyOneDoneEvent:
         session = _make_session()
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -235,6 +247,10 @@ class TestContentNotDoubled:
             DoneEvent(),
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -262,6 +278,10 @@ class TestContentNotDoubled:
             DoneEvent(),
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -293,6 +313,10 @@ class TestUsageEventModelField:
         session = _make_session(provider="mock", model=custom_model)
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(settings)
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -314,6 +338,10 @@ class TestUsageEventModelField:
         session = _make_session(provider="mock", model="gpt-4o-mini")
         mock_runtime = _make_mock_runtime(TokenEvent(content="hi"), DoneEvent())
         service = DeepAgentStreamingService(settings)
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:
@@ -337,6 +365,10 @@ class TestRuntimeErrorsSurface:
             return_value=_runtime_raises(RuntimeError("graph blew up"))
         )
         service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
 
         p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
         with p1, p2, p3, p4:


### PR DESCRIPTION
## Summary
- extract shared session/message construction and config merge helpers into `server/app/storage/common.py`
- update memory, sqlite, and postgres backends to reuse the shared helpers instead of duplicating the same logic
- add an `examples/` directory with an exhaustive `.cognition` reference example, focused variants, and sample API-managed config payloads

## Verification
- `uv run pytest tests/unit/test_message_store.py tests/unit/test_schema.py -q`
- `uv run pytest tests/unit/ -q --timeout=30`
- `uv run ruff check server/app/storage/common.py server/app/storage/memory.py server/app/storage/sqlite.py server/app/storage/postgres.py tests/unit/test_message_store.py tests/unit/test_schema.py`