### PR TITLE
docs: add exhaustive configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The CLI is one example of what you can build on Cognition. See the [Blueprints](
 | [Architecture](./docs/concepts/architecture.md) | 7-layer architecture and design principles |
 | [Extending Agents](./docs/guides/extending-agents.md) | Memory, skills, tools, subagents, and middleware |
 | [Configuration Reference](./docs/guides/configuration.md) | All YAML keys and environment variables |
+| [Examples](./examples/README.md) | Exhaustive `.cognition` examples, `.env` examples, and API payload samples |
 | [Deployment Guide](./docs/guides/deployment.md) | Docker Compose, PostgreSQL, and production hardening |
 | [API Reference](./docs/guides/api-reference.md) | Every REST endpoint and SSE event type |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,34 @@
+# Examples
+
+This directory contains reference configurations for Cognition.
+
+These examples are intentionally split by purpose:
+
+- `exhaustive-config/`: reference-complete example showing nearly every major configuration surface, including file-based `.cognition` config and sample API payloads for DB-backed config entities.
+- `minimal-config/`: smallest practical starting point.
+- `bedrock-config/`: AWS/Bedrock-oriented example.
+- `scoped-multi-tenant/`: scoping and multi-tenant configuration example.
+
+Use `exhaustive-config/` as documentation, not as a drop-in starter. It shows many options at once so you can discover the full shape of the system.
+
+## Configuration Surfaces
+
+Cognition configuration is split across three places:
+
+1. `.cognition/config.yaml`
+   - file-based project config
+   - best for stable project defaults
+
+2. Environment variables / `.env`
+   - infrastructure settings
+   - provider credentials
+   - deployment/runtime settings
+
+3. API-managed config
+   - providers
+   - agent definitions
+   - tools
+   - skills
+   - global defaults
+
+The exhaustive example includes all three so the full configuration model is visible in one place.

--- a/examples/bedrock-config/README.md
+++ b/examples/bedrock-config/README.md
@@ -1,0 +1,5 @@
+# Bedrock Config Example
+
+This example shows the most important file and environment settings for AWS Bedrock.
+
+Use `AWS_REGION`, ambient AWS credentials, or `COGNITION_BEDROCK_ROLE_ARN` for cross-account access.

--- a/examples/exhaustive-config/.env.example
+++ b/examples/exhaustive-config/.env.example
@@ -1,0 +1,95 @@
+# ----------------------------------------------------------------------------
+# Cognition environment variables
+# ----------------------------------------------------------------------------
+# This file documents the primary environment variables consumed by
+# server.app.settings.Settings and provider factories.
+#
+# Copy the values you need into your real .env file. Do not commit secrets.
+
+# ----------------------------------------------------------------------------
+# Server
+# ----------------------------------------------------------------------------
+COGNITION_HOST=127.0.0.1
+COGNITION_PORT=8000
+COGNITION_LOG_LEVEL=info
+
+# ----------------------------------------------------------------------------
+# Workspace
+# ----------------------------------------------------------------------------
+COGNITION_WORKSPACE_ROOT=.
+
+# ----------------------------------------------------------------------------
+# Provider credentials
+# ----------------------------------------------------------------------------
+OPENAI_API_KEY=
+OPENAI_API_BASE=
+
+COGNITION_OPENAI_COMPATIBLE_BASE_URL=https://openrouter.ai/api/v1
+COGNITION_OPENAI_COMPATIBLE_API_KEY=
+
+GOOGLE_API_KEY=
+
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=
+COGNITION_BEDROCK_ROLE_ARN=
+
+# ----------------------------------------------------------------------------
+# Rate limiting
+# ----------------------------------------------------------------------------
+COGNITION_RATE_LIMIT_PER_MINUTE=60
+COGNITION_RATE_LIMIT_BURST=10
+
+# ----------------------------------------------------------------------------
+# Observability
+# ----------------------------------------------------------------------------
+COGNITION_OTEL_ENABLED=false
+COGNITION_OTEL_ENDPOINT=
+COGNITION_METRICS_PORT=9090
+
+# ----------------------------------------------------------------------------
+# CORS
+# ----------------------------------------------------------------------------
+COGNITION_CORS_ORIGINS=http://localhost:3000,http://localhost:8080
+COGNITION_CORS_CREDENTIALS=true
+
+# ----------------------------------------------------------------------------
+# Persistence
+# ----------------------------------------------------------------------------
+COGNITION_PERSISTENCE_BACKEND=sqlite
+COGNITION_PERSISTENCE_URI=.cognition/state.db
+
+# ----------------------------------------------------------------------------
+# Sandbox backend
+# ----------------------------------------------------------------------------
+COGNITION_SANDBOX_BACKEND=local
+COGNITION_DOCKER_IMAGE=cognition-sandbox:latest
+COGNITION_DOCKER_NETWORK=none
+COGNITION_DOCKER_MEMORY_LIMIT=512m
+COGNITION_DOCKER_CPU_LIMIT=1.0
+
+# Kubernetes sandbox settings
+COGNITION_K8S_SANDBOX_TEMPLATE=cognition-sandbox
+COGNITION_K8S_SANDBOX_NAMESPACE=default
+COGNITION_K8S_SANDBOX_ROUTER_URL=http://sandbox-router-svc.default.svc.cluster.local:8080
+COGNITION_K8S_SANDBOX_TTL=3600
+COGNITION_K8S_SANDBOX_WARM_POOL=
+
+# ----------------------------------------------------------------------------
+# Tool blocking and scoping
+# ----------------------------------------------------------------------------
+COGNITION_BLOCKED_TOOLS=
+COGNITION_SCOPING_ENABLED=false
+COGNITION_SCOPE_KEYS=user,project
+
+# ----------------------------------------------------------------------------
+# Model catalog
+# ----------------------------------------------------------------------------
+COGNITION_MODEL_CATALOG_URL=https://models.dev/api.json
+COGNITION_MODEL_CATALOG_TTL_SECONDS=3600
+
+# ----------------------------------------------------------------------------
+# SSE
+# ----------------------------------------------------------------------------
+COGNITION_SSE_HEARTBEAT_INTERVAL_SECONDS=15.0

--- a/examples/exhaustive-config/AGENTS.md
+++ b/examples/exhaustive-config/AGENTS.md
@@ -1,0 +1,22 @@
+# Example Workspace Agent Guidance
+
+This file demonstrates the kind of project-local guidance Cognition can load by default through `agent.memory`.
+
+## Project Rules
+
+- Prefer minimal diffs over broad rewrites.
+- Run focused tests before broad test suites.
+- Treat generated files as read-only unless the task explicitly targets them.
+
+## Review Policy
+
+When asked for a review:
+- prioritize bugs and regressions
+- identify missing tests
+- call out API or schema compatibility risks first
+
+## Runtime Notes
+
+- Provider configuration may be scoped and API-managed.
+- New sessions should pick up newly registered tools automatically.
+- Use the project `.cognition/` directory as the source of truth for file-based extensions.

--- a/examples/exhaustive-config/README.md
+++ b/examples/exhaustive-config/README.md
@@ -1,0 +1,63 @@
+# Exhaustive Config Example
+
+This example is a reference-complete Cognition project layout intended to show the major configuration surfaces in one place.
+
+It is not meant to be copied unchanged into production. Instead, use it to answer questions like:
+
+- What can go in `.cognition/config.yaml`?
+- Which settings belong in `.env` instead?
+- What does a file-based agent look like?
+- How are skills, tools, and middleware laid out?
+- Which config entities are API-managed instead of file-managed?
+
+## Included Sections
+
+- `.cognition/config.yaml`
+  - project-level file config
+  - agent defaults
+  - provider bootstrap config
+  - infrastructure settings that can live in YAML
+
+- `.env.example`
+  - all important infrastructure and credential environment variables from `server.app.settings.Settings`
+
+- `.cognition/agents/`
+  - YAML and Markdown agent examples
+
+- `.cognition/skills/`
+  - a sample skill with real structure
+
+- `.cognition/tools/`
+  - a file-based tool example
+
+- `.cognition/middleware/`
+  - a custom middleware scaffold
+
+- `api/`
+  - sample request payloads for API-managed config entities
+
+## Precedence Model
+
+Configuration precedence is:
+
+1. built-in defaults
+2. `~/.cognition/config.yaml`
+3. project `.cognition/config.yaml`
+4. environment variables
+5. API-managed registry/config-store entities where applicable
+
+## Important Note
+
+Not everything in Cognition should be configured through files anymore.
+
+File configuration is best for:
+- project defaults
+- checked-in examples
+- initial provider bootstrap
+- file-based agents/skills/tools/middleware
+
+API-managed configuration is best for:
+- user- or project-scoped provider configs
+- dynamic tools and skills
+- global provider and agent defaults
+- programmatic builder/UIs

--- a/examples/exhaustive-config/api/agent-create.json
+++ b/examples/exhaustive-config/api/agent-create.json
@@ -1,0 +1,34 @@
+{
+  "name": "release-assistant",
+  "system_prompt": "You prepare release notes, changelogs, and rollout checklists.",
+  "description": "Release-focused assistant",
+  "mode": "primary",
+  "hidden": false,
+  "tools": [
+    ".cognition/tools/repo_health.py"
+  ],
+  "skills": [
+    ".cognition/skills/"
+  ],
+  "memory": [
+    "AGENTS.md"
+  ],
+  "interrupt_on": {
+    "execute": true
+  },
+  "response_format": null,
+  "model": "google/gemini-3-flash-preview",
+  "temperature": 0.2,
+  "max_tokens": 3000,
+  "recursion_limit": 300,
+  "tool_token_limit_before_evict": 8000,
+  "provider": "openai_compatible",
+  "timeout_seconds": 60,
+  "middleware": [
+    {
+      "name": "tool_retry",
+      "max_retries": 2
+    }
+  ],
+  "scope": {}
+}

--- a/examples/exhaustive-config/api/global-agent-defaults-patch.json
+++ b/examples/exhaustive-config/api/global-agent-defaults-patch.json
@@ -1,0 +1,16 @@
+{
+  "memory": [
+    "AGENTS.md"
+  ],
+  "skills": [
+    ".cognition/skills/"
+  ],
+  "subagents": [],
+  "interrupt_on": {
+    "execute": true
+  },
+  "response_format": null,
+  "tool_token_limit_before_evict": 10000,
+  "recursion_limit": 1000,
+  "mcp_servers": {}
+}

--- a/examples/exhaustive-config/api/global-provider-defaults-patch.json
+++ b/examples/exhaustive-config/api/global-provider-defaults-patch.json
@@ -1,0 +1,7 @@
+{
+  "provider": "openai_compatible",
+  "model": "google/gemini-3-flash-preview",
+  "max_tokens": 4000,
+  "system_prompt_type": "file",
+  "system_prompt_value": "system"
+}

--- a/examples/exhaustive-config/api/provider-create.json
+++ b/examples/exhaustive-config/api/provider-create.json
@@ -1,0 +1,18 @@
+{
+  "id": "openrouter-primary",
+  "provider": "openai_compatible",
+  "model": "google/gemini-3-flash-preview",
+  "display_name": "OpenRouter Gemini 3 Flash",
+  "enabled": true,
+  "priority": 0,
+  "max_retries": 2,
+  "timeout": 60,
+  "api_key_env": "COGNITION_OPENAI_COMPATIBLE_API_KEY",
+  "base_url": "https://openrouter.ai/api/v1",
+  "region": null,
+  "role_arn": null,
+  "extra": {
+    "routing": "balanced"
+  },
+  "scope": {}
+}

--- a/examples/exhaustive-config/api/skill-create.json
+++ b/examples/exhaustive-config/api/skill-create.json
@@ -1,0 +1,7 @@
+{
+  "name": "release-process",
+  "enabled": true,
+  "description": "Release checklist and rollout skill",
+  "content": "---\nname: release-process\ndescription: Release process guidance\n---\n\n# Release Process\n\n- Verify CI\n- Draft release notes\n- Confirm rollback plan\n",
+  "scope": {}
+}

--- a/examples/exhaustive-config/api/tool-create.json
+++ b/examples/exhaustive-config/api/tool-create.json
@@ -1,0 +1,8 @@
+{
+  "name": "release_summary",
+  "code": "from langchain_core.tools import tool\n\n@tool\ndef release_summary() -> str:\n    \"\"\"Return a short release summary.\"\"\"\n    return \"Release notes draft ready.\"\n",
+  "enabled": true,
+  "description": "Example API-registered tool",
+  "interrupt_on": false,
+  "scope": {}
+}

--- a/examples/minimal-config/README.md
+++ b/examples/minimal-config/README.md
@@ -1,0 +1,5 @@
+# Minimal Config Example
+
+This is the smallest practical project-level Cognition example.
+
+Use this when you want a simple starting point instead of the exhaustive reference example.

--- a/examples/scoped-multi-tenant/README.md
+++ b/examples/scoped-multi-tenant/README.md
@@ -1,0 +1,12 @@
+# Scoped Multi-Tenant Example
+
+This example shows the settings and payload patterns used for scoped, multi-tenant deployments.
+
+Typical request headers:
+
+```http
+X-Cognition-Scope-User: alice
+X-Cognition-Scope-Project: gateway
+```
+
+If `COGNITION_SCOPE_KEYS` includes additional values, Cognition expects corresponding headers.


### PR DESCRIPTION
## Summary
- add an `examples/` directory with a reference-complete `.cognition` example
- include focused example variants for minimal, Bedrock, and scoped multi-tenant setups
- include sample API payloads for API-managed configuration entities and link the examples from the top-level README

## Verification
- documentation/content-only change
- verified repository paths and example structure locally