### PR TITLE
chore: centralize version source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.8.0] — 2026-04-13
+
+### Highlights
+
+- Completed the architecture-deepening cleanup train, substantially simplifying Cognition's configuration, runtime, and storage architecture.
+
+### Architecture and Runtime
+
+- Completed the architecture-deepening RFC and follow-up cleanup train.
+- Unified scoping across API routes.
+- Removed dead `ConfigRegistry` globals.
+- Collapsed agent definition management into `DefaultConfigStore`.
+- Removed the `AgentRegistry` runtime.
+- Simplified runtime resolution and removed deprecated streaming shims.
+- Deduplicated shared storage backend logic across memory, SQLite, and PostgreSQL backends.
+
+### Dependencies
+
+- Refreshed core runtime and framework dependencies, including Deep Agents, FastAPI, Starlette, LangGraph, LangChain, OpenAI, Typer, Rich, Uvicorn, and WebSockets.
+- Updated the lockfile and aligned runtime/test seams with the refreshed dependency set.
+
+### Documentation and Examples
+
+- Added a new `examples/` directory.
+- Added an exhaustive `.cognition` reference example.
+- Added focused examples for minimal, Bedrock, and scoped multi-tenant setups.
+- Added sample API payloads for API-managed configuration entities.
+
+### Merged PRs
+
+- `#85` Complete architecture-deepening RFC and refresh core dependencies
+- `#86` refactor: unify scoping API across all routes
+- `#87` refactor: remove dead config registry globals
+- `#88` refactor: collapse agent definition registry into config store
+- `#89` refactor: remove agent registry runtime
+- `#90` refactor: simplify runtime resolution and remove streaming shims
+- `#91` refactor: deduplicate shared storage backend logic and add config examples
+- `#97` docs: add exhaustive configuration examples
+
+### Deferred Follow-up RFCs
+
+Remaining optional architectural follow-ups were captured as issues:
+
+- `#92` extract message send/resume workflow from API routes
+- `#93` extract runtime execution plan from `DeepAgentStreamingService`
+- `#94` separate unit and e2e fixture wiring
+- `#95` remove legacy provider tuple compatibility from `RuntimeResolver`
+- `#96` replace `api.dependencies` globals with a single DI strategy
+
 ## [0.7.0] — 2026-04-11
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognition"
-version = "0.6.2"
+version = "0.8.0"
 description = "Local AI coding assistant built on LangGraph Deep Agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognition"
-version = "0.8.0"
+dynamic = ["version"]
 description = "Local AI coding assistant built on LangGraph Deep Agents"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -115,6 +115,9 @@ langchain-k8s-sandbox = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["server", "client", "shared", "packages"]
+
+[tool.hatch.version]
+path = "server/version.py"
 
 [tool.ruff]
 target-version = "py311"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,3 +1,5 @@
 """Cognition server package."""
 
-__version__ = "0.1.0"
+from server.version import VERSION
+
+__version__ = VERSION

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -33,6 +33,7 @@ from server.app.settings import get_settings
 from server.app.storage import create_storage_backend
 from server.app.storage.backend import StorageBackend
 from server.app.storage.config_store import DefaultConfigStore, set_default_config_store
+from server.version import VERSION
 
 logger = structlog.get_logger(__name__)
 
@@ -190,7 +191,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="Cognition",
     description="AI-powered coding assistant",
-    version="0.5.0",
+    version=VERSION,
     lifespan=lifespan,
 )
 
@@ -225,7 +226,7 @@ async def health_check(
 
     return HealthStatus(
         status="healthy",
-        version="0.5.0",
+        version=VERSION,
         active_sessions=len(sessions_list),
         circuit_breakers=[],
         timestamp=datetime.now(UTC),

--- a/server/version.py
+++ b/server/version.py
@@ -1,0 +1,7 @@
+"""Central version information for Cognition."""
+
+from __future__ import annotations
+
+VERSION = "0.8.0"
+
+__all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add a central `server/version.py` module as the single source of truth for Cognition's version
- update `server.__version__`, FastAPI app metadata, and `/health` to read from that shared version
- switch `pyproject.toml` to dynamic versioning via Hatch so package metadata also reads from the same source

## Verification
- `uv run python -c "from server.version import VERSION; print(VERSION)"`
- `uv run python -c "import importlib.metadata; print(importlib.metadata.version('cognition'))"`
- `uv run ruff check server/version.py server/__init__.py server/app/main.py`