### PR TITLE
fix postgres-backed agent startup and streaming

### DIFF
--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -750,6 +750,7 @@ class DeepAgentRuntime:
             )
 
         except Exception as e:
+            logger.error("DeepAgentRuntime stream failed", error=str(e), exc_info=True)
             yield ErrorEvent(message=str(e), code="RUNTIME_ERROR")
 
     async def ainvoke(

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -228,7 +228,7 @@ async def agent_event_stream(
                 yield EventBuilder.error(event.message, code=event.code)
 
     except Exception as e:
-        logger.error("Agent streaming error", error=str(e), session_id=session_id)
+        logger.error("Agent streaming error", error=str(e), session_id=session_id, exc_info=True)
         yield EventBuilder.error(str(e), code="AGENT_ERROR")
 
 

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -651,13 +651,25 @@ class SessionAgentManager:
     Tracks active streaming operations for abort functionality.
     """
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        storage_backend: Any | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
+        config_store: ConfigStore | None = None,
+    ) -> None:
         """Initialize the session manager.
 
         Args:
             settings: Application settings.
+            storage_backend: Initialized storage backend shared with the app lifespan.
+            runtime_resolver: Shared runtime resolver instance.
+            config_store: Shared config store instance.
         """
         self.settings = settings
+        self._storage_backend = storage_backend
+        self._runtime_resolver = runtime_resolver
+        self._config_store = config_store
         self._services: dict[str, DeepAgentStreamingService] = {}
         self._project_paths: dict[str, str] = {}
         self._active_runtimes: dict[str, Any] = {}
@@ -677,7 +689,13 @@ class SessionAgentManager:
         Returns:
             Configured DeepAgentStreamingService for the session.
         """
-        service = DeepAgentStreamingService(settings=self.settings)
+        service = DeepAgentStreamingService(
+            settings=self.settings,
+            runtime_resolver=self._runtime_resolver,
+            config_store=self._config_store,
+        )
+        if self._storage_backend is not None:
+            service.storage_backend = self._storage_backend
         self._services[session_id] = service
         self._project_paths[session_id] = project_path
         logger.info(

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -100,7 +100,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize SessionAgentManager for DI
     from server.app.llm.deep_agent_service import SessionAgentManager
 
-    session_agent_manager = SessionAgentManager(settings)
+    session_agent_manager = SessionAgentManager(
+        settings,
+        storage_backend=storage_backend,
+        runtime_resolver=runtime_resolver,
+        config_store=config_store,
+    )
     set_session_agent_manager_dep(session_agent_manager)
     logger.info("SessionAgentManager initialized")
 

--- a/server/app/storage/config_dispatcher.py
+++ b/server/app/storage/config_dispatcher.py
@@ -39,10 +39,12 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
+
+import psycopg
+from psycopg.rows import dict_row
 
 from server.app.storage.config_models import ConfigChangeEvent
 from server.app.storage.config_registry import _scope_from_json
@@ -147,7 +149,7 @@ class InProcessDispatcher:
 class PostgresListenDispatcher:
     """Cross-instance invalidation via PostgreSQL LISTEN/NOTIFY.
 
-    Maintains a persistent asyncpg connection subscribed to
+    Maintains a persistent psycopg connection subscribed to
     "cognition_config_changes". When a NOTIFY arrives, it queries
     `config_changes` for unprocessed rows since the last poll and
     dispatches a ConfigChangeEvent for each.
@@ -156,7 +158,7 @@ class PostgresListenDispatcher:
     idle-connection timeouts on proxied Postgres deployments (e.g. RDS).
 
     Args:
-        dsn: asyncpg-compatible DSN string.
+        dsn: PostgreSQL DSN string.
         poll_batch_size: Max rows to process per NOTIFY wake-up.
         keepalive_interval: Seconds between ping queries (default 30).
     """
@@ -171,7 +173,7 @@ class PostgresListenDispatcher:
         self._poll_batch_size = poll_batch_size
         self._keepalive_interval = keepalive_interval
         self._subscribers: list[Subscriber] = []
-        self._conn: Any = None  # asyncpg.Connection
+        self._conn: psycopg.AsyncConnection[dict[str, Any]] | None = None
         self._listen_task: asyncio.Task[None] | None = None
         self._running = False
 
@@ -198,26 +200,15 @@ class PostgresListenDispatcher:
 
     async def start(self) -> None:
         """Connect to Postgres and start LISTEN loop."""
-        import asyncpg
-
         self._running = True
-        self._conn = await asyncpg.connect(self._dsn)
-        # asyncpg does not auto-decode JSONB/JSON — register codecs so that
-        # the scope column (jsonb) comes back as a Python dict, not a string.
-        await self._conn.set_type_codec(
-            "jsonb",
-            encoder=json.dumps,
-            decoder=json.loads,
-            schema="pg_catalog",
+        self._conn = await psycopg.AsyncConnection.connect(
+            self._dsn,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
         )
-        await self._conn.set_type_codec(
-            "json",
-            encoder=json.dumps,
-            decoder=json.loads,
-            schema="pg_catalog",
-        )
-        await self._conn.add_listener("cognition_config_changes", self._on_notify)
-        self._listen_task = asyncio.create_task(self._keepalive_loop())
+        await self._conn.execute("LISTEN cognition_config_changes")
+        self._listen_task = asyncio.create_task(self._listen_loop())
         logger.info("PostgresListenDispatcher started LISTEN on cognition_config_changes")
 
     async def stop(self) -> None:
@@ -231,49 +222,35 @@ class PostgresListenDispatcher:
                 pass
         if self._conn is not None:
             try:
-                await self._conn.remove_listener("cognition_config_changes", self._on_notify)
+                await self._conn.execute("UNLISTEN cognition_config_changes")
                 await self._conn.close()
             except Exception:
                 pass
             self._conn = None
         logger.info("PostgresListenDispatcher stopped")
 
-    def _on_notify(
-        self,
-        conn: Any,
-        pid: int,
-        channel: str,
-        payload: str,
-    ) -> None:
-        """Called by asyncpg when a NOTIFY arrives. Schedule async processing."""
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(self._process_pending())
-        except RuntimeError:
-            pass
-
     async def _process_pending(self) -> None:
         """Query config_changes for unprocessed rows and dispatch events."""
         if self._conn is None:
             return
         try:
-            rows = await self._conn.fetch(
+            rows = await self._conn.execute(
                 """
                 SELECT id, entity_type, name, scope, operation
                 FROM config_changes
                 WHERE processed = false
                 ORDER BY changed_at ASC
-                LIMIT $1
+                LIMIT %s
                 """,
-                self._poll_batch_size,
+                (self._poll_batch_size,),
             )
-            if not rows:
+            records = await rows.fetchall()
+            if not records:
                 return
 
-            change_ids = [row["id"] for row in rows]
+            change_ids = [row["id"] for row in records]
 
-            for row in rows:
+            for row in records:
                 event = ConfigChangeEvent(
                     entity_type=row["entity_type"],
                     name=row["name"],
@@ -282,25 +259,31 @@ class PostgresListenDispatcher:
                 )
                 await self.emit(event)
 
-            # Mark rows processed
             await self._conn.execute(
-                "UPDATE config_changes SET processed = true WHERE id = ANY($1::int[])",
-                change_ids,
+                "UPDATE config_changes SET processed = true WHERE id = ANY(%s::int[])",
+                (change_ids,),
             )
         except Exception:
             logger.exception("PostgresListenDispatcher._process_pending failed")
 
-    async def _keepalive_loop(self) -> None:
-        """Periodically ping Postgres to keep the connection alive."""
+    async def _listen_loop(self) -> None:
+        """Process LISTEN/NOTIFY events on a dedicated psycopg connection."""
+        if self._conn is None:
+            return
+
         while self._running:
             try:
-                await asyncio.sleep(self._keepalive_interval)
-                if self._conn is not None:
+                async for _notify in self._conn.notifies(
+                    timeout=self._keepalive_interval, stop_after=1
+                ):
+                    await self._process_pending()
+                    break
+                else:
                     await self._conn.execute("SELECT 1")
             except asyncio.CancelledError:
                 break
             except Exception:
-                logger.warning("PostgresListenDispatcher keepalive ping failed")
+                logger.warning("PostgresListenDispatcher listen loop failed")
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/storage/config_registry.py
+++ b/server/app/storage/config_registry.py
@@ -24,13 +24,19 @@ every mutating operation so the dispatcher can pick up the event.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
 from typing import Any, Protocol, runtime_checkable
 
 import aiosqlite
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+from psycopg_pool import AsyncConnectionPool
 
+from server.app.agent.definition import AgentDefinition
 from server.app.storage.config_models import (
     ConfigChange,
     EntityType,
@@ -142,6 +148,10 @@ class ConfigRegistry(Protocol):
         self, name: str, scope: dict[str, str] | None = None
     ) -> dict[str, Any] | None:
         """Return the best-matching agent definition dict, or None."""
+        ...
+
+    async def list_agents(self, scope: dict[str, str] | None = None) -> list[AgentDefinition]:
+        """List all agent definitions visible in the given scope."""
         ...
 
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
@@ -573,6 +583,10 @@ class SqliteConfigRegistry:
     ) -> dict[str, Any] | None:
         return await self._get_entity("agent", name, scope)
 
+    async def list_agents(self, scope: dict[str, str] | None = None) -> list[AgentDefinition]:
+        rows = await self._list_entities("agent", scope)
+        return [AgentDefinition.model_validate(r) for r in rows]
+
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
         return await self._delete_entity("agent", name, scope)
 
@@ -714,44 +728,61 @@ class SqliteConfigRegistry:
 
 
 class PostgresConfigRegistry:
-    """Postgres implementation of ConfigRegistry using asyncpg.
+    """Postgres implementation of ConfigRegistry using psycopg pool.
 
     Args:
-        dsn: asyncpg-compatible connection string
+        dsn: Postgres connection string
              (e.g. "postgresql://user:pass@host/db").
     """
 
     def __init__(self, dsn: str) -> None:
         self._dsn = dsn
-        self._pool: Any = None  # asyncpg.Pool
+        self._pool: AsyncConnectionPool[psycopg.AsyncConnection[dict[str, Any]]] | None = None
+        self._pool_lock = asyncio.Lock()
 
-    async def _get_pool(self) -> Any:
+    async def _get_pool(self) -> AsyncConnectionPool[psycopg.AsyncConnection[dict[str, Any]]]:
         if self._pool is None:
-            import asyncpg
-
-            async def _init_conn(conn: Any) -> None:
-                # asyncpg does not decode JSONB/JSON to Python objects by default.
-                # Register codecs so all json/jsonb columns come back as dicts/lists.
-                await conn.set_type_codec(
-                    "jsonb",
-                    encoder=json.dumps,
-                    decoder=json.loads,
-                    schema="pg_catalog",
-                )
-                await conn.set_type_codec(
-                    "json",
-                    encoder=json.dumps,
-                    decoder=json.loads,
-                    schema="pg_catalog",
-                )
-
-            self._pool = await asyncpg.create_pool(self._dsn, init=_init_conn)
+            async with self._pool_lock:
+                if self._pool is None:
+                    self._pool = AsyncConnectionPool(
+                        self._dsn,
+                        open=False,
+                        min_size=1,
+                        kwargs={
+                            "autocommit": True,
+                            "prepare_threshold": 0,
+                            "row_factory": dict_row,
+                        },
+                    )
+                    await self._pool.open()
         return self._pool
 
     async def close(self) -> None:
         if self._pool is not None:
             await self._pool.close()
             self._pool = None
+
+    @staticmethod
+    def _serialize_scope(scope: dict[str, str]) -> Json:
+        return Json(scope)
+
+    @staticmethod
+    def _serialize_definition(definition: dict[str, Any]) -> Json:
+        return Json(definition)
+
+    @staticmethod
+    async def _fetch_all(
+        conn: psycopg.AsyncConnection[dict[str, Any]], query: str, params: tuple[Any, ...]
+    ) -> list[dict[str, Any]]:
+        cursor = await conn.execute(query, params)
+        return list(await cursor.fetchall())
+
+    @staticmethod
+    async def _fetch_one(
+        conn: psycopg.AsyncConnection[dict[str, Any]], query: str, params: tuple[Any, ...]
+    ) -> dict[str, Any] | None:
+        cursor = await conn.execute(query, params)
+        return await cursor.fetchone()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -766,25 +797,26 @@ class PostgresConfigRegistry:
         source: str,
     ) -> None:
         pool = await self._get_pool()
-        scope_json = json.dumps(scope, sort_keys=True)
-        def_json = json.dumps(definition)
         now = datetime.now(UTC)
-        async with pool.acquire() as conn:
+        async with pool.connection() as conn:
             await conn.execute(
                 """
                 INSERT INTO config_entities (entity_type, name, scope, definition, source, created_at, updated_at)
-                VALUES ($1, $2, $3::jsonb, $4::jsonb, $5, $6, $6)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (entity_type, name, scope)
                 DO UPDATE SET definition=EXCLUDED.definition,
                               source=EXCLUDED.source,
                               updated_at=EXCLUDED.updated_at
                 """,
-                entity_type,
-                name,
-                scope_json,
-                def_json,
-                source,
-                now,
+                (
+                    entity_type,
+                    name,
+                    self._serialize_scope(scope),
+                    self._serialize_definition(definition),
+                    source,
+                    now,
+                    now,
+                ),
             )
             await self._record_change(conn, entity_type, name, scope, "upsert")
 
@@ -792,13 +824,10 @@ class PostgresConfigRegistry:
         self, entity_type: str, name: str, scope: dict[str, str] | None
     ) -> bool:
         pool = await self._get_pool()
-        scope_json = json.dumps(scope or {}, sort_keys=True)
-        async with pool.acquire() as conn:
+        async with pool.connection() as conn:
             result = await conn.execute(
-                "DELETE FROM config_entities WHERE entity_type=$1 AND name=$2 AND scope=$3::jsonb",
-                entity_type,
-                name,
-                scope_json,
+                "DELETE FROM config_entities WHERE entity_type=%s AND name=%s AND scope=%s",
+                (entity_type, name, self._serialize_scope(scope or {})),
             )
             deleted = bool(result != "DELETE 0")
             if deleted:
@@ -813,11 +842,11 @@ class PostgresConfigRegistry:
     ) -> dict[str, Any] | None:
         target_scope = scope or {}
         pool = await self._get_pool()
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(
-                "SELECT scope, definition FROM config_entities WHERE entity_type=$1 AND name=$2",
-                entity_type,
-                name,
+        async with pool.connection() as conn:
+            rows = await self._fetch_all(
+                conn,
+                "SELECT scope, definition FROM config_entities WHERE entity_type=%s AND name=%s",
+                (entity_type, name),
             )
         if not rows:
             return None
@@ -839,10 +868,11 @@ class PostgresConfigRegistry:
     ) -> list[dict[str, Any]]:
         target_scope = scope or {}
         pool = await self._get_pool()
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(
-                "SELECT name, scope, definition FROM config_entities WHERE entity_type=$1",
-                entity_type,
+        async with pool.connection() as conn:
+            rows = await self._fetch_all(
+                conn,
+                "SELECT name, scope, definition FROM config_entities WHERE entity_type=%s",
+                (entity_type,),
             )
         best_by_name: dict[str, tuple[int, dict[str, Any]]] = {}
         for row in rows:
@@ -863,18 +893,13 @@ class PostgresConfigRegistry:
         scope: dict[str, str],
         operation: str,
     ) -> None:
-        scope_json = json.dumps(scope, sort_keys=True)
         now = datetime.now(UTC)
         await conn.execute(
             """
             INSERT INTO config_changes (entity_type, name, scope, operation, changed_at, processed)
-            VALUES ($1, $2, $3::jsonb, $4, $5, false)
+            VALUES (%s, %s, %s, %s, %s, false)
             """,
-            entity_type,
-            name,
-            scope_json,
-            operation,
-            now,
+            (entity_type, name, self._serialize_scope(scope), operation, now),
         )
         # NOTIFY for cross-instance invalidation
         await conn.execute("NOTIFY cognition_config_changes")
@@ -959,6 +984,10 @@ class PostgresConfigRegistry:
     ) -> dict[str, Any] | None:
         return await self._get_entity("agent", name, scope)
 
+    async def list_agents(self, scope: dict[str, str] | None = None) -> list[AgentDefinition]:
+        rows = await self._list_entities("agent", scope)
+        return [AgentDefinition.model_validate(r) for r in rows]
+
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
         return await self._delete_entity("agent", name, scope)
 
@@ -1023,29 +1052,29 @@ class PostgresConfigRegistry:
         source: str = "file",
     ) -> bool:
         pool = await self._get_pool()
-        scope_json = json.dumps(scope, sort_keys=True)
-        def_json = json.dumps(definition)
         now = datetime.now(UTC)
-        async with pool.acquire() as conn:
-            existing = await conn.fetchrow(
-                "SELECT id FROM config_entities WHERE entity_type=$1 AND name=$2 AND scope=$3::jsonb",
-                entity_type,
-                name,
-                scope_json,
+        async with pool.connection() as conn:
+            existing = await self._fetch_one(
+                conn,
+                "SELECT id FROM config_entities WHERE entity_type=%s AND name=%s AND scope=%s",
+                (entity_type, name, self._serialize_scope(scope)),
             )
             if existing:
                 return False
             await conn.execute(
                 """
                 INSERT INTO config_entities (entity_type, name, scope, definition, source, created_at, updated_at)
-                VALUES ($1, $2, $3::jsonb, $4::jsonb, $5, $6, $6)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
-                entity_type,
-                name,
-                scope_json,
-                def_json,
-                source,
-                now,
+                (
+                    entity_type,
+                    name,
+                    self._serialize_scope(scope),
+                    self._serialize_definition(definition),
+                    source,
+                    now,
+                    now,
+                ),
             )
             await self._record_change(conn, entity_type, name, scope, "upsert")
         return True
@@ -1056,11 +1085,12 @@ class PostgresConfigRegistry:
 
     async def get_changes_since(self, since: datetime) -> list[ConfigChange]:
         pool = await self._get_pool()
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(
+        async with pool.connection() as conn:
+            rows = await self._fetch_all(
+                conn,
                 "SELECT id, entity_type, name, scope, operation, changed_at "
-                "FROM config_changes WHERE changed_at > $1 ORDER BY changed_at ASC",
-                since,
+                "FROM config_changes WHERE changed_at > %s ORDER BY changed_at ASC",
+                (since,),
             )
         result = []
         for row in rows:
@@ -1080,10 +1110,10 @@ class PostgresConfigRegistry:
         if not change_ids:
             return
         pool = await self._get_pool()
-        async with pool.acquire() as conn:
+        async with pool.connection() as conn:
             await conn.execute(
-                "UPDATE config_changes SET processed=true WHERE id = ANY($1::int[])",
-                change_ids,
+                "UPDATE config_changes SET processed=true WHERE id = ANY(%s::int[])",
+                (change_ids,),
             )
 
 
@@ -1232,6 +1262,9 @@ class MemoryConfigRegistry:
         self, name: str, scope: dict[str, str] | None = None
     ) -> dict[str, Any] | None:
         return self._get_entity("agent", name, scope)
+
+    async def list_agents(self, scope: dict[str, str] | None = None) -> list[AgentDefinition]:
+        return [AgentDefinition.model_validate(r) for r in self._list_entities("agent", scope)]
 
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
         return self._delete("agent", name, scope)

--- a/server/app/storage/postgres.py
+++ b/server/app/storage/postgres.py
@@ -19,6 +19,7 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.base import BaseStore
 from langgraph.store.postgres.aio import AsyncPostgresStore
+from psycopg_pool import AsyncConnectionPool
 
 from server.app.models import Message, Session, SessionConfig, SessionStatus, ToolCall
 from server.app.storage.backend import StorageBackend
@@ -65,6 +66,7 @@ class PostgresStorageBackend:
 
         # Store state (LangGraph cross-thread memory)
         self._store: AsyncPostgresStore | None = None
+        self._store_context: Any | None = None
 
         logger.debug(
             "PostgresStorageBackend initialized",
@@ -593,33 +595,34 @@ class PostgresStorageBackend:
         if self._checkpointer:
             return self._checkpointer
 
-        # AsyncPostgresSaver requires psycopg, not asyncpg
-        # Create a psycopg connection for the checkpointer
-        # Convert asyncpg connection string to psycopg format
         conn_string = self.connection_string.replace("postgresql+asyncpg://", "postgresql://")
 
-        # Create async psycopg connection
-        # autocommit=True is required for AsyncPostgresSaver.setup() to work properly
-        # Without it, CREATE INDEX CONCURRENTLY fails inside transaction block
-        conn = await psycopg.AsyncConnection.connect(
+        pool = AsyncConnectionPool(
             conn_string,
-            row_factory=psycopg.rows.dict_row,
-            autocommit=True,
+            open=False,
+            min_size=1,
+            max_size=self.max_pool_size,
+            kwargs={
+                "autocommit": True,
+                "prepare_threshold": 0,
+                "row_factory": psycopg.rows.dict_row,
+            },
         )
-
-        # Create the saver with the connection
-        self._checkpointer = AsyncPostgresSaver(conn)
+        await pool.open()
+        self._checkpointer_context = pool
+        self._checkpointer = AsyncPostgresSaver(pool)
         await self._checkpointer.setup()
 
         return self._checkpointer
 
     async def close_checkpointer(self) -> None:
         """Close the checkpointer connection."""
-        if self._checkpointer:
+        if self._checkpointer_context:
             try:
-                await self._checkpointer.conn.close()
+                await self._checkpointer_context.close()
             except Exception:
                 pass  # Ignore errors during cleanup
+            self._checkpointer_context = None
             self._checkpointer = None
 
     async def get_store(self) -> BaseStore | None:
@@ -627,27 +630,32 @@ class PostgresStorageBackend:
         if self._store:
             return self._store
 
-        import psycopg
-
         conn_string = self.connection_string.replace("postgresql+asyncpg://", "postgresql://")
-        conn = await psycopg.AsyncConnection.connect(
+        pool = AsyncConnectionPool(
             conn_string,
-            row_factory=psycopg.rows.dict_row,
-            autocommit=True,
+            open=False,
+            min_size=1,
+            max_size=self.max_pool_size,
+            kwargs={
+                "autocommit": True,
+                "prepare_threshold": 0,
+                "row_factory": psycopg.rows.dict_row,
+            },
         )
-        store = AsyncPostgresStore(conn)  # type: ignore[arg-type]
-        await store.setup()
-        self._store = store
+        await pool.open()
+        self._store_context = pool
+        self._store = AsyncPostgresStore(pool)
+        await self._store.setup()
         return self._store
 
     async def close_store(self) -> None:
         """Close the store connection."""
-        if self._store:
+        if self._store_context:
             try:
-                if hasattr(self._store, "conn"):
-                    await self._store.conn.close()  # type: ignore[union-attr]
+                await self._store_context.close()
             except Exception:
                 pass
+            self._store_context = None
             self._store = None
 
     # Health check


### PR DESCRIPTION
## Summary
- switch Postgres config registry and config change dispatching to psycopg so DB-backed skill discovery no longer trips asyncpg concurrency errors
- share the initialized storage, runtime resolver, and config store with per-session streaming services and use pooled psycopg LangGraph store/checkpointer connections
- add fuller streaming error logging to make future runtime failures easier to diagnose

## Testing
- uv run pytest tests/unit/test_store_wiring.py tests/unit/test_streaming_bugs.py -q
- docker compose build cognition && docker compose up -d cognition
- POST /sessions and POST /sessions/{id}/messages with a hello message against the docker-compose stack