### PR TITLE
fix provider bootstrap and otel startup

### DIFF
--- a/Dockerfile.k8sandbox
+++ b/Dockerfile.k8sandbox
@@ -1,0 +1,175 @@
+# Cognition K8s sandbox image
+#
+# Extends the base Cognition sandbox (Dockerfile.sandbox) with:
+#   - gh CLI for GitHub operations (clone, PR create, issue ops)
+#   - Node.js LTS + npm for JS/Node app development
+#   - agent-sandbox HTTP runtime server on port 8888
+#
+# The runtime server implements the k8s-agent-sandbox SDK protocol:
+#   POST /execute   - run a shell command, returns stdout/stderr/exit_code
+#   POST /upload    - upload a file into the sandbox workspace
+#   GET  /download  - download a file from the sandbox workspace
+#   GET  /list      - list a directory
+#   GET  /exists    - check if a path exists
+#
+# Workspace is /home/cognition (emptyDir mount from SandboxTemplate).
+# COGNITION_WORKSPACE_ROOT=/home/cognition is set in the SandboxTemplate env.
+#
+# Build:
+#   docker buildx build --platform linux/amd64 \
+#     -f Dockerfile.k8sandbox \
+#     -t ghcr.io/cognicellai/cognition-k8sandbox:test-k8s-runtime --push .
+
+ARG VERSION=dev
+ARG BUILD_DATE
+ARG VCS_REF
+ARG GH_CLI_VERSION=2.66.1
+ARG NODE_MAJOR=22
+
+FROM python:3.11-slim
+
+LABEL org.opencontainers.image.title="Cognition K8s Sandbox"
+LABEL org.opencontainers.image.description="K8s sandbox runtime for Cognition agent sessions"
+LABEL org.opencontainers.image.source="https://github.com/CognicellAI/Cognition"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# ── System packages ───────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gnupg \
+    jq \
+    make \
+    tree \
+    ripgrep \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── gh CLI ────────────────────────────────────────────────────────────────────
+ARG GH_CLI_VERSION
+RUN curl -fsSL \
+    "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=2 \
+    "gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" \
+    && gh --version
+
+# ── Node.js LTS ───────────────────────────────────────────────────────────────
+ARG NODE_MAJOR
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version && npm --version
+
+# ── Python dev tools + runtime server deps ────────────────────────────────────
+RUN pip install --no-cache-dir \
+    fastapi \
+    "uvicorn[standard]" \
+    python-multipart \
+    ruff \
+    mypy \
+    pytest \
+    black \
+    uv
+
+# ── Non-root user ─────────────────────────────────────────────────────────────
+RUN groupadd -r sandbox && useradd -r -g sandbox -u 1000 -m sandbox
+
+# ── Directories: workspace + tmp must be writable (readOnlyRootFilesystem=true)
+RUN mkdir -p /home/cognition /tmp /app && chown sandbox:sandbox /home/cognition /tmp /app
+
+# ── Runtime server ────────────────────────────────────────────────────────────
+# Implements the agent-sandbox HTTP protocol the k8s-agent-sandbox SDK calls.
+# All commands run via sh -c so shell features (pipes, redirects) work correctly.
+RUN cat > /app/runtime_server.py << 'PYEOF'
+import os
+import subprocess
+import urllib.parse
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+WORKSPACE = os.environ.get("COGNITION_WORKSPACE_ROOT", "/home/cognition")
+
+class ExecuteRequest(BaseModel):
+    command: str
+
+class ExecuteResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
+
+app = FastAPI(title="Cognition K8s Sandbox Runtime", version="1.0.0")
+
+@app.get("/")
+async def health():
+    return {"status": "ok", "workspace": WORKSPACE}
+
+@app.post("/execute", response_model=ExecuteResponse)
+async def execute(req: ExecuteRequest):
+    try:
+        p = subprocess.run(
+            ["sh", "-c", req.command],
+            capture_output=True, text=True, cwd=WORKSPACE,
+            env={**os.environ, "HOME": "/home/sandbox", "COGNITION_WORKSPACE_ROOT": WORKSPACE},
+        )
+        return ExecuteResponse(stdout=p.stdout, stderr=p.stderr, exit_code=p.returncode)
+    except Exception as e:
+        return ExecuteResponse(stdout="", stderr=str(e), exit_code=1)
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    try:
+        dest = os.path.join(WORKSPACE, file.filename.lstrip("/"))
+        os.makedirs(os.path.dirname(dest) or WORKSPACE, exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(await file.read())
+        return JSONResponse(200, {"message": f"Uploaded {file.filename}"})
+    except Exception as e:
+        return JSONResponse(500, {"message": str(e)})
+
+@app.get("/download/{path:path}")
+async def download(path: str):
+    p = urllib.parse.unquote(path)
+    full = p if os.path.isabs(p) else os.path.join(WORKSPACE, p.lstrip("/"))
+    if os.path.isfile(full):
+        return FileResponse(full, media_type="application/octet-stream", filename=os.path.basename(full))
+    return JSONResponse(404, {"message": "Not found"})
+
+@app.get("/list/{path:path}")
+async def list_dir(path: str):
+    p = urllib.parse.unquote(path)
+    full = p if os.path.isabs(p) else os.path.join(WORKSPACE, p.lstrip("/"))
+    if not os.path.isdir(full):
+        return JSONResponse(404, {"message": "Not a directory"})
+    entries = [
+        {"name": e.name, "size": e.stat().st_size,
+         "type": "directory" if e.is_dir() else "file",
+         "mod_time": e.stat().st_mtime}
+        for e in os.scandir(full)
+    ]
+    return JSONResponse(200, entries)
+
+@app.get("/exists/{path:path}")
+async def exists(path: str):
+    p = urllib.parse.unquote(path)
+    full = p if os.path.isabs(p) else os.path.join(WORKSPACE, p.lstrip("/"))
+    return JSONResponse(200, {"path": p, "exists": os.path.exists(full)})
+PYEOF
+
+RUN chown sandbox:sandbox /app/runtime_server.py
+
+WORKDIR /home/cognition
+USER sandbox
+
+# Default git identity for sandbox commits
+RUN git config --global user.email "sandbox@cognition.local" \
+    && git config --global user.name "Cognition Sandbox" \
+    && git config --global credential.helper store
+
+EXPOSE 8888
+
+CMD ["uvicorn", "runtime_server:app", "--app-dir", "/app", "--host", "0.0.0.0", "--port", "8888"]

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,58 +1,93 @@
-# Lightweight sandbox container for per-session code execution
+# Cognition K8s Sandbox image
 #
-# This image is used by DockerExecutionBackend to provide isolated
-# execution environments for each agent session.
+# Extends the base sandbox with:
+#   - agent-sandbox python runtime server (FastAPI on :8888)
+#   - gh CLI for GitHub operations
+#   - Node.js LTS + npm for JS/Node development
+#   - git, curl, jq, make and common dev tools
+#
+# Used by the Cognition kubernetes sandbox backend.
+# Each agent session gets its own isolated pod from this image.
 #
 # Build:
-#   docker build -f Dockerfile.sandbox -t cognition-sandbox:latest .
+#   docker buildx build --platform linux/amd64 \
+#     -f Dockerfile.sandbox \
+#     -t ghcr.io/cognicellai/cognition-sandbox:test-k8s-runtime --push .
 #
-# Features:
-#   - Python 3.11 with common dev tools
-#   - Non-root user for security
-#   - /workspace mount point for project files
-#   - Minimal footprint (~150MB)
+# Non-root user: sandbox (uid 1000)
+# Runtime port:  8888 (agent-sandbox HTTP API)
+# Workspace:     /workspace (emptyDir mount)
+# Tmp:           /tmp       (emptyDir mount)
 
-ARG VERSION=dev
-ARG BUILD_DATE
-ARG VCS_REF
+ARG GH_CLI_VERSION=2.66.1
+ARG NODE_MAJOR=22
 
 FROM python:3.11-slim
 
-# OCI Annotations / Labels
-LABEL org.opencontainers.image.title="Cognition Sandbox"
-LABEL org.opencontainers.image.description="Isolated execution environment for Cognition agent sessions"
-LABEL org.opencontainers.image.url="https://github.com/CognicellAI/Cognition"
+# OCI Labels
+LABEL org.opencontainers.image.title="Cognition K8s Sandbox"
+LABEL org.opencontainers.image.description="K8s sandbox runtime for Cognition agent sessions"
 LABEL org.opencontainers.image.source="https://github.com/CognicellAI/Cognition"
-LABEL org.opencontainers.image.version="${VERSION}"
-LABEL org.opencontainers.image.created="${BUILD_DATE}"
-LABEL org.opencontainers.image.revision="${VCS_REF}"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Install common development tools agents may need
+# ── System packages ──────────────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
+    ca-certificates \
+    gnupg \
     jq \
+    make \
+    unzip \
     tree \
     ripgrep \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install common Python tools
+# ── gh CLI ───────────────────────────────────────────────────────────────────
+ARG GH_CLI_VERSION
+RUN curl -fsSL \
+    "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=2 \
+    "gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" \
+    && gh --version
+
+# ── Node.js LTS ──────────────────────────────────────────────────────────────
+ARG NODE_MAJOR
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version && npm --version
+
+# ── Python dev tools + sandbox runtime server ────────────────────────────────
 RUN pip install --no-cache-dir \
+    fastapi \
+    uvicorn \
+    python-multipart \
     ruff \
     mypy \
     pytest \
-    black
+    black \
+    uv
 
-# Security: run as non-root
+# ── Non-root sandbox user ─────────────────────────────────────────────────────
 RUN groupadd -r sandbox && useradd -r -g sandbox -u 1000 -m sandbox
 
-# Create workspace directory
-RUN mkdir -p /workspace && chown sandbox:sandbox /workspace
+# ── Writable mount points (readOnlyRootFilesystem: true in SandboxTemplate) ──
+RUN mkdir -p /workspace /tmp && chown sandbox:sandbox /workspace /tmp
+
+# ── Runtime server (agent-sandbox python-runtime protocol) ───────────────────
+COPY deploy/sandbox/runtime_server.py /app/runtime_server.py
+RUN chown sandbox:sandbox /app/runtime_server.py
 
 WORKDIR /workspace
 USER sandbox
 
-# Keep container running so exec_run works
-CMD ["sleep", "infinity"]
+# Git defaults so agents can commit without extra config
+RUN git config --global user.email "sandbox@cognition.local" \
+    && git config --global user.name "Cognition Sandbox" \
+    && git config --global credential.helper "store"
+
+EXPOSE 8888
+
+CMD ["uvicorn", "runtime_server:app", "--app-dir", "/app", "--host", "0.0.0.0", "--port", "8888", "--log-level", "info"]

--- a/deploy/examples/cognition-sandbox-template.yaml
+++ b/deploy/examples/cognition-sandbox-template.yaml
@@ -45,7 +45,7 @@ spec:
         - name: tmp
           mountPath: /tmp
         - name: workspace
-          mountPath: /workspace
+          mountPath: /home/cognition
       volumes:
       - name: tmp
         emptyDir:

--- a/deploy/helm/cognition/templates/core/deployment.yaml
+++ b/deploy/helm/cognition/templates/core/deployment.yaml
@@ -34,7 +34,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        # Wait for database to be ready
         - name: wait-for-db
           image: busybox:1.36
           command:
@@ -52,6 +51,42 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
+        - name: init-workspace
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              WS="/home/cognition"
+              echo "Initializing workspace at ${WS}..."
+              mkdir -p "${WS}/.cognition/skills"
+              mkdir -p "${WS}/.cognition/tools"
+              mkdir -p "${WS}/.cognition/middleware"
+              mkdir -p "${WS}/.cognition/agents"
+              mkdir -p "${WS}/.cognition/sandboxes"
+              if [ ! -f "${WS}/AGENTS.md" ]; then
+                if [ -f "/etc/cognition-config/AGENTS.md" ]; then
+                  cp /etc/cognition-config/AGENTS.md "${WS}/AGENTS.md"
+                  echo "Copied AGENTS.md from ConfigMap"
+                else
+                  echo "# Cognition Agent Configuration" > "${WS}/AGENTS.md"
+                  echo "No custom AGENTS.md provided." >> "${WS}/AGENTS.md"
+                  echo "Created default AGENTS.md"
+                fi
+              fi
+              chown -R 1000:1000 "${WS}"
+              echo "Workspace initialized"
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/cognition
+            - name: config
+              mountPath: /etc/cognition-config
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -59,13 +94,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            # Server settings
+            - name: HOME
+              value: "/home/cognition"
             - name: COGNITION_HOST
               value: "0.0.0.0"
             - name: COGNITION_PORT
               value: "{{ .Values.service.port }}"
             - name: COGNITION_WORKSPACE_ROOT
-              value: "/workspace"
+              value: "/home/cognition"
             - name: COGNITION_LOG_LEVEL
               value: "{{ .Values.config.logLevel }}"
             
@@ -82,9 +118,7 @@ spec:
               value: "postgresql+asyncpg://{{ .Values.database.user }}:$(DB_PASSWORD)@{{ .Values.database.host }}:5432/{{ .Values.database.name }}"
               {{- end }}
             
-            # Credentials (API keys remain as env vars in v0.3.0)
-            # Configuration moved to .cognition/config.yaml via ConfigMap
-            # Testing if env vars still work in v0.3.0
+            # Provider settings
             - name: COGNITION_LLM_PROVIDER
               value: "{{ .Values.config.llm.provider }}"
             - name: COGNITION_LLM_MODEL
@@ -215,17 +249,14 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: workspace
-              mountPath: /workspace
-            - name: config
-              mountPath: /app/.cognition
-              readOnly: true
+              mountPath: /home/cognition
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: workspace
-          {{- if .Values.persistence.workspace.enabled }}
+          {{- if .Values.workspace.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.workspace.existingClaim | default (printf "%s-workspace" (include "cognition.fullname" .)) }}
+            claimName: {{ .Values.workspace.persistence.existingClaim | default (printf "%s-workspace" (include "cognition.fullname" .)) }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/deploy/helm/cognition/templates/core/workspace-pvc.yaml
+++ b/deploy/helm/cognition/templates/core/workspace-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.workspace.enabled }}
+{{- if .Values.workspace.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,9 +8,9 @@ metadata:
     {{- include "cognition.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.persistence.workspace.accessMode }}
-  storageClassName: {{ .Values.persistence.workspace.storageClass }}
+    - {{ .Values.workspace.persistence.accessMode }}
+  storageClassName: {{ .Values.workspace.persistence.storageClass }}
   resources:
     requests:
-      storage: {{ .Values.persistence.workspace.size }}
+      storage: {{ .Values.workspace.persistence.size }}
 {{- end }}

--- a/deploy/helm/cognition/values.yaml
+++ b/deploy/helm/cognition/values.yaml
@@ -85,11 +85,14 @@ database:
   existingSecretName: ""
   existingSecretKey: "uri"
 
-# Persistence configuration
-persistence:
-  workspace:
-    enabled: true
-    # Storage class for the workspace PVC
+# Workspace configuration
+# The workspace serves as both HOME and COGNITION_WORKSPACE_ROOT.
+# By default, an emptyDir is used (ephemeral — state lives in Postgres).
+# Enable persistence if you need custom tools/skills/agents to survive pod restarts.
+workspace:
+  persistence:
+    enabled: false
+    # Storage class for the workspace PVC (required when enabled)
     storageClass: longhorn
     # Access mode - ReadWriteMany allows multiple pods to share the workspace
     accessMode: ReadWriteMany

--- a/deploy/sandbox/runtime_server.py
+++ b/deploy/sandbox/runtime_server.py
@@ -19,10 +19,10 @@ import subprocess
 import urllib.parse
 from typing import Any
 
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
-from starlette.responses import Response
 from pydantic import BaseModel
+from starlette.responses import Response
 
 WORKSPACE = os.environ.get("COGNITION_WORKSPACE_ROOT", "/workspace")
 

--- a/deploy/sandbox/runtime_server.py
+++ b/deploy/sandbox/runtime_server.py
@@ -1,0 +1,116 @@
+# Cognition K8s Sandbox runtime server
+#
+# Implements the agent-sandbox HTTP protocol on port 8888:
+#   POST /execute        - run a shell command, return stdout/stderr/exit_code
+#   POST /upload         - upload a file into the sandbox
+#   GET  /download/{path}- download a file from the sandbox
+#   GET  /list/{path}    - list directory contents
+#   GET  /exists/{path}  - check if a path exists
+#   GET  /               - health check
+#
+# Working directory is /workspace (emptyDir mount from SandboxTemplate).
+# Path security is enforced by CognitionKubernetesSandboxBackend upstream;
+# this server does not restrict paths within the sandbox itself.
+#
+# Compatible with k8s-agent-sandbox==0.3.10
+
+import os
+import subprocess
+import urllib.parse
+
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+WORKSPACE = os.environ.get("COGNITION_WORKSPACE_ROOT", "/workspace")
+
+
+class ExecuteRequest(BaseModel):
+    command: str
+
+
+class ExecuteResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+app = FastAPI(
+    title="Cognition Sandbox Runtime",
+    description="K8s sandbox runtime for Cognition agent sessions",
+    version="1.0.0",
+)
+
+
+@app.get("/", summary="Health check")
+async def health_check():
+    return {"status": "ok", "workspace": WORKSPACE}
+
+
+@app.post("/execute", summary="Execute a shell command", response_model=ExecuteResponse)
+async def execute_command(request: ExecuteRequest):
+    try:
+        process = subprocess.run(
+            ["sh", "-c", request.command],
+            capture_output=True,
+            text=True,
+            cwd=WORKSPACE,
+            env={**os.environ, "HOME": "/home/sandbox"},
+        )
+        return ExecuteResponse(
+            stdout=process.stdout,
+            stderr=process.stderr,
+            exit_code=process.returncode,
+        )
+    except Exception as e:
+        return ExecuteResponse(stdout="", stderr=str(e), exit_code=1)
+
+
+@app.post("/upload", summary="Upload a file")
+async def upload_file(file: UploadFile = File(...)):
+    try:
+        dest = os.path.join(WORKSPACE, file.filename)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(await file.read())
+        return JSONResponse(status_code=200, content={"message": f"Uploaded {file.filename}"})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"message": str(e)})
+
+
+@app.get("/download/{encoded_path:path}", summary="Download a file")
+async def download_file(encoded_path: str):
+    path = urllib.parse.unquote(encoded_path)
+    full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
+    if os.path.isfile(full):
+        return FileResponse(path=full, media_type="application/octet-stream", filename=os.path.basename(full))
+    return JSONResponse(status_code=404, content={"message": "File not found"})
+
+
+@app.get("/list/{encoded_path:path}", summary="List directory")
+async def list_files(encoded_path: str):
+    path = urllib.parse.unquote(encoded_path)
+    full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
+    if not os.path.isdir(full):
+        return JSONResponse(status_code=404, content={"message": "Not a directory"})
+    try:
+        entries = []
+        with os.scandir(full) as it:
+            for entry in it:
+                s = entry.stat()
+                entries.append({
+                    "name": entry.name,
+                    "size": s.st_size,
+                    "type": "directory" if entry.is_dir() else "file",
+                    "mod_time": s.st_mtime,
+                })
+        return JSONResponse(status_code=200, content=entries)
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"message": str(e)})
+
+
+@app.get("/exists/{encoded_path:path}", summary="Check path exists")
+async def exists(encoded_path: str):
+    path = urllib.parse.unquote(encoded_path)
+    full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
+    return JSONResponse(status_code=200, content={"path": path, "exists": os.path.exists(full)})

--- a/deploy/sandbox/runtime_server.py
+++ b/deploy/sandbox/runtime_server.py
@@ -17,9 +17,11 @@
 import os
 import subprocess
 import urllib.parse
+from typing import Any
 
 from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse
+from starlette.responses import Response
 from pydantic import BaseModel
 
 WORKSPACE = os.environ.get("COGNITION_WORKSPACE_ROOT", "/workspace")
@@ -43,12 +45,12 @@ app = FastAPI(
 
 
 @app.get("/", summary="Health check")
-async def health_check():
+async def health_check() -> dict[str, str]:
     return {"status": "ok", "workspace": WORKSPACE}
 
 
 @app.post("/execute", summary="Execute a shell command", response_model=ExecuteResponse)
-async def execute_command(request: ExecuteRequest):
+async def execute_command(request: ExecuteRequest) -> ExecuteResponse:
     try:
         process = subprocess.run(
             ["sh", "-c", request.command],
@@ -67,19 +69,20 @@ async def execute_command(request: ExecuteRequest):
 
 
 @app.post("/upload", summary="Upload a file")
-async def upload_file(file: UploadFile = File(...)):
+async def upload_file(file: UploadFile = File(...)) -> JSONResponse:
     try:
-        dest = os.path.join(WORKSPACE, file.filename)
+        filename = file.filename or "uploaded-file"
+        dest = os.path.join(WORKSPACE, filename)
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         with open(dest, "wb") as f:
             f.write(await file.read())
-        return JSONResponse(status_code=200, content={"message": f"Uploaded {file.filename}"})
+        return JSONResponse(status_code=200, content={"message": f"Uploaded {filename}"})
     except Exception as e:
         return JSONResponse(status_code=500, content={"message": str(e)})
 
 
 @app.get("/download/{encoded_path:path}", summary="Download a file")
-async def download_file(encoded_path: str):
+async def download_file(encoded_path: str) -> Response:
     path = urllib.parse.unquote(encoded_path)
     full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
     if os.path.isfile(full):
@@ -88,13 +91,13 @@ async def download_file(encoded_path: str):
 
 
 @app.get("/list/{encoded_path:path}", summary="List directory")
-async def list_files(encoded_path: str):
+async def list_files(encoded_path: str) -> JSONResponse:
     path = urllib.parse.unquote(encoded_path)
     full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
     if not os.path.isdir(full):
         return JSONResponse(status_code=404, content={"message": "Not a directory"})
     try:
-        entries = []
+        entries: list[dict[str, Any]] = []
         with os.scandir(full) as it:
             for entry in it:
                 s = entry.stat()
@@ -110,7 +113,7 @@ async def list_files(encoded_path: str):
 
 
 @app.get("/exists/{encoded_path:path}", summary="Check path exists")
-async def exists(encoded_path: str):
+async def exists(encoded_path: str) -> JSONResponse:
     path = urllib.parse.unquote(encoded_path)
     full = os.path.join(WORKSPACE, path.lstrip("/")) if not os.path.isabs(path) else path
     return JSONResponse(status_code=200, content={"path": path, "exists": os.path.exists(full)})

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -256,18 +256,22 @@ def _create_sandbox(
 def _model_for_deepagents(params: CognitionAgentParams) -> Any:
     """Return the model object/string to hand to DeepAgents.
 
-    DeepAgents accepts either a ready BaseChatModel or a provider-prefixed model
-    string. Some runtime paths were passing a provider-prefixed string for
-    ``openai_compatible`` models, which LangChain cannot infer. When we have a
-    resolved model object from RuntimeResolver, prefer that object directly.
+    DeepAgents should receive the resolved BaseChatModel from RuntimeResolver.
+    Reconstructing provider-prefixed model strings here is unsafe because some
+    Cognition providers (notably ``openai_compatible``) are represented to
+    LangChain via explicit kwargs rather than a provider-prefixed model name.
     """
     if params.model is not None:
         return params.model
 
-    if params.provider and params.model_id:
-        return f"{params.provider}:{params.model_id}"
-
-    return params.model_id
+    provider = params.provider or "unknown"
+    model_id = params.model_id or "unknown"
+    raise ValueError(
+        "Resolved model object missing during DeepAgents creation for "
+        f"provider '{provider}' and model '{model_id}'. "
+        "Refusing to construct a provider-prefixed fallback string because it can "
+        "break provider-specific LangChain initialization."
+    )
 
 
 def _inject_subagent_middleware(subagents: list[Any], middleware: list[Any]) -> list[Any]:

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -210,6 +210,8 @@ class CognitionAgentParams:
 
     project_path: str | Path
     model: Any = None
+    provider: str | None = None
+    model_id: str | None = None
     store: Any = None
     checkpointer: Any = None
     system_prompt: str | None = None
@@ -249,6 +251,23 @@ def _create_sandbox(
         k8s_warm_pool=settings.k8s_sandbox_warm_pool,
         labels=k8s_labels or None,
     )
+
+
+def _model_for_deepagents(params: CognitionAgentParams) -> Any:
+    """Return the model object/string to hand to DeepAgents.
+
+    DeepAgents accepts either a ready BaseChatModel or a provider-prefixed model
+    string. Some runtime paths were passing a provider-prefixed string for
+    ``openai_compatible`` models, which LangChain cannot infer. When we have a
+    resolved model object from RuntimeResolver, prefer that object directly.
+    """
+    if params.model is not None:
+        return params.model
+
+    if params.provider and params.model_id:
+        return f"{params.provider}:{params.model_id}"
+
+    return params.model_id
 
 
 def _inject_subagent_middleware(subagents: list[Any], middleware: list[Any]) -> list[Any]:
@@ -314,7 +333,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
 
     runtime_ctx = RuntimeContext.from_params(
         project_path=project_path,
-        model=params.model,
+        model=params.model_id or getattr(params.model, "model_name", None) or str(params.model),
         store=params.store,
         system_prompt=params.system_prompt,
         memory=params.memory,
@@ -476,7 +495,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
     create_kwargs = cast(
         Any,
         {
-            "model": params.model,
+            "model": _model_for_deepagents(params),
             "tools": agent_tools,
             "system_prompt": prompt,
             "backend": backend,

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -261,8 +261,19 @@ def _model_for_deepagents(params: CognitionAgentParams) -> Any:
     Cognition providers (notably ``openai_compatible``) are represented to
     LangChain via explicit kwargs rather than a provider-prefixed model name.
     """
+    # Unit tests and some integration paths construct agents without a resolved
+    # provider-backed model object. Preserve the pre-fix behavior for that case
+    # by falling back to the string/default model that DeepAgents accepted before,
+    # while still avoiding the unsafe provider-prefixed reconstruction when we do
+    # know a provider and model_id pair.
     if params.model is not None:
         return params.model
+
+    if params.provider is None and params.model_id is None:
+        return None
+
+    if params.provider is None and params.model_id is not None:
+        return params.model_id
 
     provider = params.provider or "unknown"
     model_id = params.model_id or "unknown"

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -433,6 +433,34 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
         backend = self._get_backend()
         return backend.edit(file_path, old_string, new_string, replace_all=replace_all)
 
+    def download_files(self, paths: list[str]) -> list[Any]:
+        """Download files from the K8s sandbox pod.
+
+        Delegates to K8sSandbox which uses the sandbox pod HTTP /download API.
+
+        Args:
+            paths: List of file paths to download.
+
+        Returns:
+            List of FileDownloadResponse objects.
+        """
+        backend = self._get_backend()
+        return backend.download_files(paths)
+
+    def upload_files(self, files: list[Any]) -> list[Any]:
+        """Upload files to the K8s sandbox pod.
+
+        Delegates to K8sSandbox which uses the sandbox pod HTTP /upload API.
+
+        Args:
+            files: List of FileUploadRequest objects.
+
+        Returns:
+            List of FileUploadResponse objects.
+        """
+        backend = self._get_backend()
+        return backend.upload_files(files)
+
     def terminate(self) -> None:
         """Terminate the K8s sandbox and clean up resources.
 

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import structlog
 from deepagents.backends import FilesystemBackend, LocalShellBackend
@@ -445,7 +445,7 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
             List of FileDownloadResponse objects.
         """
         backend = self._get_backend()
-        return backend.download_files(paths)
+        return cast(list[Any], backend.download_files(paths))
 
     def upload_files(self, files: list[Any]) -> list[Any]:
         """Upload files to the K8s sandbox pod.
@@ -459,7 +459,7 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
             List of FileUploadResponse objects.
         """
         backend = self._get_backend()
-        return backend.upload_files(files)
+        return cast(list[Any], backend.upload_files(files))
 
     def terminate(self) -> None:
         """Terminate the K8s sandbox and clean up resources.

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -333,6 +333,8 @@ class DeepAgentStreamingService:
             agent_params = CognitionAgentParams(
                 project_path=project_path,
                 model=model,
+                provider=provider,
+                model_id=model_id,
                 store=store,
                 checkpointer=checkpointer,
                 settings=self.settings,
@@ -479,6 +481,8 @@ class DeepAgentStreamingService:
             agent_params = CognitionAgentParams(
                 project_path=project_path,
                 model=model,
+                provider=provider,
+                model_id=model_id,
                 store=store,
                 checkpointer=checkpointer,
                 settings=self.settings,

--- a/server/app/observability/__init__.py
+++ b/server/app/observability/__init__.py
@@ -6,6 +6,7 @@ Provides structured logging, OpenTelemetry tracing, and metrics collection.
 from __future__ import annotations
 
 import functools
+import inspect
 import time
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -154,7 +155,24 @@ def setup_tracing(
 
     # Instrument LangChain
     if LangchainInstrumentor:
-        LangchainInstrumentor().instrument(tracer_provider=provider)
+        instrument_signature = inspect.signature(LangchainInstrumentor().instrument)
+        supports_module_kwarg = False
+
+        wrapped = getattr(LangchainInstrumentor, "_instrument", None)
+        if wrapped is not None:
+            try:
+                supports_module_kwarg = "module" in inspect.getsource(wrapped)
+            except (OSError, TypeError):
+                supports_module_kwarg = False
+
+        if supports_module_kwarg:
+            logger.warning(
+                "Skipping LangChain OpenTelemetry instrumentation due to incompatible wrapt API"
+            )
+        elif "tracer_provider" in instrument_signature.parameters:
+            LangchainInstrumentor().instrument(tracer_provider=provider)
+        else:
+            LangchainInstrumentor().instrument()
 
 
 def setup_logging(log_level: str = "info", json_format: bool = False) -> None:

--- a/server/app/storage/config_registry.py
+++ b/server/app/storage/config_registry.py
@@ -771,6 +771,10 @@ class PostgresConfigRegistry:
         return Json(definition)
 
     @staticmethod
+    def _jsonb_param(value: Json) -> psycopg.types.json.Jsonb:
+        return psycopg.types.json.Jsonb(value.obj)
+
+    @staticmethod
     async def _fetch_all(
         conn: psycopg.AsyncConnection[dict[str, Any]], query: str, params: tuple[Any, ...]
     ) -> list[dict[str, Any]]:
@@ -811,8 +815,8 @@ class PostgresConfigRegistry:
                 (
                     entity_type,
                     name,
-                    self._serialize_scope(scope),
-                    self._serialize_definition(definition),
+                    self._jsonb_param(self._serialize_scope(scope)),
+                    self._jsonb_param(self._serialize_definition(definition)),
                     source,
                     now,
                     now,
@@ -827,7 +831,7 @@ class PostgresConfigRegistry:
         async with pool.connection() as conn:
             result = await conn.execute(
                 "DELETE FROM config_entities WHERE entity_type=%s AND name=%s AND scope=%s",
-                (entity_type, name, self._serialize_scope(scope or {})),
+                (entity_type, name, self._jsonb_param(self._serialize_scope(scope or {}))),
             )
             deleted = bool(result != "DELETE 0")
             if deleted:
@@ -899,7 +903,7 @@ class PostgresConfigRegistry:
             INSERT INTO config_changes (entity_type, name, scope, operation, changed_at, processed)
             VALUES (%s, %s, %s, %s, %s, false)
             """,
-            (entity_type, name, self._serialize_scope(scope), operation, now),
+            (entity_type, name, self._jsonb_param(self._serialize_scope(scope)), operation, now),
         )
         # NOTIFY for cross-instance invalidation
         await conn.execute("NOTIFY cognition_config_changes")
@@ -1057,7 +1061,7 @@ class PostgresConfigRegistry:
             existing = await self._fetch_one(
                 conn,
                 "SELECT id FROM config_entities WHERE entity_type=%s AND name=%s AND scope=%s",
-                (entity_type, name, self._serialize_scope(scope)),
+                (entity_type, name, self._jsonb_param(self._serialize_scope(scope))),
             )
             if existing:
                 return False
@@ -1069,8 +1073,8 @@ class PostgresConfigRegistry:
                 (
                     entity_type,
                     name,
-                    self._serialize_scope(scope),
-                    self._serialize_definition(definition),
+                    self._jsonb_param(self._serialize_scope(scope)),
+                    self._jsonb_param(self._serialize_definition(definition)),
                     source,
                     now,
                     now,

--- a/tests/unit/test_provider_resolution.py
+++ b/tests/unit/test_provider_resolution.py
@@ -395,6 +395,20 @@ class TestBuildModel:
 
         assert _model_for_deepagents(params) is resolved_model
 
+    def test_deepagents_model_input_raises_without_resolved_model(self) -> None:
+        """Fail fast instead of constructing unsafe provider:model fallbacks."""
+        from server.app.agent.cognition_agent import CognitionAgentParams, _model_for_deepagents
+
+        params = CognitionAgentParams(
+            project_path="/tmp",
+            model=None,
+            provider="openai_compatible",
+            model_id="google/gemini-3-flash-preview",
+        )
+
+        with pytest.raises(ValueError, match="Resolved model object missing"):
+            _model_for_deepagents(params)
+
     def test_openai_compatible_raises_without_base_url(self) -> None:
         """openai_compatible without a base_url raises LLMProviderConfigError."""
         from server.app.exceptions import LLMProviderConfigError

--- a/tests/unit/test_provider_resolution.py
+++ b/tests/unit/test_provider_resolution.py
@@ -381,6 +381,20 @@ class TestBuildModel:
             assert call_kwargs[1]["base_url"] == "https://openrouter.ai/api/v1"
             assert call_kwargs[1]["api_key"] == "sk-or-key"
 
+    def test_deepagents_model_input_preserves_resolved_model_instance(self) -> None:
+        """Do not reconstruct provider-prefixed strings from resolved models."""
+        from server.app.agent.cognition_agent import CognitionAgentParams, _model_for_deepagents
+
+        resolved_model = object()
+        params = CognitionAgentParams(
+            project_path="/tmp",
+            model=resolved_model,
+            provider="openai_compatible",
+            model_id="google/gemini-3-flash-preview",
+        )
+
+        assert _model_for_deepagents(params) is resolved_model
+
     def test_openai_compatible_raises_without_base_url(self) -> None:
         """openai_compatible without a base_url raises LLMProviderConfigError."""
         from server.app.exceptions import LLMProviderConfigError


### PR DESCRIPTION
## Summary
- fix Postgres provider bootstrap by sending registry scope and definition values as jsonb so the default provider seeds correctly on startup
- avoid crashing startup when the installed LangChain OpenTelemetry instrumentor is incompatible with the current wrapt API by skipping that instrumentation path with a warning
- validate the updated GHCR test image in docker-compose by confirming provider discovery and a hello message succeed with OTel enabled

## Testing
- uv run pytest tests/unit/test_store_wiring.py tests/unit/test_streaming_bugs.py -q
- docker buildx build --platform linux/amd64 -f Dockerfile -t ghcr.io/cognicellai/cognition:test-provider-otel-fix -t ghcr.io/cognicellai/cognition:test-be5de98 --push .
- docker compose up -d cognition using ghcr.io/cognicellai/cognition:test-provider-otel-fix
- GET /models/providers
- POST /sessions and POST /sessions/{id}/messages with a hello message