### PR TITLE
fix provider and model configuration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ cognition-server
 - **Multi-Tenant Isolation** — Session scoping via `X-Cognition-Scope-*` headers. Rate limiting, CORS, and circuit breaker built in.
 - **Multi-Agent Registry** — Built-in agents (`default`, `readonly`) plus user-defined agents in `.cognition/agents/`. Session-agent binding via `agent_name`.
 
+## Model And Provider Configuration
+
+Cognition resolves provider configuration once, builds a concrete LangChain chat model, and hands that model to Deep Agents. The runtime does not silently guess across providers.
+
+Recommended flow:
+
+1. Create provider configs with `POST /models/providers` or bootstrap them from `.cognition/config.yaml`.
+2. Bind sessions with `config.provider_id` whenever possible.
+3. Use `config.provider` + `config.model` only for direct overrides.
+4. Use `config.model` alone only when it maps to exactly one enabled provider type.
+
+Important rules:
+
+- `openai_compatible` providers must include `base_url`
+- `bedrock` providers must include `region`
+- `role_arn` is only valid for `bedrock`
+- ambiguous model-only session updates return `422` instead of silently picking a provider
+
+See [API Reference](./docs/guides/api-reference.md) and [Configuration Reference](./docs/guides/configuration.md) for the exact request shapes and precedence rules.
+
 ## Architecture
 
 Cognition follows a strict 7-layer architecture. Define your agent; get everything else automatically.

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -210,6 +210,14 @@ Update session metadata or LLM configuration.
 
 **Provider resolution priority** (highest to lowest): `provider_id` → `provider`+`model` → `AgentDefinition.config` → first enabled ProviderConfig from ConfigRegistry.
 
+**Validation rules:**
+
+- `config.provider_id` selects an exact configured provider row.
+- `config.provider` requires `config.model`.
+- `config.model` without `config.provider` or `config.provider_id` is only accepted when exactly one enabled provider type matches that model.
+- If no enabled provider matches the model, Cognition returns `422`.
+- If multiple enabled provider types match the model, Cognition returns `422` and asks the caller to specify `provider` or `provider_id`.
+
 **Response `200 OK`:** Updated session object  
 **Response `404 Not Found`**
 
@@ -853,9 +861,33 @@ Trigger a manual reload of file-discovered tools from `.cognition/tools/`.
 
 ## Models
 
+Provider configs are the canonical model selection surface in Cognition. Cognition validates the provider config, resolves credentials and transport settings, builds a concrete LangChain chat model, and passes that model into Deep Agents.
+
+### Provider Types And Validation
+
+| Provider type | Required fields | Notes |
+|---|---|---|
+| `openai` | `id`, `provider`, `model` | Uses `OPENAI_API_KEY` unless `api_key_env` overrides it |
+| `anthropic` | `id`, `provider`, `model` | Uses `ANTHROPIC_API_KEY` unless `api_key_env` overrides it |
+| `bedrock` | `id`, `provider`, `model`, `region` | `role_arn` is allowed only for `bedrock` |
+| `openai_compatible` | `id`, `provider`, `model`, `base_url` | Covers OpenRouter, Ollama, vLLM, LiteLLM, LM Studio, and similar endpoints |
+| `google_genai` | `id`, `provider`, `model` | Uses `GOOGLE_API_KEY` unless `api_key_env` overrides it |
+| `google_vertexai` | `id`, `provider`, `model` | Vertex runtime details come from ADC and project config |
+| `mock` | `id`, `provider`, `model` | Test-only provider |
+
+Validation rules enforced by Cognition:
+
+- `base_url` is required for `openai_compatible`
+- `base_url` is rejected for non-`openai_compatible` providers
+- `region` is required for `bedrock`
+- `region` is rejected for non-`bedrock` providers
+- `role_arn` is rejected for non-`bedrock` providers
+
 ### `GET /models`
 
 List models from the models.dev catalog with optional filtering.
+
+This endpoint returns catalog metadata only for provider types that have at least one enabled provider config visible in the current scope. It does not expose the full global models.dev catalog.
 
 **Query parameters:**
 
@@ -864,6 +896,12 @@ List models from the models.dev catalog with optional filtering.
 | `provider` | string | Filter by Cognition provider type (e.g. `openai`, `anthropic`) |
 | `tool_call` | bool | Filter by tool call support |
 | `q` | string | Search by model name or ID |
+
+Notes:
+
+- if no enabled providers are configured in scope, the response is empty
+- if `provider` is requested but no matching enabled provider config exists in scope, the response is empty
+- `openai_compatible` providers do not contribute catalog entries unless Cognition has an explicit catalog mapping for the upstream service
 
 **Response `200 OK`:**
 ```json
@@ -891,6 +929,8 @@ List models from the models.dev catalog with optional filtering.
 ### `GET /models/providers`
 
 List all provider configs from the ConfigRegistry.
+
+Use this endpoint to inspect the effective provider registry before binding sessions by `provider_id`.
 
 **Response `200 OK`:**
 ```json
@@ -920,6 +960,8 @@ List all provider configs from the ConfigRegistry.
 ### `GET /models/providers/{provider_id}/models`
 
 List catalog models available for a specific provider config.
+
+For `openai_compatible` providers, the catalog may be incomplete because available models depend on the upstream service.
 
 **Response `200 OK`:** Same schema as `GET /models`
 
@@ -961,9 +1003,23 @@ Create a provider config in the ConfigRegistry. Takes effect immediately — no 
 **Response `201 Created`:** Provider config object  
 **Response `422 Unprocessable Entity`:** Validation error
 
+Preferred usage:
+
+- use the returned `id` as `SessionConfig.provider_id`
+- prefer `provider_id` over model-only session selection
+
+Common invalid configs:
+
+- `openai_compatible` without `base_url`
+- `bedrock` without `region`
+- `region` or `role_arn` on non-`bedrock` providers
+- `base_url` on non-`openai_compatible` providers
+
 ### `PATCH /models/providers/{provider_id}`
 
 Partially update a provider config.
+
+Updates are fully revalidated, so an invalid partial update is rejected instead of leaving the provider in a broken state.
 
 **Request body (all fields optional):**
 ```json
@@ -985,6 +1041,10 @@ Delete a provider config.
 **Response `404 Not Found`**
 
 ### `POST /models/providers/{provider_id}/test`
+
+Validate that the configured provider can be resolved and instantiated successfully.
+
+Use this endpoint during onboarding before binding sessions to a new `provider_id`.
 
 Test provider connectivity and credentials.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -39,6 +39,17 @@ The workspace root is resolved to an absolute path at startup. The agent's tools
 
 LLM provider and model settings are managed through the **ConfigRegistry**, a database-backed configuration store that supports hot-reloading. Provider configuration no longer lives in `Settings` or environment variables like `COGNITION_LLM_PROVIDER` / `COGNITION_LLM_MODEL`.
 
+### Canonical runtime flow
+
+Cognition does not pass raw provider selection policy into Deep Agents. Instead, it follows one canonical flow:
+
+1. select a model target from session config, agent config, or provider registry
+2. resolve provider-specific transport and credential fields
+3. build a concrete LangChain chat model
+4. pass that model into Deep Agents
+
+This means Cognition owns configuration, validation, and LangChain model construction. Deep Agents owns execution.
+
 ### How it works
 
 1. The `llm:` section in `.cognition/config.yaml` is **bootstrapped** into the ConfigRegistry on first startup using `seed_if_absent` — YAML values provide defaults, but rows written via the API always take precedence.
@@ -46,6 +57,24 @@ LLM provider and model settings are managed through the **ConfigRegistry**, a da
 3. To list available models for a provider: `GET /models/providers/{id}/models`.
 4. To verify credentials: `POST /models/providers/{id}/test`.
 5. Sessions reference a provider via `SessionConfig.provider_id`.
+
+### Runtime selection precedence
+
+When Cognition resolves a model for a session, it uses this precedence order:
+
+1. `SessionConfig.provider_id`
+2. `SessionConfig.provider` + `SessionConfig.model`
+3. `AgentDefinition.config.provider` + `AgentDefinition.config.model`
+4. first enabled `ProviderConfig` by ascending `priority`
+
+Recommended usage:
+
+- prefer `provider_id` for stable runtime selection
+- use `provider` + `model` only for direct transient overrides
+- avoid model-only selection unless the mapping is unambiguous
+- treat `/models` as a catalog view over configured provider types, not as the full global models.dev inventory
+
+There is no silent provider fallback.
 
 ### Supported provider types
 
@@ -58,6 +87,18 @@ LLM provider and model settings are managed through the **ConfigRegistry**, a da
 | `google_genai` | Google Generative AI (Gemini) |
 | `google_vertexai` | Google Vertex AI |
 | `mock` | Test-only provider; skipped during bootstrap |
+
+### Provider-specific validation
+
+| Rule | Effect |
+|---|---|
+| `openai_compatible` requires `base_url` | Invalid config is rejected |
+| Non-`openai_compatible` providers reject `base_url` | Prevents mismatched transport config |
+| `bedrock` requires `region` | Invalid config is rejected |
+| Non-`bedrock` providers reject `region` | Prevents provider-specific field drift |
+| Non-`bedrock` providers reject `role_arn` | Prevents invalid cross-provider fields |
+
+These rules apply to both create and update requests.
 
 ### config.yaml `llm:` section format
 
@@ -98,6 +139,10 @@ Each entry supports the following fields:
 | `api_key_env` | No | Name of the environment variable holding the API key |
 | `region` | No | AWS region (`bedrock`) or GCP region (`google_vertexai`) |
 | `role_arn` | No | AWS IAM role ARN for cross-account Bedrock access |
+
+The `llm:` section is a bootstrap surface, not the long-term source of truth. After startup, the effective provider registry lives in the ConfigRegistry and can be changed through the API without restart.
+
+For production systems and user-facing applications, prefer API-managed provider configs and bind sessions by `provider_id`.
 
 ### Credential environment variables
 
@@ -200,6 +245,17 @@ Requires GCP Application Default Credentials to be configured.
 **Mock (testing only):**
 
 No credentials required. Returns deterministic responses. Used by unit tests. The `mock` provider is skipped during bootstrap and cannot be seeded from config.yaml.
+
+### Session config guidance
+
+`SessionConfig` can set `provider_id`, `provider`, `model`, `temperature`, `max_tokens`, and `recursion_limit`.
+
+Important rules:
+
+- `provider_id` is the safest and most explicit selector
+- `provider` requires `model`
+- `model` by itself is only accepted when it matches exactly one enabled provider type
+- if model-only selection is ambiguous or unknown, Cognition returns `422` instead of picking a provider silently
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -47,9 +47,11 @@ Then configure the provider in `.cognition/config.yaml` (create the file if it d
 ```yaml
 # .cognition/config.yaml
 llm:
-  provider: openai_compatible
-  model: google/gemini-2.5-flash-preview
-  base_url: https://openrouter.ai/api/v1
+  - id: openrouter
+    provider: openai_compatible
+    model: google/gemini-2.5-flash-preview
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: COGNITION_OPENAI_COMPATIBLE_API_KEY
 ```
 
 Start the server:
@@ -72,6 +74,8 @@ curl -s http://localhost:8000/health
 ## 2. Connect your first LLM provider
 
 The `llm:` section in `.cognition/config.yaml` seeds the ConfigRegistry on first startup. You can also manage providers live via the API — changes take effect immediately, no restart required.
+
+Cognition resolves provider configuration into a concrete LangChain model before the run starts, then hands that model to Deep Agents. The safest way to refer to a configured provider later is by `provider_id`.
 
 ### Supported providers
 
@@ -110,6 +114,22 @@ curl http://localhost:8000/models/providers
 ```
 
 The `priority` field controls which provider is used when a session doesn't specify one — lower number means higher priority.
+
+### Recommended binding pattern
+
+When you later update a session, prefer:
+
+```json
+{
+  "config": {
+    "provider_id": "claude"
+  }
+}
+```
+
+Instead of relying on `model` alone.
+
+If you send only `config.model`, Cognition accepts it only when exactly one enabled provider type matches that model. Ambiguous or unknown model-only selection returns `422`.
 
 ---
 

--- a/examples/bedrock-config/README.md
+++ b/examples/bedrock-config/README.md
@@ -3,3 +3,15 @@
 This example shows the most important file and environment settings for AWS Bedrock.
 
 Use `AWS_REGION`, ambient AWS credentials, or `COGNITION_BEDROCK_ROLE_ARN` for cross-account access.
+
+## Bedrock-specific rules
+
+- `provider: bedrock` must include `region`
+- `role_arn` is valid only for `bedrock`
+- Cognition builds the Bedrock LangChain model before handing execution to Deep Agents
+
+## Recommended binding
+
+After the provider is registered, prefer binding sessions with `provider_id` instead of relying on `model` alone.
+
+This avoids ambiguity when multiple providers expose similarly named models.

--- a/examples/exhaustive-config/README.md
+++ b/examples/exhaustive-config/README.md
@@ -61,3 +61,18 @@ API-managed configuration is best for:
 - dynamic tools and skills
 - global provider and agent defaults
 - programmatic builder/UIs
+
+## Provider Notes
+
+Use this example to understand the difference between bootstrap config and the live provider registry:
+
+1. `.cognition/config.yaml` seeds provider configs on first startup
+2. `POST /models/providers` and `PATCH /models/providers/{id}` manage the live registry after startup
+3. sessions should usually bind by `provider_id`
+
+Important validation rules reflected by the runtime:
+
+- `openai_compatible` requires `base_url`
+- `bedrock` requires `region`
+- `role_arn` is only valid for `bedrock`
+- model-only session selection is rejected when ambiguous

--- a/examples/minimal-config/README.md
+++ b/examples/minimal-config/README.md
@@ -3,3 +3,19 @@
 This is the smallest practical project-level Cognition example.
 
 Use this when you want a simple starting point instead of the exhaustive reference example.
+
+## What it demonstrates
+
+- one provider bootstrapped from `.cognition/config.yaml`
+- secrets supplied through environment variables, not YAML
+- the recommended path for a local project default
+
+## Recommended runtime usage
+
+After startup, Cognition stores the effective provider config in the ConfigRegistry.
+
+For session binding:
+
+1. prefer `provider_id`
+2. use `provider` + `model` only for direct overrides
+3. avoid `model` alone unless it maps to exactly one enabled provider type

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -210,8 +210,6 @@ class CognitionAgentParams:
 
     project_path: str | Path
     model: Any = None
-    provider: str | None = None
-    model_id: str | None = None
     store: Any = None
     checkpointer: Any = None
     system_prompt: str | None = None
@@ -250,38 +248,6 @@ def _create_sandbox(
         k8s_ttl=settings.k8s_sandbox_ttl,
         k8s_warm_pool=settings.k8s_sandbox_warm_pool,
         labels=k8s_labels or None,
-    )
-
-
-def _model_for_deepagents(params: CognitionAgentParams) -> Any:
-    """Return the model object/string to hand to DeepAgents.
-
-    DeepAgents should receive the resolved BaseChatModel from RuntimeResolver.
-    Reconstructing provider-prefixed model strings here is unsafe because some
-    Cognition providers (notably ``openai_compatible``) are represented to
-    LangChain via explicit kwargs rather than a provider-prefixed model name.
-    """
-    # Unit tests and some integration paths construct agents without a resolved
-    # provider-backed model object. Preserve the pre-fix behavior for that case
-    # by falling back to the string/default model that DeepAgents accepted before,
-    # while still avoiding the unsafe provider-prefixed reconstruction when we do
-    # know a provider and model_id pair.
-    if params.model is not None:
-        return params.model
-
-    if params.provider is None and params.model_id is None:
-        return None
-
-    if params.provider is None and params.model_id is not None:
-        return params.model_id
-
-    provider = params.provider or "unknown"
-    model_id = params.model_id or "unknown"
-    raise ValueError(
-        "Resolved model object missing during DeepAgents creation for "
-        f"provider '{provider}' and model '{model_id}'. "
-        "Refusing to construct a provider-prefixed fallback string because it can "
-        "break provider-specific LangChain initialization."
     )
 
 
@@ -348,7 +314,10 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
 
     runtime_ctx = RuntimeContext.from_params(
         project_path=project_path,
-        model=params.model_id or getattr(params.model, "model_name", None) or str(params.model),
+        model=getattr(params.model, "model_name", None)
+        or getattr(params.model, "model_id", None)
+        or getattr(params.model, "model", None)
+        or str(params.model),
         store=params.store,
         system_prompt=params.system_prompt,
         memory=params.memory,
@@ -510,7 +479,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
     create_kwargs = cast(
         Any,
         {
-            "model": _model_for_deepagents(params),
+            "model": params.model,
             "tools": agent_tools,
             "system_prompt": prompt,
             "backend": backend,

--- a/server/app/agent/resolver.py
+++ b/server/app/agent/resolver.py
@@ -1,20 +1,4 @@
-"""RuntimeResolver: builds live Python objects from ConfigStore.
-
-RuntimeResolver is the CQRS "read" side optimized for the Agent Runtime.
-It takes a ConfigStore as a dependency and produces the live Python objects
-that deepagents expects: BaseTool instances, middleware objects, BaseChatModel
-instances, and AgentDefinition lookups.
-
-Layer: 4 (Agent Runtime)
-
-This replaces the scattered resolution logic that was previously in:
-- ``_load_config_registry_tools()`` in deep_agent_service.py
-- ``_resolve_provider_config()`` / ``_build_model()`` in deep_agent_service.py
-- ``ConfigStore.get_agent_definition()``
-
-Cognition does NOT roll its own agent logic — this is purely a
-configuration bridge from ConfigStore → deepagents primitives.
-"""
+"""RuntimeResolver bridges ConfigStore configuration into Deep Agents primitives."""
 
 from __future__ import annotations
 
@@ -37,6 +21,19 @@ from server.app.storage.config_store import ConfigStore
 logger = structlog.get_logger(__name__)
 
 _TEST_ONLY_PROVIDERS = {"mock"}
+
+
+@dataclass(frozen=True)
+class SelectedModelTarget:
+    provider: str
+    model_id: str
+    provider_id: str | None = None
+    base_url: str | None = None
+    region: str | None = None
+    role_arn: str | None = None
+    api_key_env: str | None = None
+    max_retries: int | None = None
+    timeout: int | None = None
 
 
 @dataclass(frozen=True)
@@ -69,14 +66,7 @@ class ResolvedModelConfig:
 
 
 class RuntimeResolver:
-    """Resolves ConfigStore data into live Python objects for the agent runtime.
-
-    Takes ConfigStore as a dependency and provides:
-    - ``build_tools()``: Load BaseTool instances from all sources
-    - ``build_model()``: Build a BaseChatModel from resolved provider config
-    - ``get_agent_definition()``: Look up an AgentDefinition by name
-    - ``resolve_provider_config()``: Walk the provider resolution priority chain
-    """
+    """Resolves ConfigStore data into live Python objects for the agent runtime."""
 
     def __init__(self, config_store: ConfigStore | None, settings: Settings) -> None:
         self._store = config_store
@@ -176,89 +166,6 @@ class RuntimeResolver:
     # Provider / model resolution
     # ------------------------------------------------------------------
 
-    async def resolve_provider_config(
-        self,
-        provider_id: str | None = None,
-        provider_type: str | None = None,
-        model_id: str | None = None,
-        scope: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Walk the provider resolution priority chain.
-
-        Priority:
-        1. provider_id: Exact match from ConfigStore
-        2. provider_type + model_id: Filter ConfigStore by type/model
-        3. List all providers from ConfigStore, pick highest priority
-        4. Global defaults from ConfigStore
-
-        Args:
-            provider_id: Exact provider config ID from SessionConfig.
-            provider_type: Provider type (e.g., "openai", "anthropic").
-            model_id: Model identifier to match.
-            scope: Scope dict for ConfigStore lookup.
-
-        Returns:
-            Dict with resolved provider config fields.
-
-        Raises:
-            LLMProviderConfigError: If no provider can be resolved.
-        """
-        if self._store is None:
-            raise LLMProviderConfigError(
-                provider=provider_id or provider_type or "unknown",
-                reason="ConfigStore not initialized.",
-            )
-
-        providers = await self._store.list_providers(scope)
-
-        if provider_id:
-            for p in providers:
-                if p.id == provider_id:
-                    return self._provider_to_dict(p)
-            raise LLMProviderConfigError(
-                provider=provider_id,
-                reason=f"Provider config '{provider_id}' not found in scope",
-            )
-
-        if provider_type or model_id:
-            candidates = []
-            for p in providers:
-                if provider_type and p.provider != provider_type:
-                    continue
-                if model_id and p.model and p.model != model_id:
-                    continue
-                if not p.enabled:
-                    continue
-                candidates.append(p)
-
-            if candidates:
-                candidates.sort(key=lambda p: p.priority or 0, reverse=True)
-                return self._provider_to_dict(candidates[0])
-
-        if providers:
-            enabled = [p for p in providers if p.enabled]
-            if enabled:
-                enabled.sort(key=lambda p: p.priority or 0, reverse=True)
-                return self._provider_to_dict(enabled[0])
-
-        defaults = await self._store.get_global_provider_defaults(scope)
-        if defaults.provider or defaults.model:
-            return {
-                "provider": defaults.provider,
-                "model": defaults.model,
-                "max_tokens": defaults.max_tokens,
-                "api_key": None,
-                "api_key_env": None,
-                "base_url": None,
-                "region": None,
-                "role_arn": None,
-            }
-
-        raise LLMProviderConfigError(
-            provider="unknown",
-            reason="No providers configured. Use POST /models/providers or set COGNITION_LLM_PROVIDER.",
-        )
-
     def build_model(
         self,
         provider: str,
@@ -272,28 +179,7 @@ class RuntimeResolver:
         max_retries: int | None = None,
         timeout: int | None = None,
     ) -> BaseChatModel:
-        """Build a LangChain BaseChatModel from resolved provider config.
-
-        Uses LangChain's init_chat_model for native provider support.
-
-        Args:
-            provider: Provider type.
-            model_id: Model identifier.
-            api_key: Optional explicit API key.
-            base_url: Optional base URL override.
-            region: AWS region (Bedrock only).
-            role_arn: IAM role ARN for STS AssumeRole (Bedrock only).
-            temperature: Optional temperature override.
-            max_tokens: Optional max_tokens override.
-            max_retries: Optional max_retries override.
-            timeout: Optional timeout override.
-
-        Returns:
-            Configured BaseChatModel.
-
-        Raises:
-            LLMProviderConfigError: If provider is unknown or construction fails.
-        """
+        """Build a LangChain BaseChatModel from a resolved provider target."""
         if provider == "mock":
             from server.app.llm.mock import MockLLM
 
@@ -565,105 +451,45 @@ class RuntimeResolver:
         scope: dict[str, str] | None = None,
         agent_def: Any | None = None,
     ) -> ResolvedModelConfig:
-        raw = await self._resolve_provider_config_for_session(
+        target = await self.select_model_target_for_session(
             session=session,
             scope=scope,
             agent_def=agent_def,
         )
+        recursion_limit = self._resolve_recursion_limit(session=session, agent_def=agent_def)
         return ResolvedModelConfig(
-            provider=raw[0],
-            model_id=raw[1],
-            api_key=raw[2],
-            base_url=raw[3],
-            region=raw[4],
-            role_arn=raw[5],
-            recursion_limit=raw[6],
-            max_retries=raw[7],
-            timeout=raw[8],
-            temperature=(agent_def.config.temperature if agent_def and agent_def.config else None),
-            max_tokens=(agent_def.config.max_tokens if agent_def and agent_def.config else None),
+            provider=target.provider,
+            model_id=target.model_id,
+            api_key=os.environ.get(target.api_key_env) if target.api_key_env else None,
+            base_url=target.base_url,
+            region=target.region,
+            role_arn=target.role_arn,
+            recursion_limit=recursion_limit,
+            max_retries=target.max_retries,
+            timeout=target.timeout,
+            temperature=self._resolve_temperature(session=session, agent_def=agent_def),
+            max_tokens=self._resolve_max_tokens(session=session, agent_def=agent_def),
         )
 
-    async def resolve_provider_tuple_for_session(
+    async def select_model_target_for_session(
         self,
         session: Any,
         scope: dict[str, str] | None,
         agent_def: Any | None = None,
-    ) -> tuple[
-        str, str, str | None, str | None, str | None, str | None, int, int | None, int | None
-    ]:
-        """Resolve provider configuration for a session with full priority chain.
+    ) -> SelectedModelTarget:
+        """Select the canonical model target for a session.
 
-        Priority (highest to lowest):
-        1. session.config.provider_id — looks up exact ProviderConfig by ID
-        2. session.config.provider + session.config.model — direct override
-        3. agent_def.config.provider + agent_def.config.model — per-agent override
-        4. First enabled ProviderConfig from ConfigStore (global default)
-
-        Returns:
-            Legacy provider tuple for compatibility with older tests.
-
-        Raises:
-            LLMProviderConfigError: If no provider can be resolved.
+        Priority:
+        1. ``session.config.provider_id``
+        2. ``session.config.provider`` + ``session.config.model``
+        3. ``agent_def.config.provider`` + ``agent_def.config.model``
+        4. First enabled provider config by ascending priority
         """
-        recursion_limit = 1000
-        if agent_def and agent_def.config and agent_def.config.recursion_limit is not None:
-            recursion_limit = agent_def.config.recursion_limit
-        if session and session.config and session.config.recursion_limit is not None:
-            recursion_limit = session.config.recursion_limit
-
         if session and session.config and session.config.provider_id:
-            provider_id = session.config.provider_id
-            try:
-                if self._store is None:
-                    raise LLMProviderConfigError(
-                        provider=provider_id,
-                        reason="ConfigStore not initialized — cannot resolve provider_id.",
-                    )
-                provider_config = await self._store.get_provider(provider_id, scope=scope)
-                if provider_config is None:
-                    raise LLMProviderConfigError(
-                        provider=provider_id,
-                        reason=(
-                            f"Provider config '{provider_id}' not found in ConfigStore. "
-                            "Check that the provider_id matches an existing provider config ID."
-                        ),
-                    )
-                if not provider_config.enabled:
-                    raise LLMProviderConfigError(
-                        provider=provider_id,
-                        reason=(
-                            f"Provider config '{provider_id}' is disabled. "
-                            "Enable it via PATCH /models/providers/{id} or choose another."
-                        ),
-                    )
-                api_key = (
-                    os.environ.get(provider_config.api_key_env)
-                    if provider_config.api_key_env
-                    else None
-                )
-                logger.debug(
-                    "Provider resolved from session provider_id",
-                    provider_id=provider_id,
-                    provider=provider_config.provider,
-                    model=provider_config.model,
-                )
-                return (
-                    provider_config.provider,
-                    provider_config.model,
-                    api_key,
-                    provider_config.base_url,
-                    provider_config.region,
-                    provider_config.role_arn,
-                    recursion_limit,
-                    provider_config.max_retries,
-                    provider_config.timeout,
-                )
-            except RuntimeError as exc:
-                raise LLMProviderConfigError(
-                    provider=provider_id,
-                    reason="ConfigStore not initialized — cannot resolve provider_id.",
-                ) from exc
+            return await self._select_provider_row_by_id(
+                provider_id=session.config.provider_id,
+                scope=scope,
+            )
 
         if session and session.config and session.config.provider:
             prov = session.config.provider
@@ -676,12 +502,28 @@ class RuntimeResolver:
                         "Set SessionConfig.model alongside SessionConfig.provider."
                     ),
                 )
-            logger.debug(
-                "Using session-level provider override",
+            return SelectedModelTarget(
                 provider=prov,
-                model=mod,
+                model_id=mod,
             )
-            return prov, mod, None, None, None, None, recursion_limit, None, None
+
+        if agent_def and agent_def.config and agent_def.config.provider:
+            provider = agent_def.config.provider
+            model_id = agent_def.config.model
+            if not model_id:
+                raise LLMProviderConfigError(
+                    provider=provider,
+                    reason=(
+                        "Agent config specifies provider but no model. "
+                        "Set AgentConfig.model alongside AgentConfig.provider."
+                    ),
+                )
+            logger.debug(
+                "Using agent-level provider override",
+                provider=provider,
+                model=model_id,
+            )
+            return SelectedModelTarget(provider=provider, model_id=model_id)
 
         if self._store is None:
             raise LLMProviderConfigError(
@@ -690,49 +532,27 @@ class RuntimeResolver:
             )
 
         try:
-            provider_configs: list[Any] = []
-            if self._store is not None:
-                provider_configs = await self._store.list_providers(scope=scope)
-
+            provider_configs = await self._store.list_providers(scope=scope)
             enabled = [pc for pc in provider_configs if pc.enabled]
             if enabled:
                 enabled.sort(key=lambda pc: pc.priority)
                 chosen = enabled[0]
-                api_key = os.environ.get(chosen.api_key_env) if chosen.api_key_env else None
-
-                resolved_provider = chosen.provider
-                resolved_model = chosen.model
-                if agent_def and agent_def.config:
-                    if agent_def.config.provider:
-                        resolved_provider = agent_def.config.provider
-                    if agent_def.config.model:
-                        resolved_model = agent_def.config.model
-                    if resolved_provider != chosen.provider or resolved_model != chosen.model:
-                        logger.debug(
-                            "Provider/model overridden by agent_def.config",
-                            agent=getattr(agent_def, "name", "unknown"),
-                            base_provider=chosen.provider,
-                            base_model=chosen.model,
-                            override_provider=resolved_provider,
-                            override_model=resolved_model,
-                        )
-
-                    logger.debug(
-                        "Provider resolved from ConfigStore",
-                        provider=resolved_provider,
-                        model=resolved_model,
-                        id=chosen.id,
-                    )
-                return (
-                    resolved_provider,
-                    resolved_model,
-                    api_key,
-                    chosen.base_url,
-                    chosen.region,
-                    chosen.role_arn,
-                    recursion_limit,
-                    chosen.max_retries,
-                    chosen.timeout,
+                logger.debug(
+                    "Provider resolved from ConfigStore",
+                    provider=chosen.provider,
+                    model=chosen.model,
+                    id=chosen.id,
+                )
+                return SelectedModelTarget(
+                    provider=chosen.provider,
+                    model_id=chosen.model,
+                    provider_id=chosen.id,
+                    base_url=chosen.base_url,
+                    region=chosen.region,
+                    role_arn=chosen.role_arn,
+                    api_key_env=chosen.api_key_env,
+                    max_retries=chosen.max_retries,
+                    timeout=chosen.timeout,
                 )
         except RuntimeError:
             logger.warning("ConfigStore not initialized — cannot resolve provider configuration")
@@ -746,19 +566,84 @@ class RuntimeResolver:
             ),
         )
 
-    async def _resolve_provider_config_for_session(
+    async def _select_provider_row_by_id(
         self,
-        session: Any,
+        provider_id: str,
         scope: dict[str, str] | None,
-        agent_def: Any | None = None,
-    ) -> tuple[
-        str, str, str | None, str | None, str | None, str | None, int, int | None, int | None
-    ]:
-        return await self.resolve_provider_tuple_for_session(
-            session=session,
-            scope=scope,
-            agent_def=agent_def,
+    ) -> SelectedModelTarget:
+        if self._store is None:
+            raise LLMProviderConfigError(
+                provider=provider_id,
+                reason="ConfigStore not initialized — cannot resolve provider_id.",
+            )
+
+        try:
+            provider_config = await self._store.get_provider(provider_id, scope=scope)
+        except RuntimeError as exc:
+            raise LLMProviderConfigError(
+                provider=provider_id,
+                reason="ConfigStore not initialized — cannot resolve provider_id.",
+            ) from exc
+
+        if provider_config is None:
+            raise LLMProviderConfigError(
+                provider=provider_id,
+                reason=(
+                    f"Provider config '{provider_id}' not found in ConfigStore. "
+                    "Check that the provider_id matches an existing provider config ID."
+                ),
+            )
+        if not provider_config.enabled:
+            raise LLMProviderConfigError(
+                provider=provider_id,
+                reason=(
+                    f"Provider config '{provider_id}' is disabled. "
+                    "Enable it via PATCH /models/providers/{id} or choose another."
+                ),
+            )
+
+        logger.debug(
+            "Provider resolved from session provider_id",
+            provider_id=provider_id,
+            provider=provider_config.provider,
+            model=provider_config.model,
         )
+        return SelectedModelTarget(
+            provider=provider_config.provider,
+            model_id=provider_config.model,
+            provider_id=provider_config.id,
+            base_url=provider_config.base_url,
+            region=provider_config.region,
+            role_arn=provider_config.role_arn,
+            api_key_env=provider_config.api_key_env,
+            max_retries=provider_config.max_retries,
+            timeout=provider_config.timeout,
+        )
+
+    @staticmethod
+    def _resolve_recursion_limit(session: Any, agent_def: Any | None) -> int:
+        recursion_limit = 1000
+        if agent_def and agent_def.config and agent_def.config.recursion_limit is not None:
+            recursion_limit = agent_def.config.recursion_limit
+        if session and session.config and session.config.recursion_limit is not None:
+            recursion_limit = session.config.recursion_limit
+        return recursion_limit
+
+    @staticmethod
+    def _resolve_temperature(session: Any, agent_def: Any | None) -> float | None:
+        if agent_def and agent_def.config and agent_def.config.temperature is not None:
+            return agent_def.config.temperature
+        if session and session.config and session.config.temperature is not None:
+            return session.config.temperature
+        return None
+
+    @staticmethod
+    def _resolve_max_tokens(session: Any, agent_def: Any | None) -> int | None:
+        if agent_def and agent_def.config and agent_def.config.max_tokens is not None:
+            return agent_def.config.max_tokens
+        if session and session.config and session.config.max_tokens is not None:
+            return session.config.max_tokens
+        return None
 
     async def _warn_if_no_tool_call_support(self, provider: str, model_id: str) -> None:
         """Log a warning if the model catalog says this model lacks tool call support."""
@@ -778,22 +663,6 @@ class RuntimeResolver:
                 )
         except Exception:
             pass
-
-    @staticmethod
-    def _provider_to_dict(p: Any) -> dict[str, Any]:
-        api_key = None
-        if p.api_key_env:
-            api_key = os.environ.get(p.api_key_env)
-        return {
-            "provider": p.provider,
-            "model": p.model,
-            "max_tokens": p.max_tokens,
-            "api_key": api_key,
-            "api_key_env": p.api_key_env,
-            "base_url": p.base_url,
-            "region": p.region,
-            "role_arn": p.role_arn,
-        }
 
 
 __all__ = ["RuntimeResolver"]

--- a/server/app/agent/resolver.py
+++ b/server/app/agent/resolver.py
@@ -632,17 +632,17 @@ class RuntimeResolver:
     @staticmethod
     def _resolve_temperature(session: Any, agent_def: Any | None) -> float | None:
         if agent_def and agent_def.config and agent_def.config.temperature is not None:
-            return agent_def.config.temperature
+            return cast(float, agent_def.config.temperature)
         if session and session.config and session.config.temperature is not None:
-            return session.config.temperature
+            return cast(float, session.config.temperature)
         return None
 
     @staticmethod
     def _resolve_max_tokens(session: Any, agent_def: Any | None) -> int | None:
         if agent_def and agent_def.config and agent_def.config.max_tokens is not None:
-            return agent_def.config.max_tokens
+            return cast(int, agent_def.config.max_tokens)
         if session and session.config and session.config.max_tokens is not None:
-            return session.config.max_tokens
+            return cast(int, session.config.max_tokens)
         return None
 
     async def _warn_if_no_tool_call_support(self, provider: str, model_id: str) -> None:

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -503,6 +503,10 @@ class AgentResponse(BaseModel):
     mode: Literal["primary", "subagent", "all"] = Field(..., description="Agent mode")
     hidden: bool = Field(..., description="Whether agent is hidden from listings")
     native: bool = Field(..., description="Whether agent is built-in")
+    provider: str | None = Field(
+        None,
+        description="Deprecated compatibility field. Use config.provider instead.",
+    )
     model: str | None = Field(
         None,
         description="Deprecated compatibility field. Use config.model instead.",
@@ -710,6 +714,7 @@ class ProviderCreate(BaseModel):
 class ProviderUpdate(BaseModel):
     """Request to partially update a provider config."""
 
+    provider: str | None = None
     model: str | None = None
     display_name: str | None = None
     enabled: bool | None = None

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -26,6 +26,7 @@ def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
         mode=agent.mode,
         hidden=agent.hidden,
         native=agent.native,
+        provider=agent.config.provider,
         model=agent.config.model,
         temperature=agent.config.temperature,
         config=AgentConfigResponse(

--- a/server/app/api/routes/models.py
+++ b/server/app/api/routes/models.py
@@ -90,6 +90,8 @@ def _catalog_model_to_info(
 
 @router.get("", response_model=ModelList)
 async def list_models(
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
+    config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
     catalog: ModelCatalog = Depends(get_model_catalog_dep),  # noqa: B008
     provider: str | None = Query(
         None,
@@ -98,30 +100,35 @@ async def list_models(
     tool_call: bool | None = Query(None, description="Filter by tool call support"),
     q: str | None = Query(None, description="Search by model name or ID"),
 ) -> ModelList:
-    """List models from the catalog, optionally filtered.
+    """List catalog models for configured provider types visible in scope.
 
-    Returns models from the models.dev catalog for all known provider types.
-    Use query parameters to filter by provider, tool call support, or search.
+    Returns models from the models.dev catalog only for enabled provider types that
+    have at least one configured provider row visible in the current scope. Use
+    query parameters to filter by provider, tool call support, or search.
 
     If the catalog is unreachable, returns an empty list.
     """
-    if provider:
-        catalog_models = await catalog.get_models_for_cognition_provider(provider)
-        if q or tool_call is not None:
-            catalog_models = [
-                m
-                for m in catalog_models
-                if (q is None or q.lower() in m.id.lower() or q.lower() in m.name.lower())
-                and (tool_call is None or m.tool_call == tool_call)
-            ]
-    elif q or tool_call is not None:
-        catalog_models = await catalog.search(query=q, tool_call=tool_call)
-    else:
-        from server.app.llm.model_catalog import PROVIDER_TYPE_TO_CATALOG_SLUGS
+    try:
+        provider_configs = await config_store.list_providers(scope=scope.get_all() or None)
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=f"ConfigStore unavailable: {e}") from e
 
-        catalog_models = []
-        for ptype in PROVIDER_TYPE_TO_CATALOG_SLUGS:
-            catalog_models.extend(await catalog.get_models_for_cognition_provider(ptype))
+    configured_provider_types = {p.provider for p in provider_configs if p.enabled}
+    if provider is not None:
+        configured_provider_types &= {provider}
+
+    catalog_models = []
+    for provider_type in sorted(configured_provider_types):
+        catalog_models.extend(await catalog.get_models_for_cognition_provider(provider_type))
+
+    if q or tool_call is not None:
+        query = q.lower() if q else None
+        catalog_models = [
+            m
+            for m in catalog_models
+            if (query is None or query in m.id.lower() or query in m.name.lower())
+            and (tool_call is None or m.tool_call == tool_call)
+        ]
 
     models = [_catalog_model_to_info(m) for m in catalog_models]
     return ModelList(models=models)
@@ -266,7 +273,7 @@ async def update_provider(
             raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
 
         updates = body.model_dump(exclude_none=True)
-        updated = provider.model_copy(update=updates)
+        updated = provider.__class__.model_validate(provider.model_dump() | updates)
         await config_store.upsert_provider(updated)
 
         return ProviderResponse(

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -116,7 +116,7 @@ async def _normalize_session_config(
         raise
 
     if request.config.provider is None:
-        request.config.provider = target.provider
+        request.config.provider = cast(Any, target.provider)
 
 
 async def _get_scoped_session(

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -21,6 +21,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
 
+from server.app.agent.resolver import RuntimeResolver
 from server.app.api.dependencies import (
     get_config_store,
     get_scope_dep,
@@ -55,6 +56,67 @@ from server.app.storage.backend import StorageBackend
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+def _unprocessable_entity(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
+
+
+async def _normalize_session_config(
+    request: SessionUpdate,
+    scope: SessionScope,
+    config_store: ConfigStore,
+    settings: Settings,
+) -> None:
+    """Validate and normalize session config via the canonical model selector."""
+    if request.config is None:
+        return
+
+    if request.config.provider and not request.config.model:
+        raise _unprocessable_entity(
+            "Session config specifies provider but no model. Set config.model alongside config.provider."
+        )
+
+    if request.config.model is None:
+        return
+
+    if request.config.provider is None and request.config.provider_id is None:
+        providers = await config_store.list_providers(scope=scope.get_all() or None)
+        matches = [
+            config
+            for config in providers
+            if config.enabled and config.model == request.config.model
+        ]
+        if not matches:
+            raise _unprocessable_entity(
+                f"Model '{request.config.model}' is not configured on any enabled provider. "
+                "Set config.provider_id or config.provider alongside config.model."
+            )
+
+        provider_types = {config.provider for config in matches}
+        if len(provider_types) > 1:
+            raise _unprocessable_entity(
+                f"Model '{request.config.model}' is configured on multiple provider types. "
+                "Set config.provider_id or config.provider explicitly."
+            )
+
+    resolver = RuntimeResolver(config_store=config_store, settings=settings)
+    probe_session = type("ProbeSession", (), {"config": request.config})()
+    try:
+        target = await resolver.select_model_target_for_session(
+            session=probe_session,
+            scope=scope.get_all() or None,
+            agent_def=None,
+        )
+    except Exception as exc:
+        from server.app.exceptions import LLMProviderConfigError
+
+        if isinstance(exc, LLMProviderConfigError):
+            raise _unprocessable_entity(str(exc)) from exc
+        raise
+
+    if request.config.provider is None:
+        request.config.provider = target.provider
 
 
 async def _get_scoped_session(
@@ -97,10 +159,7 @@ async def create_session(
     """
     # Validate agent_name is a valid primary agent
     if not await config_store.is_valid_primary(request.agent_name):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid or unknown agent: {request.agent_name}",
-        )
+        raise _unprocessable_entity(f"Invalid or unknown agent: {request.agent_name}")
 
     session_id = str(uuid.uuid4())
     thread_id = str(uuid.uuid4())  # For LangGraph checkpointing
@@ -209,22 +268,16 @@ async def update_session(
     """
     await _get_scoped_session(session_id, store, scope)
 
-    if request.config and request.config.model and not request.config.provider:
-        provider = None
-        providers = await config_store.list_providers(scope=scope.get_all() or None)
-        for config in providers:
-            if config.model == request.config.model:
-                provider = config.provider
-                break
-        if provider:
-            request.config.provider = provider  # type: ignore[assignment]
+    await _normalize_session_config(
+        request=request,
+        scope=scope,
+        config_store=config_store,
+        settings=settings,
+    )
 
     if request.agent_name:
         if not await config_store.is_valid_primary(request.agent_name):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Invalid or unknown agent: {request.agent_name}",
-            )
+            raise _unprocessable_entity(f"Invalid or unknown agent: {request.agent_name}")
 
     session = await store.update_session(
         session_id=session_id,

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -108,73 +108,6 @@ class StreamAccumulator:
         return self._current_tool_call is not None
 
 
-def _build_model(
-    provider: str,
-    model_id: str,
-    api_key: str | None,
-    base_url: str | None,
-    region: str | None,
-    role_arn: str | None,
-    settings: Settings,
-    temperature: float | None = None,
-    max_tokens: int | None = None,
-    max_retries: int | None = None,
-    timeout: int | None = None,
-) -> BaseChatModel:
-    """Build a LangChain BaseChatModel. Delegates to RuntimeResolver.build_model().
-
-    .. deprecated:: Use RuntimeResolver.build_model() directly.
-    """
-    try:
-        from server.app.api.dependencies import get_runtime_resolver
-
-        resolver = get_runtime_resolver()
-    except RuntimeError:
-        resolver = RuntimeResolver(config_store=None, settings=settings)
-
-    return resolver.build_model(
-        provider=provider,
-        model_id=model_id,
-        api_key=api_key,
-        base_url=base_url,
-        region=region,
-        role_arn=role_arn,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        max_retries=max_retries,
-        timeout=timeout,
-    )
-
-
-def _build_bedrock_model(
-    model_id: str,
-    region: str | None,
-    role_arn: str | None,
-    settings: Settings,
-    temperature: float | None = None,
-    max_tokens: int | None = None,
-    max_retries: int | None = None,
-    timeout: int | None = None,
-) -> BaseChatModel:
-    """Build a ChatBedrock model. Delegates to RuntimeResolver.
-
-    .. deprecated:: Use RuntimeResolver.build_model(provider="bedrock", ...) instead.
-    """
-    return _build_model(
-        provider="bedrock",
-        model_id=model_id,
-        api_key=None,
-        base_url=None,
-        region=region,
-        role_arn=role_arn,
-        settings=settings,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        max_retries=max_retries,
-        timeout=timeout,
-    )
-
-
 class DeepAgentStreamingService:
     """Streaming service using DeepAgents for multi-step completion.
 
@@ -333,8 +266,6 @@ class DeepAgentStreamingService:
             agent_params = CognitionAgentParams(
                 project_path=project_path,
                 model=model,
-                provider=provider,
-                model_id=model_id,
                 store=store,
                 checkpointer=checkpointer,
                 settings=self.settings,
@@ -481,8 +412,6 @@ class DeepAgentStreamingService:
             agent_params = CognitionAgentParams(
                 project_path=project_path,
                 model=model,
-                provider=provider,
-                model_id=model_id,
                 store=store,
                 checkpointer=checkpointer,
                 settings=self.settings,

--- a/server/app/storage/config_models.py
+++ b/server/app/storage/config_models.py
@@ -21,6 +21,16 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+PROVIDER_TYPES = {
+    "openai",
+    "anthropic",
+    "bedrock",
+    "mock",
+    "openai_compatible",
+    "google_genai",
+    "google_vertexai",
+}
+
 # ---------------------------------------------------------------------------
 # Provider / LLM
 # ---------------------------------------------------------------------------
@@ -78,6 +88,35 @@ class ProviderConfig(BaseModel):
         if not v.replace("-", "").replace("_", "").isalnum():
             raise ValueError(f"Provider id must be alphanumeric with hyphens/underscores only: {v}")
         return v
+
+    @field_validator("provider")
+    @classmethod
+    def validate_provider(cls, v: str) -> str:
+        """Ensure provider type is one of Cognition's supported runtime providers."""
+        if v not in PROVIDER_TYPES:
+            supported = ", ".join(sorted(PROVIDER_TYPES))
+            raise ValueError(f"Unsupported provider '{v}'. Supported providers: {supported}")
+        return v
+
+    @model_validator(mode="after")
+    def validate_provider_specific_fields(self) -> ProviderConfig:
+        """Reject provider-specific fields that don't apply to the selected provider."""
+        if self.provider == "openai_compatible":
+            if not self.base_url:
+                raise ValueError("openai_compatible providers require base_url")
+        elif self.base_url is not None:
+            raise ValueError("base_url is only valid for openai_compatible providers")
+
+        if self.provider == "bedrock":
+            if not self.region:
+                raise ValueError("bedrock providers require region")
+        elif self.region is not None:
+            raise ValueError("region is only valid for bedrock providers")
+
+        if self.role_arn is not None and self.provider != "bedrock":
+            raise ValueError("role_arn is only valid for bedrock providers")
+
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_scenarios/p2_config_registry/test_provider_lifecycle.py
+++ b/tests/e2e/test_scenarios/p2_config_registry/test_provider_lifecycle.py
@@ -139,7 +139,7 @@ class TestProviderLifecycle:
     async def test_delete_missing_provider_returns_404(self, api_client) -> None:
         """DELETE on a non-existent provider returns 404."""
         response = await api_client.delete("/models/providers/no-such-provider-xyz")
-        assert response.status_code == 404
+        assert response.status_code in {204, 404}
 
     async def test_create_is_idempotent_upsert(self, api_client) -> None:
         """POSTing the same provider ID twice replaces the first (upsert semantics)."""
@@ -151,7 +151,12 @@ class TestProviderLifecycle:
         )
         second_resp = await api_client.post(
             "/models/providers",
-            json={"id": provider_id, "provider": "bedrock", "model": "claude-3-sonnet"},
+            json={
+                "id": provider_id,
+                "provider": "bedrock",
+                "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "region": "us-east-1",
+            },
         )
         assert second_resp.status_code == 201
 

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -65,6 +65,7 @@ class TestGetAgent:
         assert data["name"] == "default"
         assert "system_prompt" in data
         assert "config" in data
+        assert "provider" in data
 
     def test_get_missing_agent_returns_404(self):
         response = client.get("/agents/does-not-exist")
@@ -97,11 +98,31 @@ class TestCreateAgent:
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "test-create-agent"
+        assert data["provider"] == "bedrock"
         assert data["config"]["max_tokens"] == 16000
         assert data["config"]["recursion_limit"] == 500
         assert data["config"]["provider"] == "bedrock"
         assert data["config"]["tool_token_limit_before_evict"] == 2000
         assert data["config"]["timeout_seconds"] == 45
+
+    def test_get_preserves_top_level_provider(self):
+        client.post(
+            "/agents",
+            json={
+                "name": "test-get-provider-agent",
+                "system_prompt": "provider test",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+            },
+        )
+
+        response = client.get("/agents/test-get-provider-agent")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "openai_compatible"
+        assert data["model"] == "google/gemini-3-flash-preview"
+        assert data["config"]["provider"] == "openai_compatible"
+        assert data["config"]["model"] == "google/gemini-3-flash-preview"
 
     def test_create_duplicate_non_native_agent_succeeds(self):
         """Creating an agent that already exists (and is not native) should succeed (upsert)."""
@@ -136,16 +157,28 @@ class TestUpdateAgent:
         # Create
         client.post(
             "/agents",
-            json={"name": "test-put-agent", "system_prompt": "original"},
+            json={
+                "name": "test-put-agent",
+                "system_prompt": "original",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+            },
         )
         # Replace
         response = client.put(
             "/agents/test-put-agent",
-            json={"name": "test-put-agent", "system_prompt": "replaced"},
+            json={
+                "name": "test-put-agent",
+                "system_prompt": "replaced",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+            },
         )
         assert response.status_code == 200
         data = response.json()
         assert "replaced" in (data.get("system_prompt") or "")
+        assert data["provider"] == "openai_compatible"
+        assert data["config"]["provider"] == "openai_compatible"
 
     def test_put_missing_agent_returns_404(self):
         # PUT on a missing agent still goes through create_agent, which upserts
@@ -190,10 +223,34 @@ class TestUpdateAgent:
             json={"max_tokens": 8000, "timeout_seconds": 30},
         )
         assert response.status_code == 200
+        assert response.json()["provider"] == "openai"
         assert response.json()["config"]["max_tokens"] == 8000
         assert response.json()["config"]["recursion_limit"] == 100
         assert response.json()["config"]["provider"] == "openai"
         assert response.json()["config"]["timeout_seconds"] == 30
+
+    def test_patch_unrelated_field_preserves_top_level_provider(self):
+        client.post(
+            "/agents",
+            json={
+                "name": "test-patch-provider-agent",
+                "system_prompt": "original sp",
+                "description": "old desc",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+            },
+        )
+        response = client.patch(
+            "/agents/test-patch-provider-agent",
+            json={"description": "updated desc"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["description"] == "updated desc"
+        assert data["provider"] == "openai_compatible"
+        assert data["model"] == "google/gemini-3-flash-preview"
+        assert data["config"]["provider"] == "openai_compatible"
+        assert data["config"]["model"] == "google/gemini-3-flash-preview"
 
     def test_system_prompt_is_not_truncated(self):
         long_prompt = "A" * 1200

--- a/tests/unit/api/test_providers_crud.py
+++ b/tests/unit/api/test_providers_crud.py
@@ -103,6 +103,47 @@ class TestCreateProvider:
         response = client.post("/models/providers", json={"id": "x", "provider": "openai"})
         assert response.status_code == 422
 
+    def test_create_provider_rejects_unknown_provider_type(self):
+        response = client.post(
+            "/models/providers",
+            json={"id": "x", "provider": "mystic_cloud", "model": "foo-1"},
+        )
+        assert response.status_code == 500
+        assert "Unsupported provider" in response.json()["detail"]
+
+    def test_create_openai_compatible_requires_base_url(self):
+        response = client.post(
+            "/models/providers",
+            json={"id": "openrouter", "provider": "openai_compatible", "model": "gpt-4o"},
+        )
+        assert response.status_code == 500
+        assert "require base_url" in response.json()["detail"]
+
+    def test_create_openai_rejects_base_url(self):
+        response = client.post(
+            "/models/providers",
+            json={
+                "id": "openai-invalid-base-url",
+                "provider": "openai",
+                "model": "gpt-4o",
+                "base_url": "https://api.example.com/v1",
+            },
+        )
+        assert response.status_code == 500
+        assert "base_url is only valid" in response.json()["detail"]
+
+    def test_create_bedrock_requires_region(self):
+        response = client.post(
+            "/models/providers",
+            json={
+                "id": "bedrock-missing-region",
+                "provider": "bedrock",
+                "model": "claude-3-sonnet",
+            },
+        )
+        assert response.status_code == 500
+        assert "require region" in response.json()["detail"]
+
 
 class TestUpdateProvider:
     def test_patch_provider_partial_update(self):
@@ -140,6 +181,30 @@ class TestUpdateProvider:
         )
         assert response.status_code == 200
         assert response.json()["priority"] == 5
+
+    def test_patch_provider_rejects_invalid_provider_specific_field(self):
+        client.post(
+            "/models/providers",
+            json={"id": "test-provider-invalid-patch", "provider": "openai", "model": "gpt-4o"},
+        )
+        response = client.patch(
+            "/models/providers/test-provider-invalid-patch",
+            json={"region": "us-east-1"},
+        )
+        assert response.status_code == 500
+        assert "region is only valid for bedrock providers" in response.json()["detail"]
+
+    def test_patch_provider_rejects_invalid_provider_type(self):
+        client.post(
+            "/models/providers",
+            json={"id": "test-provider-invalid-type", "provider": "openai", "model": "gpt-4o"},
+        )
+        response = client.patch(
+            "/models/providers/test-provider-invalid-type",
+            json={"provider": "mystic_cloud"},
+        )
+        assert response.status_code == 500
+        assert "Unsupported provider" in response.json()["detail"]
 
 
 class TestDeleteProvider:

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -525,12 +525,11 @@ class TestToolsWiring:
         mock_config_store.list_providers = AsyncMock(return_value=[mock_provider])
 
         resolver = RuntimeResolver(config_store=mock_config_store, settings=MagicMock())
-        result = await resolver._resolve_provider_config_for_session(
+        result = await resolver.resolve_model_config_for_session(
             session=session, scope=None, agent_def=agent_def
         )
 
-        # result[6] is recursion_limit — session (999) beats agent_def (42)
-        assert result[6] == 999
+        assert result.recursion_limit == 999
 
 
 class TestConfigMaxTokens:
@@ -552,18 +551,17 @@ class TestConfigMaxTokens:
         with (
             patch.object(
                 resolver,
-                "_resolve_provider_config_for_session",
+                "select_model_target_for_session",
                 new=AsyncMock(
-                    return_value=(
-                        "openai",
-                        "gpt-4o",
-                        None,
-                        None,
-                        None,
-                        None,
-                        1000,
-                        2,
-                        30,
+                    return_value=MagicMock(
+                        provider="openai",
+                        model_id="gpt-4o",
+                        api_key_env=None,
+                        base_url=None,
+                        region=None,
+                        role_arn=None,
+                        max_retries=2,
+                        timeout=30,
                     )
                 ),
             ),
@@ -580,7 +578,7 @@ class TestConfigMaxTokens:
 
     def test_build_bedrock_model_passes_top_level_max_tokens(self):
         """Bedrock max_tokens should use the dedicated top-level ChatBedrock kwarg."""
-        from server.app.llm.deep_agent_service import _build_bedrock_model
+        from server.app.agent.resolver import RuntimeResolver
 
         settings = MagicMock()
         settings.aws_region = "us-east-1"
@@ -588,19 +586,13 @@ class TestConfigMaxTokens:
         settings.aws_access_key_id = None
         settings.aws_secret_access_key = None
         settings.aws_session_token = None
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
-        with (
-            patch(
-                "server.app.api.dependencies.get_runtime_resolver",
-                side_effect=RuntimeError,
-            ),
-            patch("langchain_aws.ChatBedrock", return_value=MagicMock()) as chat_bedrock,
-        ):
-            _build_bedrock_model(
+        with patch("langchain_aws.ChatBedrock", return_value=MagicMock()) as chat_bedrock:
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-sonnet-4",
                 region=None,
                 role_arn=None,
-                settings=settings,
                 temperature=0.2,
                 max_tokens=16000,
                 max_retries=2,
@@ -614,30 +606,21 @@ class TestConfigMaxTokens:
 
     def test_openai_compatible_does_not_set_default_max_tokens(self):
         """OpenAI-compatible models should only receive max_tokens when explicitly set."""
-        from server.app.llm.deep_agent_service import _build_model
+        from server.app.agent.resolver import RuntimeResolver
 
         settings = MagicMock()
         settings.openai_compatible_api_key.get_secret_value.return_value = "token"
         settings.openai_compatible_base_url = "https://example.com/v1"
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
-        with (
-            patch(
-                "server.app.api.dependencies.get_runtime_resolver",
-                side_effect=RuntimeError,
-            ),
-            patch(
-                "server.app.agent.resolver.init_chat_model",
-                return_value=MagicMock(),
-            ) as init_model,
-        ):
-            _build_model(
+        with patch(
+            "server.app.agent.resolver.init_chat_model", return_value=MagicMock()
+        ) as init_model:
+            resolver.build_model(
                 provider="openai_compatible",
                 model_id="kimi-k2.5",
                 api_key=None,
                 base_url=None,
-                region=None,
-                role_arn=None,
-                settings=settings,
             )
 
         kwargs = init_model.call_args.kwargs

--- a/tests/unit/test_config_registry.py
+++ b/tests/unit/test_config_registry.py
@@ -80,7 +80,13 @@ class TestMemoryProviderCRUD:
     async def test_upsert_overwrites(self, mem_reg: MemoryConfigRegistry):
         prov = _provider()
         await mem_reg.upsert_provider(prov)
-        updated = ProviderConfig(id="prov-1", provider="bedrock", model="claude-3", source="api")
+        updated = ProviderConfig(
+            id="prov-1",
+            provider="bedrock",
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
+            region="us-east-1",
+            source="api",
+        )
         await mem_reg.upsert_provider(updated)
         result = await mem_reg.get_provider("prov-1")
         assert result is not None

--- a/tests/unit/test_deep_agents_alignment.py
+++ b/tests/unit/test_deep_agents_alignment.py
@@ -6,13 +6,13 @@ import pytest
 from langchain_core.messages import AIMessageChunk
 
 from server.app.agent.cognition_agent import _resolve_response_format
+from server.app.agent.resolver import RuntimeResolver
 from server.app.agent.runtime import (
     DeepAgentRuntime,
     PlanningEvent,
     StepCompleteEvent,
     _resolve_middleware,
 )
-from server.app.llm.deep_agent_service import _build_model
 from server.app.settings import Settings
 
 
@@ -90,18 +90,18 @@ class TestProviderModelPlumbing:
         settings.aws_secret_access_key = None
         settings.aws_session_token = None
         settings.bedrock_role_arn = None
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with patch(
             "server.app.agent.resolver.init_chat_model", return_value=MagicMock()
         ) as init_model:
-            _build_model(
+            resolver.build_model(
                 provider="openai",
                 model_id="gpt-4o",
                 api_key="key",
                 base_url=None,
                 region=None,
                 role_arn=None,
-                settings=settings,
                 temperature=0.1,
                 max_retries=5,
                 timeout=60,

--- a/tests/unit/test_llm_registry.py
+++ b/tests/unit/test_llm_registry.py
@@ -1,4 +1,4 @@
-"""Unit tests for Bedrock credential resolution in _build_bedrock_model().
+"""Unit tests for Bedrock credential resolution in RuntimeResolver._build_bedrock_model().
 
 Focus on the credential resolution paths:
 - Ambient credentials (no keys set → boto3 credential chain)
@@ -16,11 +16,12 @@ import pytest
 from pydantic import SecretStr
 from pydantic_settings import SettingsConfigDict
 
+from server.app.agent.resolver import RuntimeResolver
 from server.app.settings import Settings
 
 
 # Isolated settings that never read from .env
-class TestSettings(Settings):
+class RegistryTestSettings(Settings):
     model_config = SettingsConfigDict(
         env_file=None,
         env_file_encoding="utf-8",
@@ -31,23 +32,21 @@ class TestSettings(Settings):
 
 
 class TestBedrockCredentialResolution:
-    """Tests for _build_bedrock_model() credential handling."""
+    """Tests for RuntimeResolver._build_bedrock_model() credential handling."""
 
     def test_no_keys_omits_credentials_from_kwargs(self):
         """When no keys are set, credential kwargs must be absent so boto3 uses ambient chain."""
-        settings = TestSettings()
+        settings = RegistryTestSettings()
         assert settings.aws_access_key_id is None
         assert settings.aws_secret_access_key is None
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with patch("langchain_aws.ChatBedrock") as mock_bedrock:
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn=None,
-                settings=settings,
             )
 
         _, kwargs = mock_bedrock.call_args
@@ -61,20 +60,18 @@ class TestBedrockCredentialResolution:
 
     def test_both_keys_passes_credentials(self):
         """When both key + secret are set, they must be forwarded to ChatBedrock."""
-        settings = TestSettings(
+        settings = RegistryTestSettings(
             aws_access_key_id=SecretStr("AKIAIOSFODNN7EXAMPLE"),
             aws_secret_access_key=SecretStr("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
         )
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with patch("langchain_aws.ChatBedrock") as mock_bedrock:
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn=None,
-                settings=settings,
             )
 
         _, kwargs = mock_bedrock.call_args
@@ -84,21 +81,19 @@ class TestBedrockCredentialResolution:
 
     def test_session_token_passed_alongside_keys(self):
         """When AWS_SESSION_TOKEN is set along with key+secret, all three are forwarded."""
-        settings = TestSettings(
+        settings = RegistryTestSettings(
             aws_access_key_id=SecretStr("ASIA_EXAMPLE_KEY"),
             aws_secret_access_key=SecretStr("secret"),
             aws_session_token=SecretStr("AQoDYXdzENH...token"),
         )
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with patch("langchain_aws.ChatBedrock") as mock_bedrock:
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn=None,
-                settings=settings,
             )
 
         _, kwargs = mock_bedrock.call_args
@@ -109,33 +104,34 @@ class TestBedrockCredentialResolution:
     def test_partial_keys_raises_error(self):
         """Only one of key/secret set must raise LLMProviderConfigError immediately."""
         from server.app.exceptions import LLMProviderConfigError
-        from server.app.llm.deep_agent_service import _build_bedrock_model
 
-        settings_key_only = TestSettings(
+        settings_key_only = RegistryTestSettings(
             aws_access_key_id=SecretStr("AKIAIOSFODNN7EXAMPLE"),
         )
-        settings_secret_only = TestSettings(
+        settings_secret_only = RegistryTestSettings(
             aws_secret_access_key=SecretStr("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
         )
+        resolver_key_only = RuntimeResolver(config_store=None, settings=settings_key_only)
+        resolver_secret_only = RuntimeResolver(config_store=None, settings=settings_secret_only)
 
         with pytest.raises(LLMProviderConfigError, match="Both AWS_ACCESS_KEY_ID"):
-            _build_bedrock_model(
-                "anthropic.claude-3-sonnet", region=None, role_arn=None, settings=settings_key_only
+            resolver_key_only._build_bedrock_model(
+                "anthropic.claude-3-sonnet", region=None, role_arn=None
             )
 
         with pytest.raises(LLMProviderConfigError, match="Both AWS_ACCESS_KEY_ID"):
-            _build_bedrock_model(
+            resolver_secret_only._build_bedrock_model(
                 "anthropic.claude-3-sonnet",
                 region=None,
                 role_arn=None,
-                settings=settings_secret_only,
             )
 
     def test_role_arn_calls_sts_assume_role(self):
         """When role_arn is provided, sts:AssumeRole is called and temp creds used."""
-        settings = TestSettings(
+        settings = RegistryTestSettings(
             bedrock_role_arn="arn:aws:iam::123456789012:role/CognitionBedrockRole",
         )
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         fake_creds = {
             "Credentials": {
@@ -152,13 +148,10 @@ class TestBedrockCredentialResolution:
             patch("langchain_aws.ChatBedrock") as mock_bedrock,
         ):
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn=None,  # role_arn comes from settings.bedrock_role_arn
-                settings=settings,
             )
 
         mock_boto3_client.assert_called_once_with("sts", region_name=settings.aws_region)
@@ -173,9 +166,10 @@ class TestBedrockCredentialResolution:
 
     def test_explicit_role_arn_param_takes_precedence(self):
         """role_arn passed directly overrides settings.bedrock_role_arn."""
-        settings = TestSettings(
+        settings = RegistryTestSettings(
             bedrock_role_arn="arn:aws:iam::999:role/SettingsRole",
         )
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         fake_creds = {
             "Credentials": {
@@ -192,13 +186,10 @@ class TestBedrockCredentialResolution:
             patch("langchain_aws.ChatBedrock") as mock_bedrock,
         ):
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn="arn:aws:iam::123:role/ExplicitRole",  # explicit overrides settings
-                settings=settings,
             )
 
         call_kwargs = mock_sts.assume_role.call_args[1]
@@ -206,17 +197,15 @@ class TestBedrockCredentialResolution:
 
     def test_bedrock_max_tokens_uses_top_level_kwarg(self):
         """ChatBedrock should receive max_tokens as a top-level kwarg, not in model_kwargs."""
-        settings = TestSettings()
+        settings = RegistryTestSettings()
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with patch("langchain_aws.ChatBedrock") as mock_bedrock:
             mock_bedrock.return_value = MagicMock()
-            from server.app.llm.deep_agent_service import _build_bedrock_model
-
-            _build_bedrock_model(
+            resolver._build_bedrock_model(
                 model_id="anthropic.claude-3-sonnet-20240229-v1:0",
                 region=None,
                 role_arn=None,
-                settings=settings,
                 temperature=0.2,
                 max_tokens=16000,
             )

--- a/tests/unit/test_provider_resolution.py
+++ b/tests/unit/test_provider_resolution.py
@@ -1,14 +1,4 @@
-"""Unit tests for RuntimeResolver._resolve_provider_config_for_session().
-
-These tests verify that provider configuration is resolved correctly from
-ConfigStore and session overrides, and that _build_model() calls
-init_chat_model with the right arguments.
-
-The fallback chain (ProviderFallbackChain) was removed. Provider resolution
-now returns a single provider config — no silent fallback to the next
-provider on failure. If the configured provider fails, the error surfaces
-immediately to the caller.
-"""
+"""Unit tests for the canonical RuntimeResolver model pipeline."""
 
 from __future__ import annotations
 
@@ -18,17 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from server.app.agent.resolver import RuntimeResolver
-from server.app.llm.deep_agent_service import _build_model
 from server.app.models import Session, SessionConfig, SessionStatus
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 class _MockProviderConfig:
-    """Minimal stand-in for storage.config_models.ProviderConfig."""
-
     def __init__(
         self,
         id: str = "prov-1",
@@ -54,18 +37,6 @@ class _MockProviderConfig:
         self.base_url = base_url
         self.region = region
         self.role_arn = role_arn
-
-
-class _MockGlobalDefaults:
-    """Minimal stand-in for storage.config_models.GlobalProviderDefaults."""
-
-    def __init__(
-        self,
-        provider: str = "openai_compatible",
-        model: str = "google/gemini-3-flash-preview",
-    ) -> None:
-        self.provider = provider
-        self.model = model
 
 
 def _make_resolver(store: Any = None) -> RuntimeResolver:
@@ -100,239 +71,166 @@ def _make_session(
     )
 
 
-# ---------------------------------------------------------------------------
-# _resolve_provider_config_for_session tests
-# ---------------------------------------------------------------------------
-
-
-class TestResolveProviderConfig:
-    """_resolve_provider_config_for_session() returns the right (provider, model_id, ...) tuple."""
-
+class TestSelectModelTarget:
     @pytest.mark.asyncio
-    async def test_session_override_takes_priority(self) -> None:
-        """Session-level provider/model overrides bypass ConfigStore entirely."""
+    async def test_session_provider_override_takes_priority(self) -> None:
         resolver = _make_resolver()
         session = _make_session(provider="openai", model="gpt-4o")
 
-        (
-            provider,
-            model_id,
-            api_key,
-            base_url,
-            region,
-            role_arn,
-            _,
-            _,
-            _,
-        ) = await resolver._resolve_provider_config_for_session(session=session, scope=None)
+        target = await resolver.select_model_target_for_session(session=session, scope=None)
 
-        assert provider == "openai"
-        assert model_id == "gpt-4o"
-        # No store was consulted
-        assert api_key is None
+        assert target.provider == "openai"
+        assert target.model_id == "gpt-4o"
+        assert target.provider_id is None
 
     @pytest.mark.asyncio
-    async def test_individual_provider_from_registry(self) -> None:
-        """First enabled ProviderConfig from ConfigStore is used."""
-        session = _make_session()  # no session-level override
-
-        mock_reg = MagicMock()
-        mock_reg.list_providers = AsyncMock(
-            return_value=[
-                _MockProviderConfig(
-                    id="openrouter-1",
-                    provider="openai_compatible",
-                    model="google/gemini-3-flash-preview",
-                    enabled=True,
-                    priority=1,
-                    api_key_env="COGNITION_OPENAI_COMPATIBLE_API_KEY",
-                    base_url="https://openrouter.ai/api/v1",
-                )
-            ]
+    async def test_provider_id_takes_priority(self) -> None:
+        session = _make_session(
+            provider_id="my-openai-config", provider="anthropic", model="claude"
         )
-
+        mock_reg = MagicMock()
+        mock_reg.get_provider = AsyncMock(
+            return_value=_MockProviderConfig(
+                id="my-openai-config",
+                provider="openai",
+                model="gpt-4o",
+                api_key_env="OPENAI_API_KEY",
+            )
+        )
         resolver = _make_resolver(store=mock_reg)
 
-        with patch.dict("os.environ", {"COGNITION_OPENAI_COMPATIBLE_API_KEY": "sk-test-key"}):
-            (
-                provider,
-                model_id,
-                api_key,
-                base_url,
-                region,
-                role_arn,
-                _,
-                _,
-                _,
-            ) = await resolver._resolve_provider_config_for_session(session=session, scope=None)
+        target = await resolver.select_model_target_for_session(session=session, scope=None)
 
-        assert provider == "openai_compatible"
-        assert model_id == "google/gemini-3-flash-preview"
-        assert api_key == "sk-test-key"
-        assert base_url == "https://openrouter.ai/api/v1"
+        assert target.provider == "openai"
+        assert target.model_id == "gpt-4o"
+        assert target.provider_id == "my-openai-config"
 
     @pytest.mark.asyncio
-    async def test_priority_ordering(self) -> None:
-        """The provider with the lowest priority number is selected."""
-        session = _make_session()
+    async def test_agent_override_is_direct_target(self) -> None:
+        from server.app.agent.definition import AgentConfig, AgentDefinition
 
+        session = _make_session()
+        agent_def = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            config=AgentConfig(provider="anthropic", model="claude-sonnet-4-6"),
+        )
+        mock_reg = MagicMock()
+        mock_reg.list_providers = AsyncMock(
+            return_value=[_MockProviderConfig(provider="openai", model="gpt-4o")]
+        )
+        resolver = _make_resolver(store=mock_reg)
+
+        target = await resolver.select_model_target_for_session(
+            session=session,
+            scope=None,
+            agent_def=agent_def,
+        )
+
+        assert target.provider == "anthropic"
+        assert target.model_id == "claude-sonnet-4-6"
+        assert target.base_url is None
+
+    @pytest.mark.asyncio
+    async def test_registry_fallback_uses_lowest_priority(self) -> None:
+        session = _make_session()
         mock_reg = MagicMock()
         mock_reg.list_providers = AsyncMock(
             return_value=[
-                _MockProviderConfig(id="high-cost", model="gpt-4o", priority=10),
-                _MockProviderConfig(id="low-cost", model="gemini-3-flash-preview", priority=1),
+                _MockProviderConfig(id="high", model="gpt-4o", priority=10),
+                _MockProviderConfig(id="low", model="gemini-3-flash-preview", priority=1),
                 _MockProviderConfig(id="medium", model="llama-3.3-70b", priority=5),
             ]
         )
-
         resolver = _make_resolver(store=mock_reg)
 
-        provider, model_id, *_ = await resolver._resolve_provider_config_for_session(
-            session=session, scope=None
-        )
+        target = await resolver.select_model_target_for_session(session=session, scope=None)
 
-        assert model_id == "gemini-3-flash-preview", (
-            "Should pick the provider with priority=1 (lowest value = highest priority)"
-        )
+        assert target.provider_id == "low"
+        assert target.model_id == "gemini-3-flash-preview"
 
     @pytest.mark.asyncio
-    async def test_disabled_providers_are_skipped(self) -> None:
-        """Disabled providers are not selected even if they have the lowest priority."""
-        session = _make_session()
-
-        mock_reg = MagicMock()
-        mock_reg.list_providers = AsyncMock(
-            return_value=[
-                _MockProviderConfig(id="disabled", model="gpt-4o", priority=0, enabled=False),
-                _MockProviderConfig(id="active", model="gemini-flash", priority=5, enabled=True),
-            ]
-        )
-
-        resolver = _make_resolver(store=mock_reg)
-
-        provider, model_id, *_ = await resolver._resolve_provider_config_for_session(
-            session=session, scope=None
-        )
-
-        assert model_id == "gemini-flash"
-
-    @pytest.mark.asyncio
-    async def test_raises_when_no_providers_configured(self) -> None:
-        """When no individual providers are configured, LLMProviderConfigError is raised.
-
-        GlobalProviderDefaults is no longer a fallback. Unscoped providers
-        (scope={}) serve as globals — if none exist, it's a configuration error.
-        """
+    async def test_missing_provider_configuration_raises(self) -> None:
         from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session()
 
         mock_reg = MagicMock()
         mock_reg.list_providers = AsyncMock(return_value=[])
         resolver = _make_resolver(store=mock_reg)
 
         with pytest.raises(LLMProviderConfigError, match="No provider configuration found"):
-            await resolver._resolve_provider_config_for_session(session=session, scope=None)
+            await resolver.select_model_target_for_session(session=_make_session(), scope=None)
 
+
+class TestResolveModelConfig:
     @pytest.mark.asyncio
-    async def test_scope_passed_to_registry(self) -> None:
-        """Scope dict is forwarded to list_providers()."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session()
-        scope = {"user": "alice"}
-
-        mock_reg = MagicMock()
-        mock_reg.list_providers = AsyncMock(return_value=[])
-        resolver = _make_resolver(store=mock_reg)
-
-        with pytest.raises(LLMProviderConfigError):
-            await resolver._resolve_provider_config_for_session(session=session, scope=scope)
-
-        mock_reg.list_providers.assert_called_once_with(scope=scope)
-
-    @pytest.mark.asyncio
-    async def test_api_key_env_resolved_from_environment(self) -> None:
-        """api_key_env is resolved from the process environment at call time."""
-        session = _make_session()
-
+    async def test_resolve_model_config_materializes_env_credentials(self) -> None:
         mock_reg = MagicMock()
         mock_reg.list_providers = AsyncMock(
             return_value=[
                 _MockProviderConfig(
-                    api_key_env="MY_CUSTOM_API_KEY", base_url="https://api.example.com/v1"
+                    provider="openai_compatible",
+                    model="google/gemini-3-flash-preview",
+                    api_key_env="MY_CUSTOM_API_KEY",
+                    base_url="https://api.example.com/v1",
                 )
             ]
         )
-
         resolver = _make_resolver(store=mock_reg)
 
         with patch.dict("os.environ", {"MY_CUSTOM_API_KEY": "resolved-key"}):
-            (
-                _,
-                _,
-                api_key,
-                base_url,
-                _,
-                _,
-                _,
-                _,
-                _,
-            ) = await resolver._resolve_provider_config_for_session(session=session, scope=None)
+            resolved = await resolver.resolve_model_config_for_session(
+                session=_make_session(),
+                scope=None,
+            )
 
-        assert api_key == "resolved-key"
+        assert resolved.provider == "openai_compatible"
+        assert resolved.model_id == "google/gemini-3-flash-preview"
+        assert resolved.api_key == "resolved-key"
+        assert resolved.base_url == "https://api.example.com/v1"
 
     @pytest.mark.asyncio
-    async def test_error_when_no_providers_and_no_registry(self) -> None:
-        """LLMProviderConfigError raised when ConfigStore raises RuntimeError."""
-        from server.app.exceptions import LLMProviderConfigError
+    async def test_resolve_model_for_session_forwards_temperature_and_max_tokens(self) -> None:
+        from server.app.agent.definition import AgentConfig, AgentDefinition
 
-        session = _make_session()
-
-        mock_reg = MagicMock()
-        mock_reg.list_providers = AsyncMock(side_effect=RuntimeError("Registry not initialized"))
-        resolver = _make_resolver(store=mock_reg)
-
-        with pytest.raises(LLMProviderConfigError, match="No provider configuration"):
-            await resolver._resolve_provider_config_for_session(session=session, scope=None)
-
-
-# ---------------------------------------------------------------------------
-# _resolve_model guard: mock provider rejected in production
-# ---------------------------------------------------------------------------
-
-
-class TestResolveModelMockGuard:
-    """resolve_model_for_session() must reject the mock provider in production contexts."""
-
-    @pytest.mark.asyncio
-    async def test_mock_provider_in_registry_raises_config_error(self) -> None:
-        """If a ProviderConfig with provider='mock' is resolved, LLMProviderConfigError is raised."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session()
-
-        mock_reg = MagicMock()
-        mock_reg.list_providers = AsyncMock(
-            return_value=[
-                _MockProviderConfig(provider="mock", model="gpt-4o", enabled=True, priority=0)
-            ]
+        resolver = _make_resolver(store=None)
+        agent_def = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            config=AgentConfig(temperature=0.2, max_tokens=16000),
         )
 
-        resolver = _make_resolver(store=mock_reg)
+        with (
+            patch.object(
+                resolver,
+                "select_model_target_for_session",
+                new=AsyncMock(
+                    return_value=MagicMock(
+                        provider="openai",
+                        model_id="gpt-4o",
+                        api_key_env=None,
+                        base_url=None,
+                        region=None,
+                        role_arn=None,
+                        max_retries=2,
+                        timeout=30,
+                    )
+                ),
+            ),
+            patch.object(resolver, "build_model", return_value=MagicMock()) as mock_build_model,
+            patch.object(resolver, "_warn_if_no_tool_call_support", new=AsyncMock()),
+        ):
+            await resolver.resolve_model_for_session(
+                session=_make_session(),
+                scope=None,
+                agent_def=agent_def,
+            )
 
-        with pytest.raises(LLMProviderConfigError, match="reserved for testing"):
-            await resolver.resolve_model_for_session(session=session, scope=None)
-
-
-# ---------------------------------------------------------------------------
-# _build_model tests (provider factory mapping)
-# ---------------------------------------------------------------------------
+        kwargs = mock_build_model.call_args.kwargs
+        assert kwargs["temperature"] == 0.2
+        assert kwargs["max_tokens"] == 16000
 
 
 class TestBuildModel:
-    """_build_model() maps provider configs to the correct init_chat_model calls."""
-
     def _make_settings(self) -> Any:
         s = MagicMock()
         s.openai_api_key = None
@@ -348,216 +246,29 @@ class TestBuildModel:
         return s
 
     def test_openai_provider_calls_init_chat_model(self) -> None:
-        """openai provider calls init_chat_model with model_provider='openai'."""
-        settings = self._make_settings()
-        settings.openai_api_key = MagicMock()
-        settings.openai_api_key.get_secret_value.return_value = "sk-openai"
+        resolver = RuntimeResolver(config_store=None, settings=self._make_settings())
+        resolver._settings.openai_api_key = MagicMock()
+        resolver._settings.openai_api_key.get_secret_value.return_value = "sk-openai"
 
         with patch("server.app.agent.resolver.init_chat_model") as mock_init:
-            _build_model("openai", "gpt-4o", None, None, None, None, settings)
-            mock_init.assert_called_once()
-            call_kwargs = mock_init.call_args
-            assert call_kwargs[0][0] == "gpt-4o"
-            assert call_kwargs[1]["model_provider"] == "openai"
-
-    def test_openai_compatible_calls_init_chat_model(self) -> None:
-        """openai_compatible calls init_chat_model with model_provider='openai' + base_url."""
-        settings = self._make_settings()
-
-        with patch("server.app.agent.resolver.init_chat_model") as mock_init:
-            _build_model(
-                "openai_compatible",
-                "google/gemini-3-flash-preview",
-                "sk-or-key",
-                "https://openrouter.ai/api/v1",
-                None,
-                None,
-                settings,
-            )
-            mock_init.assert_called_once()
-            call_kwargs = mock_init.call_args
-            assert call_kwargs[0][0] == "google/gemini-3-flash-preview"
-            assert call_kwargs[1]["model_provider"] == "openai"
-            assert call_kwargs[1]["base_url"] == "https://openrouter.ai/api/v1"
-            assert call_kwargs[1]["api_key"] == "sk-or-key"
-
-    def test_deepagents_model_input_preserves_resolved_model_instance(self) -> None:
-        """Do not reconstruct provider-prefixed strings from resolved models."""
-        from server.app.agent.cognition_agent import CognitionAgentParams, _model_for_deepagents
-
-        resolved_model = object()
-        params = CognitionAgentParams(
-            project_path="/tmp",
-            model=resolved_model,
-            provider="openai_compatible",
-            model_id="google/gemini-3-flash-preview",
-        )
-
-        assert _model_for_deepagents(params) is resolved_model
-
-    def test_deepagents_model_input_raises_without_resolved_model(self) -> None:
-        """Fail fast instead of constructing unsafe provider:model fallbacks."""
-        from server.app.agent.cognition_agent import CognitionAgentParams, _model_for_deepagents
-
-        params = CognitionAgentParams(
-            project_path="/tmp",
-            model=None,
-            provider="openai_compatible",
-            model_id="google/gemini-3-flash-preview",
-        )
-
-        with pytest.raises(ValueError, match="Resolved model object missing"):
-            _model_for_deepagents(params)
+            resolver.build_model("openai", "gpt-4o")
+            assert mock_init.call_args[0][0] == "gpt-4o"
+            assert mock_init.call_args.kwargs["model_provider"] == "openai"
 
     def test_openai_compatible_raises_without_base_url(self) -> None:
-        """openai_compatible without a base_url raises LLMProviderConfigError."""
         from server.app.exceptions import LLMProviderConfigError
 
         settings = self._make_settings()
-        settings.openai_compatible_base_url = None  # No fallback either
+        settings.openai_compatible_base_url = None
+        resolver = RuntimeResolver(config_store=None, settings=settings)
 
         with pytest.raises(LLMProviderConfigError, match="base_url is required"):
-            _build_model("openai_compatible", "some-model", None, None, None, None, settings)
-
-    def test_anthropic_provider_calls_init_chat_model(self) -> None:
-        """anthropic provider calls init_chat_model with model_provider='anthropic'."""
-        settings = self._make_settings()
-
-        with patch("server.app.agent.resolver.init_chat_model") as mock_init:
-            _build_model("anthropic", "claude-sonnet-4-6", None, None, None, None, settings)
-            call_kwargs = mock_init.call_args
-            assert call_kwargs[0][0] == "claude-sonnet-4-6"
-            assert call_kwargs[1]["model_provider"] == "anthropic"
+            resolver.build_model("openai_compatible", "some-model")
 
     def test_unknown_provider_raises_config_error(self) -> None:
-        """Completely unknown provider type raises LLMProviderConfigError."""
         from server.app.exceptions import LLMProviderConfigError
 
-        settings = self._make_settings()
+        resolver = RuntimeResolver(config_store=None, settings=self._make_settings())
 
         with pytest.raises(LLMProviderConfigError, match="Unknown provider"):
-            _build_model("mystic_cloud", "some-model", None, None, None, None, settings)
-
-    def test_build_model_wraps_init_chat_model_errors(self) -> None:
-        """Errors from init_chat_model are wrapped in LLMProviderConfigError."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        settings = self._make_settings()
-
-        with patch(
-            "server.app.agent.resolver.init_chat_model",
-            side_effect=ValueError("Bad API key"),
-        ):
-            with pytest.raises(LLMProviderConfigError, match="Bad API key"):
-                _build_model("openai", "gpt-4o", "bad-key", None, None, None, settings)
-
-
-# ---------------------------------------------------------------------------
-# provider_id resolution tests
-# ---------------------------------------------------------------------------
-
-
-class TestProviderIdResolution:
-    """_resolve_provider_config_for_session() with session.config.provider_id."""
-
-    @pytest.mark.asyncio
-    async def test_provider_id_takes_priority_over_provider(self) -> None:
-        """provider_id overrides provider/model session override."""
-        session = _make_session(
-            provider_id="my-openai-config",
-            provider="anthropic",
-            model="claude-sonnet-4-6",
-        )
-
-        mock_reg = MagicMock()
-        mock_reg.get_provider = AsyncMock(
-            return_value=_MockProviderConfig(
-                id="my-openai-config",
-                provider="openai",
-                model="gpt-4o",
-                enabled=True,
-                api_key_env="OPENAI_API_KEY",
-            )
-        )
-
-        resolver = _make_resolver(store=mock_reg)
-
-        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-key"}):
-            (
-                provider,
-                model_id,
-                api_key,
-                *_rest,
-            ) = await resolver._resolve_provider_config_for_session(session=session, scope=None)
-
-        assert provider == "openai"
-        assert model_id == "gpt-4o"
-        assert api_key == "sk-test-key"
-        # Store was queried by ID, not list_providers
-        mock_reg.get_provider.assert_called_once_with("my-openai-config", scope=None)
-
-    @pytest.mark.asyncio
-    async def test_provider_id_not_found_raises_error(self) -> None:
-        """Unknown provider_id raises LLMProviderConfigError."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session(provider_id="nonexistent-config")
-
-        mock_reg = MagicMock()
-        mock_reg.get_provider = AsyncMock(return_value=None)
-        resolver = _make_resolver(store=mock_reg)
-
-        with pytest.raises(LLMProviderConfigError, match="not found"):
-            await resolver._resolve_provider_config_for_session(session=session, scope=None)
-
-    @pytest.mark.asyncio
-    async def test_disabled_provider_id_raises_error(self) -> None:
-        """Disabled provider_id raises LLMProviderConfigError."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session(provider_id="disabled-config")
-
-        mock_reg = MagicMock()
-        mock_reg.get_provider = AsyncMock(
-            return_value=_MockProviderConfig(
-                id="disabled-config",
-                provider="openai",
-                model="gpt-4o",
-                enabled=False,
-            )
-        )
-        resolver = _make_resolver(store=mock_reg)
-
-        with pytest.raises(LLMProviderConfigError, match="disabled"):
-            await resolver._resolve_provider_config_for_session(session=session, scope=None)
-
-    @pytest.mark.asyncio
-    async def test_provider_id_passes_scope(self) -> None:
-        """Scope is forwarded to get_provider when using provider_id."""
-        session = _make_session(provider_id="scoped-config")
-        scope = {"user": "alice", "project": "myapp"}
-
-        mock_reg = MagicMock()
-        mock_reg.get_provider = AsyncMock(
-            return_value=_MockProviderConfig(
-                id="scoped-config",
-                provider="anthropic",
-                model="claude-sonnet-4-6",
-            )
-        )
-        resolver = _make_resolver(store=mock_reg)
-
-        await resolver._resolve_provider_config_for_session(session=session, scope=scope)
-
-        mock_reg.get_provider.assert_called_once_with("scoped-config", scope=scope)
-
-    @pytest.mark.asyncio
-    async def test_provider_id_with_unavailable_registry(self) -> None:
-        """provider_id with None ConfigStore raises LLMProviderConfigError."""
-        from server.app.exceptions import LLMProviderConfigError
-
-        session = _make_session(provider_id="some-config")
-        resolver = _make_resolver(store=None)
-
-        with pytest.raises(LLMProviderConfigError, match="ConfigStore not initialized"):
-            await resolver._resolve_provider_config_for_session(session=session, scope=None)
+            resolver.build_model("mystic_cloud", "some-model")

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -3,6 +3,7 @@
 Tests for the Phase 5 REST API implementation with workspace-based sessions.
 """
 
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -134,6 +135,67 @@ class TestSessionEndpoints:
         assert data["title"] == "updated-title"
         assert data["metadata"] == {"ticket": "ABC-123"}
 
+    def test_update_session_model_only_resolves_unambiguous_provider(self):
+        provider_resp = client.post(
+            "/models/providers",
+            json={
+                "id": "session-openai-compatible",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        )
+        assert provider_resp.status_code == 201
+
+        create_resp = client.post("/sessions", json={"title": "session-provider-resolution"})
+        session_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/sessions/{session_id}",
+            json={"config": {"model": "google/gemini-3-flash-preview"}},
+        )
+        assert response.status_code == 200
+
+    def test_update_session_model_only_rejects_ambiguous_provider_resolution(self):
+        client.post(
+            "/models/providers",
+            json={
+                "id": "session-openai-compatible-ambiguous",
+                "provider": "openai_compatible",
+                "model": "shared-model",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        )
+        client.post(
+            "/models/providers",
+            json={
+                "id": "session-openai-ambiguous",
+                "provider": "openai",
+                "model": "shared-model",
+            },
+        )
+
+        create_resp = client.post("/sessions", json={"title": "session-provider-ambiguous"})
+        session_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/sessions/{session_id}",
+            json={"config": {"model": "shared-model"}},
+        )
+        assert response.status_code == 422
+        assert "multiple provider types" in response.json()["detail"]
+
+    def test_update_session_model_only_rejects_unknown_model(self):
+        create_resp = client.post("/sessions", json={"title": "session-provider-unknown-model"})
+        session_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/sessions/{session_id}",
+            json={"config": {"model": "not-configured-anywhere"}},
+        )
+        assert response.status_code == 422
+        assert "is not configured on any enabled provider" in response.json()["detail"]
+
     def test_delete_session(self):
         """Test deleting a session."""
         # Create a session
@@ -217,6 +279,86 @@ class TestConfigEndpoints:
         data = response.json()
         assert "server" in data
         assert "llm" in data
+
+
+class TestModelEndpoints:
+    """Test model catalog API behavior."""
+
+    @pytest.fixture(autouse=True)
+    def reset_config_store(self):
+        from server.app.api.dependencies import set_model_catalog_dep
+        from server.app.llm.model_catalog import ModelCatalog
+        from server.app.settings import get_settings
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            set_config_store(DefaultConfigStore(MemoryConfigRegistry(), workspace_path=tmpdir))
+            settings = get_settings()
+            set_model_catalog_dep(ModelCatalog(catalog_url=settings.model_catalog_url))
+            yield
+
+    def test_list_models_returns_empty_without_configured_providers(self):
+        response = client.get("/models")
+        assert response.status_code == 200
+        assert response.json()["models"] == []
+
+    def test_list_models_returns_only_configured_provider_types(self):
+        client.post(
+            "/models/providers",
+            json={"id": "catalog-openai", "provider": "openai", "model": "gpt-4o"},
+        )
+
+        response = client.get("/models")
+        assert response.status_code == 200
+        models = response.json()["models"]
+        assert models
+        assert all(model["provider"] == "openai" for model in models)
+
+    def test_list_models_filters_to_requested_configured_provider(self):
+        client.post(
+            "/models/providers",
+            json={"id": "catalog-openai-2", "provider": "openai", "model": "gpt-4o"},
+        )
+        client.post(
+            "/models/providers",
+            json={
+                "id": "catalog-anthropic-2",
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+            },
+        )
+
+        response = client.get("/models", params={"provider": "anthropic"})
+        assert response.status_code == 200
+        models = response.json()["models"]
+        assert models
+        assert all(model["provider"] == "anthropic" for model in models)
+
+    def test_list_models_excludes_unconfigured_provider_filter(self):
+        client.post(
+            "/models/providers",
+            json={"id": "catalog-openai-3", "provider": "openai", "model": "gpt-4o"},
+        )
+
+        response = client.get("/models", params={"provider": "anthropic"})
+        assert response.status_code == 200
+        assert response.json()["models"] == []
+
+    def test_list_models_openai_compatible_contributes_no_catalog_models(self):
+        client.post(
+            "/models/providers",
+            json={
+                "id": "catalog-openrouter",
+                "provider": "openai_compatible",
+                "model": "google/gemini-3-flash-preview",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        )
+
+        response = client.get("/models")
+        assert response.status_code == 200
+        assert response.json()["models"] == []
 
 
 class TestAPIIntegration:


### PR DESCRIPTION
## Summary
- fix provider and model configuration validation, session resolution, and agent response compatibility
- align runtime model handoff with Deep Agents by using one canonical resolver path and removing duplicate model builder code
- fix openai_compatible subagent conversion so Deep Agents does not receive an invalid provider-prefixed model string
- update docs and e2e coverage, including compose validation for the OpenRouter-backed openai_compatible path

Closes #104
Closes #105