### PR TITLE
fix openai-compatible subagent model conversion

### DIFF
--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -400,7 +400,7 @@ class AgentDefinition(BaseModel):
 
         if self.config.model:
             provider = self.config.provider
-            if provider:
+            if provider and provider != "openai_compatible":
                 spec["model"] = f"{provider}:{self.config.model}"
             else:
                 spec["model"] = self.config.model

--- a/tests/unit/test_agent_definition.py
+++ b/tests/unit/test_agent_definition.py
@@ -196,6 +196,21 @@ class TestAgentDefinition:
                 system_prompt="You are a test agent.",
             )
 
+    def test_to_subagent_does_not_construct_openai_compatible_model_string(self):
+        """openai_compatible subagents must not emit provider-prefixed model strings."""
+        agent = AgentDefinition(
+            name="researcher",
+            system_prompt="You are a researcher.",
+            config=AgentConfig(
+                provider="openai_compatible",
+                model="google/gemini-3-flash-preview",
+            ),
+        )
+
+        subagent = agent.to_subagent()
+
+        assert subagent["model"] == "google/gemini-3-flash-preview"
+
     def test_valid_name_with_hyphen_and_underscore(self):
         """Test that names with hyphens and underscores are valid."""
         agent = AgentDefinition(


### PR DESCRIPTION
## Summary
- stop subagent conversion from constructing invalid `openai_compatible:model` strings for Deep Agents
- preserve the raw model id for `openai_compatible` subagents so LangChain receives a supported model value
- add regression coverage for openai-compatible subagent conversion

Closes #105