### PR TITLE
Fix release image build isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,24 +75,14 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.scope }}
           cache-to: type=gha,mode=max,scope=${{ matrix.scope }}
 
-  # ─── Build amd64 images (native x86 runner) ───────────────────────────────
-  build-amd64:
+  # ─── Build amd64 app image (native x86 runner) ────────────────────────────
+  build-amd64-app:
     needs: test
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      matrix:
-        include:
-          - dockerfile: ./Dockerfile
-            image-suffix: ""
-            scope: cognition-amd64
-          - dockerfile: ./Dockerfile.sandbox
-            image-suffix: "-sandbox"
-            scope: cognition-sandbox-amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -107,24 +97,60 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push amd64 image
+      - name: Build and push amd64 app image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          # Push with an arch-specific tag; merged into the multi-arch manifest later
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image-suffix }}:${{ github.sha }}-amd64
-          cache-from: type=gha,scope=${{ matrix.scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.scope }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          cache-from: type=gha,scope=cognition-amd64
+          cache-to: type=gha,mode=max,scope=cognition-amd64
           build-args: |
             BUILD_DATE=${{ github.event.release.created_at }}
             VCS_REF=${{ github.sha }}
             VERSION=${{ github.event.release.tag_name }}
 
-  # ─── Build arm64 images (native ARM runner — no QEMU) ─────────────────────
-  build-arm64:
+  # ─── Build amd64 sandbox image (native x86 runner) ────────────────────────
+  build-amd64-sandbox:
+    needs: test
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push amd64 sandbox image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.sandbox
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox:${{ github.sha }}-amd64
+          cache-from: type=gha,scope=cognition-sandbox-amd64
+          cache-to: type=gha,mode=max,scope=cognition-sandbox-amd64
+          build-args: |
+            BUILD_DATE=${{ github.event.release.created_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.event.release.tag_name }}
+
+  # ─── Build arm64 app image (native ARM runner — no QEMU) ──────────────────
+  build-arm64-app:
     needs: test
     if: github.event_name == 'release'
     runs-on: ubuntu-24.04-arm  # Native ARM64 — eliminates QEMU emulation overhead
@@ -132,15 +158,42 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      matrix:
-        include:
-          - dockerfile: ./Dockerfile
-            image-suffix: ""
-            scope: cognition-arm64
-          - dockerfile: ./Dockerfile.sandbox
-            image-suffix: "-sandbox"
-            scope: cognition-sandbox-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 app image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          cache-from: type=gha,scope=cognition-arm64
+          cache-to: type=gha,mode=max,scope=cognition-arm64
+          build-args: |
+            BUILD_DATE=${{ github.event.release.created_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.event.release.tag_name }}
+
+  # ─── Build arm64 sandbox image (native ARM runner — no QEMU) ──────────────
+  build-arm64-sandbox:
+    needs: test
+    if: github.event_name == 'release'
+    runs-on: ubuntu-24.04-arm  # Native ARM64 — eliminates QEMU emulation overhead
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -155,37 +208,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push arm64 image
+      - name: Build and push arm64 sandbox image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ./Dockerfile.sandbox
           platforms: linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image-suffix }}:${{ github.sha }}-arm64
-          cache-from: type=gha,scope=${{ matrix.scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.scope }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox:${{ github.sha }}-arm64
+          cache-from: type=gha,scope=cognition-sandbox-arm64
+          cache-to: type=gha,mode=max,scope=cognition-sandbox-arm64
           build-args: |
             BUILD_DATE=${{ github.event.release.created_at }}
             VCS_REF=${{ github.sha }}
             VERSION=${{ github.event.release.tag_name }}
 
-  # ─── Merge amd64 + arm64 into final multi-arch manifests ──────────────────
-  # Combines the two per-arch images into a single manifest list with all
-  # release tags (semver, major.minor, latest).
-  merge-manifests:
-    needs: [build-amd64, build-arm64]
+  # ─── Merge amd64 + arm64 into final multi-arch app manifest ────────────────
+  merge-manifests-app:
+    needs: [build-amd64-app, build-arm64-app]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      matrix:
-        include:
-          - image-suffix: ""
-          - image-suffix: "-sandbox"
 
     steps:
       - name: Log in to Container Registry
@@ -202,7 +247,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image-suffix }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -210,14 +255,52 @@ jobs:
             type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
 
       - name: Create multi-arch manifest
-        # Combine the per-arch images into a single manifest list.
-        # Each tag from metadata-action is applied to the merged manifest.
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image-suffix }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           AMD64="${IMAGE}:${{ github.sha }}-amd64"
           ARM64="${IMAGE}:${{ github.sha }}-arm64"
 
-          # Build -t flag list from metadata tags
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{print "-t " $0}' | tr '\n' ' ')
+
+          docker buildx imagetools create $TAGS "$AMD64" "$ARM64"
+
+  # ─── Merge amd64 + arm64 into final multi-arch sandbox manifest ────────────
+  merge-manifests-sandbox:
+    needs: [build-amd64-sandbox, build-arm64-sandbox]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+
+      - name: Create multi-arch manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox"
+          AMD64="${IMAGE}:${{ github.sha }}-amd64"
+          ARM64="${IMAGE}:${{ github.sha }}-arm64"
+
           TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{print "-t " $0}' | tr '\n' ' ')
 
           docker buildx imagetools create $TAGS "$AMD64" "$ARM64"

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -21,6 +21,7 @@
 
 ARG GH_CLI_VERSION=2.66.1
 ARG NODE_MAJOR=22
+ARG TARGETARCH
 
 FROM python:3.11-slim
 
@@ -46,10 +47,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # ── gh CLI ───────────────────────────────────────────────────────────────────
 ARG GH_CLI_VERSION
-RUN curl -fsSL \
-    "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" \
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+        amd64|arm64) gh_arch="${TARGETARCH}" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+    "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${gh_arch}.tar.gz" \
     | tar -xz -C /usr/local/bin --strip-components=2 \
-    "gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" \
+    "gh_${GH_CLI_VERSION}_linux_${gh_arch}/bin/gh" \
     && gh --version
 
 # ── Node.js LTS ──────────────────────────────────────────────────────────────

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-<<<<<<< HEAD
 from typing import Annotated, Any, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -132,11 +131,7 @@ async def _normalize_session_config(
         raise
 
     if request.config.provider is None:
-<<<<<<< HEAD
-        request.config.provider = cast(Any, target.provider)
-=======
         request.config.provider = _as_session_provider(target.provider)
->>>>>>> d1e262c (Fix release image build isolation)
 
 
 async def _get_scoped_session(

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from typing import Annotated, Any, cast
+<<<<<<< HEAD
+from typing import Annotated, Any, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -56,6 +57,21 @@ from server.app.storage.backend import StorageBackend
 from server.app.storage.config_store import ConfigStore
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+SessionProvider = Literal[
+    "openai",
+    "anthropic",
+    "bedrock",
+    "mock",
+    "openai_compatible",
+    "google_genai",
+    "google_vertexai",
+]
+
+
+def _as_session_provider(provider: str) -> SessionProvider | None:
+    return cast(SessionProvider, provider)
 
 
 def _unprocessable_entity(detail: str) -> HTTPException:
@@ -116,7 +132,11 @@ async def _normalize_session_config(
         raise
 
     if request.config.provider is None:
+<<<<<<< HEAD
         request.config.provider = cast(Any, target.provider)
+=======
+        request.config.provider = _as_session_provider(target.provider)
+>>>>>>> d1e262c (Fix release image build isolation)
 
 
 async def _get_scoped_session(


### PR DESCRIPTION
## Summary
- make the sandbox image install the correct `gh` CLI binary for the target architecture
- split release image builds into independent app and sandbox jobs for amd64 and arm64
- split manifest publishing so app and sandbox multi-arch releases are created independently
- tighten typing around session provider normalization and resolver config extraction while keeping `workspaces/` excluded from mypy

## Validation
- `uv run ruff check .`
- `uv run mypy .`