### PR TITLE
Prepare v0.8.3 patch release

### DIFF
--- a/.github/workflows/pre-release-images.yml
+++ b/.github/workflows/pre-release-images.yml
@@ -1,0 +1,245 @@
+name: Pre-Release Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without v prefix (for example 0.8.3)"
+        required: true
+      prerelease_tag:
+        description: "Temporary container tag suffix (for example rc1)"
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cognicellai/cognition
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run unit tests
+        run: uv run pytest tests/unit -v
+
+      - name: Run type checking
+        run: uv run mypy .
+
+      - name: Run linting
+        run: uv run ruff check .
+
+  build-amd64-app:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push amd64 app image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}-amd64
+          cache-from: type=gha,scope=cognition-amd64
+          cache-to: type=gha,mode=max,scope=cognition-amd64
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=v${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}
+
+  build-amd64-sandbox:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push amd64 sandbox image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.sandbox
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox:${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}-amd64
+          cache-from: type=gha,scope=cognition-sandbox-amd64
+          cache-to: type=gha,mode=max,scope=cognition-sandbox-amd64
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=v${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}
+
+  build-arm64-app:
+    needs: test
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 app image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}-arm64
+          cache-from: type=gha,scope=cognition-arm64
+          cache-to: type=gha,mode=max,scope=cognition-arm64
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=v${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}
+
+  build-arm64-sandbox:
+    needs: test
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 sandbox image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.sandbox
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox:${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}-arm64
+          cache-from: type=gha,scope=cognition-sandbox-arm64
+          cache-to: type=gha,mode=max,scope=cognition-sandbox-arm64
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=v${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}
+
+  merge-manifests-app:
+    needs: [build-amd64-app, build-arm64-app]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create app pre-release manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          TAG="${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}"
+          AMD64="${IMAGE}:${TAG}-amd64"
+          ARM64="${IMAGE}:${TAG}-arm64"
+
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            "$AMD64" "$ARM64"
+
+  merge-manifests-sandbox:
+    needs: [build-amd64-sandbox, build-arm64-sandbox]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create sandbox pre-release manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-sandbox"
+          TAG="${{ github.event.inputs.version }}-${{ github.event.inputs.prerelease_tag }}"
+          AMD64="${IMAGE}:${TAG}-amd64"
+          ARM64="${IMAGE}:${TAG}-arm64"
+
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            "$AMD64" "$ARM64"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,11 @@ Cognition is designed to be highly pluggable using native `deepagents` extension
 #### Subagents
 1. Define specialized subagents in `.cognition/config.yaml` to handle complex domain-specific tasks in isolated contexts.
 
+### Releases
+- Follow `docs/guides/release-checklist.md` for all release preparation, validation, tagging, and post-release verification.
+- Do not cut or replace a release tag until the exact release commit has passed code-quality and container-build validation.
+- Before tagging, run the pre-release image workflow for the exact release branch commit so app and sandbox multi-arch pushes are proven against GHCR.
+
 ### Testing & Scenarios
 - **Unit Tests**: Fast, mocked dependencies. No containers.
 - **E2E Tests**: Use `tests/e2e/`. May require running server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.8.3] — 2026-04-17
+
+### Highlights
+
+- Hardened the release pipeline so multi-arch app and sandbox images are validated and published independently for the 0.8.x line.
+
+### Release and Container Fixes
+
+- Fixed the sandbox image to install the correct `gh` CLI binary for the target architecture, unblocking `linux/arm64` sandbox builds.
+- Split release image builds into independent app and sandbox jobs for `linux/amd64` and `linux/arm64` so one image family no longer cancels the other.
+- Split multi-arch manifest publication into independent app and sandbox jobs so partial release image failures are isolated correctly.
+
+### Validation and Release Process
+
+- Restored strict release validation after the build-isolation changes by fixing the related `mypy` regressions in runtime resolver and session config normalization.
+- Added a dedicated release checklist document and updated agent guidance so future releases validate the exact release commit before tagging.
+
+### Merged PRs
+
+- `#110` fix release image build isolation
+
 ## [0.8.2] — 2026-04-16
 
 ### Highlights

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -1,0 +1,139 @@
+# Release Checklist
+
+This checklist defines the standard release process for Cognition patch, minor, and major releases.
+
+Use this document before cutting any Git tag or GitHub release. The goal is to prove that the exact release commit is shippable before publication, especially for multi-arch container images.
+
+## Release Principles
+
+1. Never tag first and validate later.
+2. Keep source release, Git tag, and published container images tied to the same commit.
+3. Do not mutate an existing published tag to fix packaging mistakes. Cut a new patch release instead.
+4. Release-critical fixes must land on `main` before release preparation begins.
+5. Prefer a short-lived `release/vX.Y.Z` branch for release-only metadata updates.
+
+## Release Branch
+
+1. Start from `origin/main`, not a stale or divergent local branch.
+2. Create a short-lived branch named `release/vX.Y.Z`.
+3. Limit branch changes to release-scoped updates:
+   - `server/version.py`
+   - `CHANGELOG.md`
+   - minimal `ROADMAP.md` updates when required
+   - other release metadata only when necessary
+4. Do not mix feature work, opportunistic refactors, or unrelated dependency churn into the release branch.
+
+## Pre-Release Validation
+
+Run these checks from the exact release branch commit:
+
+```bash
+uv run pytest tests/unit -v
+uv run ruff check .
+uv run mypy .
+```
+
+All three must pass before the release PR is merged.
+
+## Container Validation
+
+Before tagging, prove the release commit can build all required container variants.
+
+Required image targets:
+
+1. App image `linux/amd64`
+2. App image `linux/arm64`
+3. Sandbox image `linux/amd64`
+4. Sandbox image `linux/arm64`
+
+At minimum, validate that:
+
+1. `Dockerfile` builds on both target architectures.
+2. `Dockerfile.sandbox` builds on both target architectures.
+3. App and sandbox image build paths are independent.
+4. Multi-arch manifest creation can succeed for app and sandbox images independently.
+
+### Required Pre-Release Workflow
+
+Run `.github/workflows/pre-release-images.yml` from the release branch before tagging.
+
+Use temporary candidate tags such as `0.8.3-rc1` so the exact release commit exercises the real registry push and manifest creation path without mutating final semver tags.
+
+That workflow must complete successfully for:
+
+1. app `linux/amd64`
+2. app `linux/arm64`
+3. sandbox `linux/amd64`
+4. sandbox `linux/arm64`
+5. app candidate manifest creation
+6. sandbox candidate manifest creation
+
+## Release Workflow Expectations
+
+For a release to be considered healthy, the release workflow must be able to complete these jobs successfully:
+
+1. `test (3.11)`
+2. `test (3.12)`
+3. `build-amd64-app`
+4. `build-amd64-sandbox`
+5. `build-arm64-app`
+6. `build-arm64-sandbox`
+7. `merge-manifests-app`
+8. `merge-manifests-sandbox`
+
+If one image family fails, the other should still be able to build independently. That behavior is required for release workflow hygiene.
+
+## Release PR
+
+Open a PR from `release/vX.Y.Z` to `main`.
+
+The PR should include:
+
+1. version bump
+2. changelog entry
+3. any required roadmap release metadata updates
+4. validation output summary
+
+Recommended PR body sections:
+
+1. Summary
+2. Validation
+3. Release notes or key fixes
+
+## Tagging And Publishing
+
+Only create the Git tag after:
+
+1. the release PR is merged
+2. the merge commit is confirmed on `origin/main`
+3. validation is green
+4. the pre-release image workflow has succeeded for the exact release commit
+5. the release commit is the one intended for source and images
+
+Then:
+
+1. create tag `vX.Y.Z`
+2. create GitHub release from that exact commit
+3. monitor release workflow to completion
+
+## Post-Release Verification
+
+Verify all of the following:
+
+1. GitHub release exists and points at the intended commit
+2. release workflow completed successfully
+3. app multi-arch manifest was published
+4. sandbox multi-arch manifest was published
+5. expected semver tags exist for both packages
+6. no last-minute divergence exists between release notes and shipped code
+
+## Recovery Rule
+
+If a release fails because of packaging, workflow, or container issues after the tag is published:
+
+1. do not rebuild different code under the same release tag
+2. land the fix on `main`
+3. prepare a new patch release
+4. cut `vX.Y.(Z+1)` from the corrected commit
+
+This keeps source history, release notes, and container artifacts consistent.

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.8.2"
+VERSION = "0.8.3"
 
 __all__ = ["VERSION"]

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,6 @@ wheels = [
 
 [[package]]
 name = "cognition"
-version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "deepagents" },
@@ -627,27 +626,38 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "asyncpg", marker = "extra == 'deploy'", specifier = ">=0.30.0" },
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "cognition", extras = ["openai", "bedrock", "test", "deploy", "k8s"], marker = "extra == 'all'" },
-    { name = "cognition", extras = ["test", "openai"], marker = "extra == 'dev'" },
     { name = "deepagents", specifier = ">=0.1.0" },
+    { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
     { name = "docker", marker = "extra == 'deploy'", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
     { name = "langchain", specifier = ">=1.2.13" },
+    { name = "langchain-aws", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=0.2.0" },
     { name = "langchain-core", specifier = ">=0.3.0,<1.3.0" },
+    { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'all'", editable = "packages/langchain-k8s-sandbox" },
     { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'k8s'", editable = "packages/langchain-k8s-sandbox" },
+    { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=0.2.0" },
+    { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'deploy'", specifier = ">=2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=1.0.0" },
     { name = "langsmith", extras = ["otel"], specifier = ">=0.4.25" },
     { name = "mcp", specifier = ">=1.2.0" },
+    { name = "mlflow", extras = ["genai"], marker = "extra == 'all'", specifier = ">=2.19.0" },
     { name = "mlflow", extras = ["genai"], marker = "extra == 'deploy'", specifier = ">=2.19.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
+    { name = "openai", marker = "extra == 'all'", specifier = ">=1.52.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=1.52.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.52.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.28.0" },
@@ -657,12 +667,21 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.43" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'all'", specifier = ">=3.1.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'deploy'", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
+    { name = "pytest", marker = "extra == 'all'", specifier = ">=8.3.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.24.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'all'", specifier = ">=6.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'all'", specifier = ">=2.3.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.12" },
@@ -675,7 +694,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["openai", "bedrock", "test", "dev", "deploy", "k8s", "all"]
+provides-extras = ["all", "bedrock", "deploy", "dev", "k8s", "openai", "test"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]


### PR DESCRIPTION
## Summary
- bump Cognition's version metadata to `0.8.3` and add the `0.8.3` changelog entry
- add a release checklist and a manual pre-release image workflow so the exact release commit can prove app and sandbox multi-arch pushes before tagging
- refresh `uv.lock` so the lockfile matches the current dependency metadata used for release validation

## Validation
- `uv run pytest tests/unit -v`
- `uv run ruff check .`
- `uv run mypy .`

## Pre-Release Image Plan
- run `.github/workflows/pre-release-images.yml` from `release/v0.8.3`
- use candidate tags like `0.8.3-rc1`
- require app/sandbox amd64+arm64 image builds and candidate manifest creation before cutting `v0.8.3`