### PR TITLE
Fix #112: resolve AgentDefinition tools against workspace root

### DIFF
--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -317,6 +317,8 @@ class AgentDefinition(BaseModel):
                 if "/" in tool_path or tool_path.endswith(".py"):
                     # Treat as file path
                     tool_file = base / tool_path
+                    if not tool_file.exists() and not tool_file.suffix:
+                        tool_file = tool_file.with_suffix(".py")
                     if not tool_file.exists():
                         logger.warning(
                             "Tool file not found — skipping",

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -318,6 +318,13 @@ class AgentDefinition(BaseModel):
                     # Treat as file path
                     tool_file = base / tool_path
                     if not tool_file.exists():
+                        logger.warning(
+                            "Tool file not found — skipping",
+                            tool_path=tool_path,
+                            resolved=str(tool_file),
+                            base_path=str(base),
+                            agent=self.name,
+                        )
                         continue
 
                     # Load module from file

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -385,8 +385,14 @@ class AgentDefinition(BaseModel):
 
         return resolved_tools
 
-    def to_subagent(self) -> dict[str, Any]:
+    def to_subagent(self, base_path: str | Path | None = None) -> dict[str, Any]:
         """Translate AgentDefinition to Deep Agents SubAgent TypedDict.
+
+        Args:
+            base_path: Base path for resolving relative tool file paths. Should
+                be the workspace root — not a per-session sandbox — because
+                ``.cognition/tools/`` is a workspace-level concept loaded into
+                the server process. See issue #112.
 
         Returns:
             A dict matching the Deep Agents SubAgent TypedDict specification:
@@ -414,7 +420,7 @@ class AgentDefinition(BaseModel):
 
         # Resolve tools from paths to BaseTool instances
         # This prevents AttributeError when ToolNode tries to access .name on strings
-        resolved_tools = self._resolve_tools()
+        resolved_tools = self._resolve_tools(base_path=base_path)
         if resolved_tools:
             spec["tools"] = resolved_tools
 

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -193,7 +193,12 @@ class DeepAgentStreamingService:
             resolved.skills.append("/skills/api/")
 
         all_defs = await cs.list_agent_definitions(include_hidden=True)
-        resolved.subagents = [s.to_subagent() for s in all_defs if s.name != agent_def.name]
+        workspace_base = str(self.settings.workspace_path)
+        resolved.subagents = [
+            s.to_subagent(base_path=workspace_base)
+            for s in all_defs
+            if s.name != agent_def.name
+        ]
 
         if agent_def.memory:
             resolved.memory = list(agent_def.memory)
@@ -211,9 +216,7 @@ class DeepAgentStreamingService:
             resolved.middleware = _resolve_middleware(agent_def.middleware)
 
         if agent_def.tools:
-            agent_def_tools = agent_def._resolve_tools(
-                base_path=str(self.settings.workspace_path)
-            )
+            agent_def_tools = agent_def._resolve_tools(base_path=workspace_base)
             if agent_def_tools:
                 custom_tools = list(custom_tools) + agent_def_tools
 

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -211,7 +211,9 @@ class DeepAgentStreamingService:
             resolved.middleware = _resolve_middleware(agent_def.middleware)
 
         if agent_def.tools:
-            agent_def_tools = agent_def._resolve_tools(base_path=project_path)
+            agent_def_tools = agent_def._resolve_tools(
+                base_path=str(self.settings.workspace_path)
+            )
             if agent_def_tools:
                 custom_tools = list(custom_tools) + agent_def_tools
 

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -413,7 +413,7 @@ class TestMiddlewareWiring:
 
 class TestToolsWiring:
     @pytest.mark.asyncio
-    async def test_agent_def_tools_added_to_runtime_tools(self):
+    async def test_agent_def_tools_added_to_runtime_tools(self, tmp_path):
         """Tools from AgentDefinition._resolve_tools() are included in runtime tools."""
         from langchain_core.tools import BaseTool
 
@@ -435,6 +435,7 @@ class TestToolsWiring:
         mock_def_registry.subagents = MagicMock(return_value=[])
 
         s = MagicMock(spec=Settings)
+        s.workspace_path = tmp_path
         service = DeepAgentStreamingService(s)
 
         mock_config_store = MagicMock()
@@ -490,6 +491,9 @@ class TestToolsWiring:
                 pass
 
         assert len(resolve_tools_calls) == 1
+        # Must resolve against the workspace root, NOT the per-session sandbox
+        # path passed as project_path. See issue #112.
+        assert resolve_tools_calls[0].get("base_path") == str(tmp_path)
 
         params = _get_params(create_agent_mock)
         assert params is not None

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -501,6 +501,89 @@ class TestToolsWiring:
         assert agent_def_tool in passed_tools
 
     @pytest.mark.asyncio
+    async def test_subagent_to_subagent_receives_workspace_path(self, tmp_path):
+        """Subagents' to_subagent() must get base_path=settings.workspace_path.
+
+        Follow-up to issue #112: primary agent fix wasn't enough — subagent
+        tools resolve via to_subagent() and also need the workspace root.
+        """
+        from server.app.agent.definition import AgentDefinition
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+        from server.app.settings import Settings
+
+        session = _make_session()
+        mock_runtime = _make_mock_runtime(DoneEvent())
+
+        primary = AgentDefinition(name="test-agent", system_prompt="primary")
+        subagent_def = AgentDefinition(
+            name="helper",
+            description="helps",
+            system_prompt="sub",
+        )
+
+        s = MagicMock(spec=Settings)
+        s.workspace_path = tmp_path
+        service = DeepAgentStreamingService(s)
+
+        mock_config_store = MagicMock()
+        mock_config_store.get_agent_definition = AsyncMock(return_value=primary)
+        mock_config_store.list_agent_definitions = AsyncMock(
+            return_value=[primary, subagent_def]
+        )
+        mock_config_store.list_tools = AsyncMock(return_value=[])
+        mock_config_store.list_mcp_servers = AsyncMock(return_value=[])
+        service._config_store = mock_config_store
+
+        mock_storage = MagicMock()
+        mock_storage.get_session = AsyncMock(return_value=session)
+        mock_storage.get_checkpointer = AsyncMock(return_value=MagicMock())
+        mock_storage.get_store = AsyncMock(return_value=MagicMock())
+        service.storage_backend = mock_storage
+
+        to_subagent_calls: list[Any] = []
+
+        def _fake_to_subagent(self_inner: Any, **kwargs: Any) -> dict[str, Any]:
+            to_subagent_calls.append(kwargs)
+            return {"name": self_inner.name, "description": "", "system_prompt": "x"}
+
+        with (
+            patch(
+                "server.app.llm.deep_agent_service.DeepAgentRuntime",
+                return_value=mock_runtime,
+            ),
+            patch.object(
+                service,
+                "_resolve_model",
+                new_callable=AsyncMock,
+                return_value=(MagicMock(), "mock", "mock-model", 100),
+            ),
+            patch(
+                "server.app.llm.deep_agent_service.create_cognition_agent",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "server.app.storage.factory.create_storage_backend",
+                return_value=mock_storage,
+            ),
+            patch(
+                "server.app.agent.definition.AgentDefinition.to_subagent",
+                _fake_to_subagent,
+            ),
+        ):
+            async for _ in service.stream_response(
+                session_id=session.id,
+                thread_id=session.thread_id,
+                project_path="/tmp/ws",
+                content="hello",
+            ):
+                pass
+
+        # One call per non-primary def
+        assert len(to_subagent_calls) == 1
+        assert to_subagent_calls[0].get("base_path") == str(tmp_path)
+
+    @pytest.mark.asyncio
     async def test_session_recursion_limit_beats_agent_def(self):
         """session.config.recursion_limit must override agent_def.config.recursion_limit."""
         from server.app.agent.definition import AgentConfig, AgentDefinition

--- a/tests/unit/test_agent_definition.py
+++ b/tests/unit/test_agent_definition.py
@@ -529,6 +529,35 @@ class TestResolveTools:
         assert len(resolved) == 1
         assert resolved[0].name == "do_thing"
 
+    def test_to_subagent_passes_base_path_to_resolver(self, tmp_path):
+        """to_subagent(base_path=...) must forward base_path to _resolve_tools.
+
+        Without this, subagent tool files referenced by relative path fail to
+        resolve — see issue #112 follow-up.
+        """
+        tools_dir = tmp_path / ".cognition" / "tools"
+        tools_dir.mkdir(parents=True)
+        tool_file = tools_dir / "sub_tool.py"
+        tool_file.write_text(
+            "from langchain_core.tools import tool\n"
+            "\n"
+            "@tool\n"
+            "def sub_action(x: str) -> str:\n"
+            "    '''sub tool'''\n"
+            "    return x\n"
+        )
+
+        agent = AgentDefinition(
+            name="breach-analyst",
+            description="analyses breaches",
+            system_prompt="test",
+            tools=[".cognition/tools/sub_tool.py"],
+        )
+        spec = agent.to_subagent(base_path=str(tmp_path))
+        assert "tools" in spec
+        assert len(spec["tools"]) == 1
+        assert spec["tools"][0].name == "sub_action"
+
     def test_missing_tool_file_logs_warning(self, tmp_path):
         """Missing tool file emits a warning (not silent) — see issue #112."""
         from structlog.testing import capture_logs

--- a/tests/unit/test_agent_definition.py
+++ b/tests/unit/test_agent_definition.py
@@ -501,3 +501,52 @@ class TestAgentDefinitionPathValidation:
         assert len(results["tools"]) == 1
         assert len(results["skills"]) == 1
         assert len(results["memory"]) == 1
+
+
+class TestResolveTools:
+    """Tests for AgentDefinition._resolve_tools."""
+
+    def test_resolves_file_path_relative_to_base(self, tmp_path):
+        """Relative .py tool paths resolve against base_path (workspace root)."""
+        tools_dir = tmp_path / ".cognition" / "tools"
+        tools_dir.mkdir(parents=True)
+        tool_file = tools_dir / "my_tool.py"
+        tool_file.write_text(
+            "from langchain_core.tools import tool\n"
+            "\n"
+            "@tool\n"
+            "def do_thing(x: str) -> str:\n"
+            "    '''does a thing'''\n"
+            "    return x\n"
+        )
+
+        agent = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            tools=[".cognition/tools/my_tool.py"],
+        )
+        resolved = agent._resolve_tools(base_path=str(tmp_path))
+        assert len(resolved) == 1
+        assert resolved[0].name == "do_thing"
+
+    def test_missing_tool_file_logs_warning(self, tmp_path):
+        """Missing tool file emits a warning (not silent) — see issue #112."""
+        from structlog.testing import capture_logs
+
+        agent = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            tools=[".cognition/tools/missing.py"],
+        )
+        with capture_logs() as logs:
+            resolved = agent._resolve_tools(base_path=str(tmp_path))
+
+        assert resolved == []
+        warnings = [
+            log
+            for log in logs
+            if log.get("log_level") == "warning"
+            and "Tool file not found" in log.get("event", "")
+        ]
+        assert warnings, f"expected warning for missing tool, got: {logs}"
+        assert warnings[0]["tool_path"] == ".cognition/tools/missing.py"

--- a/tests/unit/test_agent_definition.py
+++ b/tests/unit/test_agent_definition.py
@@ -529,6 +529,30 @@ class TestResolveTools:
         assert len(resolved) == 1
         assert resolved[0].name == "do_thing"
 
+    def test_resolves_suffixless_file_path_adds_py_extension(self, tmp_path):
+        """Relative tool paths missing the .py suffix still resolve if the
+        .py file exists.
+        """
+        tools_dir = tmp_path / ".cognition" / "tools"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "bare_tool.py").write_text(
+            "from langchain_core.tools import tool\n"
+            "\n"
+            "@tool\n"
+            "def bare(x: str) -> str:\n"
+            "    '''bare tool'''\n"
+            "    return x\n"
+        )
+
+        agent = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            tools=[".cognition/tools/bare_tool"],
+        )
+        resolved = agent._resolve_tools(base_path=str(tmp_path))
+        assert len(resolved) == 1
+        assert resolved[0].name == "bare"
+
     def test_to_subagent_passes_base_path_to_resolver(self, tmp_path):
         """to_subagent(base_path=...) must forward base_path to _resolve_tools.
 


### PR DESCRIPTION
## Summary
- Fixes #112. `AgentDefinition._resolve_tools()` was receiving the per-session sandbox directory as `base_path`, so relative tool paths in agent frontmatter (e.g. `.cognition/tools/my_tool.py`) silently resolved to a path inside the sandbox that never exists. The agent was left with only built-in tools. Fix: pass `settings.workspace_path` — tool loading runs in the server process, and `.cognition/tools/` is a workspace-level concept shared across sessions.
- Follow-up fix in the same PR: `AgentDefinition.to_subagent()` called `_resolve_tools()` with no `base_path`, so subagents' custom tools hit the same silent failure (fell back to CWD / `/app`). Thread `base_path` through `to_subagent()` and pass `settings.workspace_path` from the service caller.
- Replace the silent `continue` in `_resolve_tools` with a `logger.warning` when a tool file is missing, so this class of misconfiguration surfaces in logs instead of requiring a trace patch to diagnose.
- In the file-path branch, if the resolved path has no suffix and doesn't exist, retry with `.py` appended before warning. Matches the existing behavior in the module-path fallback branch and lets users reference tool files without an extension (e.g. `.cognition/tools/foo`).

## Test plan
- [x] `uv run pytest tests/unit/test_agent_definition.py tests/unit/test_agent_def_field_wiring.py::TestToolsWiring` — 45 passed
- [x] New `TestResolveTools` unit tests cover: file-path tool resolves against given `base_path`; suffixless paths fall back to `.py`; `to_subagent(base_path=...)` forwards to resolver; missing file logs a structured warning.
- [x] New service-layer test `test_subagent_to_subagent_receives_workspace_path` asserts the caller passes `settings.workspace_path` into every subagent's `to_subagent`.
- [x] Existing `test_agent_def_tools_added_to_runtime_tools` updated to assert the resolved `base_path` is `settings.workspace_path`, not the session sandbox `project_path`.
- [ ] Manual verification on a real workspace (primary agent + subagent with relative tool paths in `.cognition/tools/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)