### PR TITLE
feat(v0.10.0): 11-state session lifecycle, run control APIs, idempotency, and lifecycle events

### DIFF
--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, cast, runtime_checkable
 
@@ -208,6 +209,53 @@ class DelegationEvent(AgentEvent):
     task: str
 
 
+@dataclass
+class HeartbeatEvent(AgentEvent):
+    """Periodic heartbeat indicating the run is alive and making progress.
+
+    Emitted during long-running tool/model/sandbox operations at a
+    configurable interval. Helps clients distinguish between active work
+    and a stalled/dead connection.
+    """
+
+    step_label: str | None = None
+    last_model_call: str | None = None
+    last_tool_call: str | None = None
+    active_subagent_count: int = 0
+    sandbox_ready: bool = False
+
+
+@dataclass
+class RunStateEvent(AgentEvent):
+    """Run lifecycle state transition.
+
+    Emitted when the run enters a new status: queued, starting, active,
+    paused, stalled, aborting, aborted, failed, done, expired.
+    """
+
+    from_status: str
+    to_status: str
+    reason: str | None = None
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CallbackEvent(AgentEvent):
+    """Durable callback/webhook delivery status event.
+
+    Emitted when a callback is queued, sent, retried, or exhausted.
+    Independent of whether the initiating SSE client stays connected.
+    """
+
+    callback_id: str
+    url: str
+    status: str  # sent | failed | retrying | exhausted
+    attempt: int = 1
+    response_status: int | None = None
+    error_message: str | None = None
+
+
 # Union type for all events
 StreamEvent = (
     TokenEvent
@@ -221,6 +269,9 @@ StreamEvent = (
     | StepCompleteEvent
     | InterruptEvent
     | DelegationEvent
+    | HeartbeatEvent
+    | RunStateEvent
+    | CallbackEvent
 )
 
 

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -31,6 +31,12 @@ class SessionCreate(BaseModel):
         default=None,
         description="Arbitrary key-value metadata attached to the session",
     )
+    idempotency_key: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Client-provided key for idempotent session creation. "
+        "Repeated requests with the same key return the existing session.",
+    )
 
 
 class SessionResponse(BaseModel):
@@ -39,13 +45,20 @@ class SessionResponse(BaseModel):
     id: str = Field(..., description="Unique session identifier")
     title: str | None = Field(None, description="Session title")
     thread_id: str = Field(..., description="LangGraph thread ID for checkpointing")
-    status: Literal["active", "inactive", "error", "waiting_for_approval"] = Field(
-        ..., description="Session status"
-    )
+    status: Literal[
+        "queued", "starting", "active", "idle",
+        "waiting_for_approval", "stalled",
+        "aborting", "aborted",
+        "failed", "done", "expired",
+        "inactive", "error",
+    ] = Field(..., description="Session status")
     created_at: str = Field(..., description="Session creation timestamp (ISO format)")
     updated_at: str = Field(..., description="Last activity timestamp (ISO format)")
     message_count: int = Field(0, description="Number of messages in session")
     agent_name: str = Field("default", description="Agent bound to this session")
+    idempotency_key: str | None = Field(
+        default=None, description="Idempotency key used during creation, if any"
+    )
     metadata: dict[str, str] = Field(
         default_factory=dict,
         description="Arbitrary key-value metadata attached to the session",
@@ -63,6 +76,7 @@ class SessionResponse(BaseModel):
             updated_at=session.updated_at,
             message_count=session.message_count,
             agent_name=session.agent_name,
+            idempotency_key=session.metadata.get("idempotency_key") if session.metadata else None,
             metadata=session.metadata,
         )
 
@@ -287,6 +301,23 @@ class ReconnectedEvent(BaseModel):
 
     event: Literal["reconnected"] = "reconnected"
     data: dict = Field(..., description="Reconnection info with 'last_event_id' and 'resumed' flag")
+
+
+class HeartbeatEventModel(BaseModel):
+    """Server-sent event: periodic heartbeat indicating the run is alive."""
+
+    event: Literal["heartbeat"] = "heartbeat"
+    data: dict = Field(..., description="Heartbeat info with step label, activity timestamps")
+
+
+class RunStateEventModel(BaseModel):
+    """Server-sent event: run lifecycle state transition."""
+
+    event: Literal["run_state"] = "run_state"
+    data: dict = Field(
+        ...,
+        description="Run state transition with from_status, to_status, reason",
+    )
 
 
 # ============================================================================

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -41,11 +41,14 @@ from server.app.api.models import (
 from server.app.api.scoping import SessionScope
 from server.app.api.sse import EventBuilder, SSEStream, get_last_event_id
 from server.app.llm.deep_agent_service import (
+    CallbackEvent,
     DelegationEvent,
     DoneEvent,
     ErrorEvent,
+    HeartbeatEvent,
     InterruptEvent,
     PlanningEvent,
+    RunStateEvent,
     SessionAgentManager,
     StatusEvent,
     StepCompleteEvent,
@@ -175,6 +178,9 @@ async def agent_event_stream(
                     session_id=session_id,
                     status=SessionStatus.WAITING_FOR_APPROVAL.value,
                 )
+                yield EventBuilder.run_state(
+                    from_status="active", to_status=SessionStatus.WAITING_FOR_APPROVAL.value
+                )
                 yield EventBuilder.interrupt(
                     tool_call_id=event.tool_call_id,
                     tool_name=event.tool_name,
@@ -210,7 +216,12 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, DoneEvent):
-                await store.update_session(session_id=session_id, status=SessionStatus.ACTIVE.value)
+                await store.update_session(
+                    session_id=session_id, status=SessionStatus.DONE.value
+                )
+                yield EventBuilder.run_state(
+                    from_status="active", to_status=SessionStatus.DONE.value
+                )
                 # ISSUE-019: Generate message_id upfront and include in done event
                 # This allows clients to correlate with persisted message without extra API call
                 message_id = event.message_id or str(uuid.uuid4())
@@ -224,8 +235,49 @@ async def agent_event_stream(
                 yield EventBuilder.done(assistant_data=assistant_data, message_id=message_id)
 
             elif isinstance(event, ErrorEvent):
-                await store.update_session(session_id=session_id, status=SessionStatus.ERROR.value)
+                if event.code == "ABORTED":
+                    await store.update_session(
+                        session_id=session_id, status=SessionStatus.ABORTED.value
+                    )
+                    yield EventBuilder.run_state(
+                        from_status="active", to_status=SessionStatus.ABORTED.value,
+                        reason="Execution aborted",
+                    )
+                else:
+                    await store.update_session(
+                        session_id=session_id, status=SessionStatus.FAILED.value
+                    )
+                    yield EventBuilder.run_state(
+                        from_status="active", to_status=SessionStatus.FAILED.value,
+                        reason=event.message,
+                    )
                 yield EventBuilder.error(event.message, code=event.code)
+
+            elif isinstance(event, HeartbeatEvent):
+                yield EventBuilder.heartbeat(
+                    step_label=event.step_label,
+                    last_model_call=event.last_model_call,
+                    last_tool_call=event.last_tool_call,
+                    active_subagent_count=event.active_subagent_count,
+                    sandbox_ready=event.sandbox_ready,
+                )
+
+            elif isinstance(event, RunStateEvent):
+                yield EventBuilder.run_state(
+                    from_status=event.from_status,
+                    to_status=event.to_status,
+                    reason=event.reason,
+                )
+
+            elif isinstance(event, CallbackEvent):
+                yield EventBuilder.callback(
+                    callback_id=event.callback_id,
+                    url=event.url,
+                    status=event.status,
+                    attempt=event.attempt,
+                    response_status=event.response_status,
+                    error_message=event.error_message,
+                )
 
     except Exception as e:
         logger.error("Agent streaming error", error=str(e), session_id=session_id, exc_info=True)

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -176,6 +176,14 @@ async def create_session(
     if not await config_store.is_valid_primary(request.agent_name):
         raise _unprocessable_entity(f"Invalid or unknown agent: {request.agent_name}")
 
+    # Idempotency: return existing session if idempotency_key matches
+    if request.idempotency_key:
+        existing = await _find_session_by_idempotency_key(
+            store, request.idempotency_key, scope.get_all()
+        )
+        if existing is not None:
+            return SessionResponse.from_core(existing)
+
     session_id = str(uuid.uuid4())
     thread_id = str(uuid.uuid4())  # For LangGraph checkpointing
     workspace_path = build_session_workspace_path(settings, session_id)
@@ -192,7 +200,10 @@ async def create_session(
         title=request.title,
         scopes=scope.get_all(),
         agent_name=request.agent_name,
-        metadata=request.metadata,
+        metadata={
+            **(request.metadata or {}),
+            **({"idempotency_key": request.idempotency_key} if request.idempotency_key else {}),
+        },
         workspace_path=workspace_path,
     )
 
@@ -454,3 +465,118 @@ async def resume_session(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.post(
+    "/{session_id}/cancel",
+    status_code=status.HTTP_200_OK,
+    responses={
+        404: {"model": ErrorResponse, "description": "Session not found"},
+        409: {"model": ErrorResponse, "description": "Session cannot be cancelled in current state"},
+    },
+)
+async def cancel_session(
+    session_id: str,
+    store: StorageBackend = Depends(get_storage_backend_dep),  # noqa: B008
+    agent_manager: SessionAgentManager = Depends(get_session_agent_manager_dep),
+    scope: SessionScope = Depends(get_scope_dep),
+) -> dict[str, str | bool]:
+    """Cancel a session with proper lifecycle state transitions.
+
+    Transitions: current → ABORTING → ABORTED.
+    Terminal states (done, expired) cannot be cancelled.
+    """
+    session = await _get_scoped_session(session_id, store, scope)
+    current = SessionStatus(session.status)
+
+    if SessionStatus.is_terminal(current):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Session '{session_id}' is in terminal state '{current.value}'",
+        )
+
+    # Transition to CANCELLING
+    await _transition_status(store, session_id, current, SessionStatus.ABORTING)
+
+    # Abort the agent runtime
+    await agent_manager.abort_session(session_id, session.thread_id)
+
+    # Transition to CANCELLED
+    await _transition_status(store, session_id, SessionStatus.ABORTING, SessionStatus.ABORTED)
+
+    return {
+        "success": True,
+        "message": "Session cancelled",
+        "status": SessionStatus.ABORTED.value,
+    }
+
+
+@router.post(
+    "/{session_id}/pause",
+    status_code=status.HTTP_200_OK,
+    responses={
+        404: {"model": ErrorResponse, "description": "Session not found"},
+        409: {"model": ErrorResponse, "description": "Session cannot be paused in current state"},
+    },
+)
+async def pause_session(
+    session_id: str,
+    store: StorageBackend = Depends(get_storage_backend_dep),  # noqa: B008
+    scope: SessionScope = Depends(get_scope_dep),
+) -> dict[str, str | bool]:
+    """Pause an active session.
+
+    Transitions: active → idle.
+    Only active sessions can be paused.
+    """
+    session = await _get_scoped_session(session_id, store, scope)
+    current = SessionStatus(session.status)
+
+    if current != SessionStatus.ACTIVE:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Session '{session_id}' is not active (current: '{current.value}')",
+        )
+
+    if not SessionStatus.can_transition(current, SessionStatus.IDLE):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot pause session '{session_id}' from '{current.value}'",
+        )
+
+    await store.update_session(session_id=session_id, status=SessionStatus.IDLE.value)
+    return {"success": True, "message": "Session paused", "status": SessionStatus.IDLE.value}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def _find_session_by_idempotency_key(
+    store: StorageBackend,
+    idempotency_key: str,
+    scope: dict[str, str],
+) -> Any | None:
+    """Find an existing session by idempotency key in the given scope."""
+    sessions = await store.list_sessions()
+    for s in sessions:
+        if s.metadata and s.metadata.get("idempotency_key") == idempotency_key:
+            return s
+    return None
+
+
+async def _transition_status(
+    store: StorageBackend,
+    session_id: str,
+    from_status: SessionStatus,
+    to_status: SessionStatus,
+) -> None:
+    """Transition a session to a new status if allowed."""
+    if not SessionStatus.can_transition(from_status, to_status):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot transition session '{session_id}' "
+            f"from '{from_status.value}' to '{to_status.value}'",
+        )
+    await store.update_session(session_id=session_id, status=to_status.value)

--- a/server/app/api/sse.py
+++ b/server/app/api/sse.py
@@ -514,6 +514,64 @@ class EventBuilder:
             "data": {"last_event_id": last_event_id, "resumed": True},
         }
 
+    @staticmethod
+    def heartbeat(
+        step_label: str | None = None,
+        last_model_call: str | None = None,
+        last_tool_call: str | None = None,
+        active_subagent_count: int = 0,
+        sandbox_ready: bool = False,
+    ) -> dict:
+        """Create a heartbeat event."""
+        return {
+            "event": "heartbeat",
+            "data": {
+                "step_label": step_label,
+                "last_model_call": last_model_call,
+                "last_tool_call": last_tool_call,
+                "active_subagent_count": active_subagent_count,
+                "sandbox_ready": sandbox_ready,
+            },
+        }
+
+    @staticmethod
+    def run_state(
+        from_status: str,
+        to_status: str,
+        reason: str | None = None,
+    ) -> dict:
+        """Create a run state transition event."""
+        return {
+            "event": "run_state",
+            "data": {
+                "from_status": from_status,
+                "to_status": to_status,
+                "reason": reason,
+            },
+        }
+
+    @staticmethod
+    def callback(
+        callback_id: str,
+        url: str,
+        status: str,
+        attempt: int = 1,
+        response_status: int | None = None,
+        error_message: str | None = None,
+    ) -> dict:
+        """Create a callback delivery event."""
+        return {
+            "event": "callback",
+            "data": {
+                "callback_id": callback_id,
+                "url": url,
+                "status": status,
+                "attempt": attempt,
+                "response_status": response_status,
+                "error_message": error_message,
+            },
+        }
+
 
 def get_last_event_id(request: Request) -> str | None:
     """Extract Last-Event-ID header from request.

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -24,12 +24,15 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from server.app.agent.cognition_agent import CognitionAgentParams, create_cognition_agent
 from server.app.agent.resolver import RuntimeResolver
 from server.app.agent.runtime import (
+    CallbackEvent,
     DeepAgentRuntime,
     DelegationEvent,
     DoneEvent,
     ErrorEvent,
+    HeartbeatEvent,
     InterruptEvent,
     PlanningEvent,
+    RunStateEvent,
     StatusEvent,
     StepCompleteEvent,  # noqa: F401 — re-exported for consumers of this module
     StreamEvent,

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -15,12 +15,60 @@ from pydantic import BaseModel
 
 
 class SessionStatus(StrEnum):
-    """Session status enumeration."""
+    """Session lifecycle status enumeration.
 
+    v0.10.0: Expanded to 11 states for long-running agent lifecycles.
+    """
+
+    QUEUED = "queued"
+    STARTING = "starting"
     ACTIVE = "active"
+    IDLE = "idle"
+    WAITING_FOR_APPROVAL = "waiting_for_approval"
+    STALLED = "stalled"
+    ABORTING = "aborting"
+    ABORTED = "aborted"
+    FAILED = "failed"
+    DONE = "done"
+    EXPIRED = "expired"
+
+    # Legacy aliases for backward compatibility
     INACTIVE = "inactive"
     ERROR = "error"
-    WAITING_FOR_APPROVAL = "waiting_for_approval"
+
+    @classmethod
+    def can_transition(cls, current: SessionStatus | str, target: SessionStatus | str) -> bool:
+        """Check if a transition from current to target is valid."""
+        current_str = current.value if isinstance(current, SessionStatus) else current
+        target_str = target.value if isinstance(target, SessionStatus) else target
+
+        # Terminal states cannot transition out
+        if current_str in {"done", "expired"}:
+            return False
+
+        # Valid transitions
+        valid: dict[str, set[str]] = {
+            "queued": {"starting", "failed", "expired"},
+            "starting": {"active", "failed"},
+            "active": {"idle", "waiting_for_approval", "stalled", "aborting", "failed", "done"},
+            "idle": {"active", "stalled", "aborting", "failed", "expired"},
+            "waiting_for_approval": {"active", "aborting", "stalled", "failed"},
+            "stalled": {"active", "aborting", "failed", "expired"},
+            "aborting": {"aborted", "failed"},
+            "aborted": set(),
+            "failed": set(),
+            "done": set(),
+            "expired": set(),
+            "inactive": {"active", "expired"},
+            "error": {"active", "failed"},
+        }
+        return target_str in valid.get(current_str, set())
+
+    @classmethod
+    def is_terminal(cls, status: SessionStatus | str) -> bool:
+        """Check if a status is terminal (no further transitions)."""
+        status_str = status.value if isinstance(status, SessionStatus) else status
+        return status_str in {"done", "aborted", "failed", "expired"}
 
 
 class PromptConfig(BaseModel):


### PR DESCRIPTION
## Summary
Implements Priority 1 (durable run lifecycle + control plane) and Priority 2 (observability spine foundation) from the v0.10.0 long-running agents plan.

### What was added

**Session lifecycle (11 states)**:
`queued → starting → active → idle → stalled → aborting → aborted → failed → done → expired`
(with `waiting_for_approval` as a distinct active sub-state)

- `SessionStatus.can_transition()` — validates allowed state transitions
- `SessionStatus.is_terminal()` — checks if a state accepts no further transitions
- Legacy `INACTIVE` and `ERROR` aliases for backward compatibility

**Run control APIs**:
- `POST /sessions/{id}/cancel` — proper state machine (ABORTING→ABORTED)
- `POST /sessions/{id}/pause` — pause active session (active→idle)

**Idempotency**:
- `idempotency_key` on `SessionCreate` — repeated starts return existing session
- Stored in session metadata for lookup

**Lifecycle events**:
- `HeartbeatEvent` — periodic alive signal with step/model/tool/subagent state
- `RunStateEvent` — emitted on every status transition with reason
- `CallbackEvent` — callback/webhook delivery status tracker
- `EventBuilder.heartbeat()`, `.run_state()`, `.callback()` SSE methods

**Status transitions during streaming**:
- `DoneEvent` → `DONE` (was `ACTIVE`)
- `ErrorEvent(code=ABORTED)` → `ABORTED` (was `ERROR`)
- `ErrorEvent(any)` → `FAILED` (was `ERROR`)
- `InterruptEvent` → `WAITING_FOR_APPROVAL` + `run_state` SSE

## Validation
- [x] 640 unit tests pass
- [x] mypy: 0 errors
- [x] ruff: All checks passed