### PR TITLE
feat(v0.10.0): sandbox lifecycle events and runtime verification

### DIFF
--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -208,6 +208,23 @@ class DelegationEvent(AgentEvent):
     task: str
 
 
+@dataclass
+class SandboxLifecycleEvent(AgentEvent):
+    """Sandbox backend lifecycle transition.
+
+    Emitted during sandbox: provision, verification, execution,
+    cleanup, and teardown.
+    """
+
+    sandbox_id: str
+    phase: str  # provision_requested, provisioned, verified, command_started, command_completed, cleanup_started, teardown_complete
+    sandbox_backend: str  # local, docker, kubernetes
+    duration_ms: float | None = None
+    exit_code: int | None = None
+    is_warm_pool_hit: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 # Union type for all events
 StreamEvent = (
     TokenEvent
@@ -221,6 +238,7 @@ StreamEvent = (
     | StepCompleteEvent
     | InterruptEvent
     | DelegationEvent
+    | SandboxLifecycleEvent
 )
 
 

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -13,6 +13,7 @@ provides K8s-native isolation for production deployments on Kubernetes.
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 from typing import Any, cast
 
@@ -306,7 +307,65 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
                 template=self._template,
                 namespace=self._namespace,
             )
+
+            # Verify runtime readiness before agent execution
+            self._verify_sandbox_runtime()
+
         return self._backend
+
+    def _verify_sandbox_runtime(self) -> None:
+        """Verify sandbox runtime readiness before agent work begins.
+
+        Checks env vars, workspace root, writable directories, and optional
+        GitHub auth status. Logs warnings for any failures so builders can
+        diagnose issues before an agent run fails mysteriously.
+        """
+        if self._backend is None:
+            return
+
+        checks: list[tuple[str, str, bool | None]] = []
+
+        # Check workspace root
+        expected_root = str(self._root_dir)
+        result = self._backend.execute(f'test -d {shlex.quote(expected_root)} && echo "ok" || echo "missing"')
+        workspace_ok = result.exit_code == 0
+        checks.append(("workspace_root", f"Expected {expected_root}", workspace_ok))
+
+        # Check writable workspace
+        result = self._backend.execute(f'test -w {shlex.quote(expected_root)} && echo "ok" || echo "ro"')
+        writable_ok = result.exit_code == 0
+        checks.append(("workspace_writable", expected_root, writable_ok))
+
+        # Check writable temp
+        result = self._backend.execute('test -w /tmp && echo "ok" || echo "ro"')
+        tmp_ok = result.exit_code == 0
+        checks.append(("temp_writable", "/tmp", tmp_ok))
+
+        # Check env vars
+        result = self._backend.execute("env | grep -c COGNITION_WORKSPACE_ROOT")
+        env_ok = result.exit_code == 0 and result.output.strip().isdigit() and int(result.output.strip()) > 0
+        checks.append(("env_var", "COGNITION_WORKSPACE_ROOT", env_ok))
+
+        # Check GitHub auth if token is expected
+        gh_token = os.environ.get("GH_TOKEN", "") or os.environ.get("GITHUB_TOKEN", "")
+        if gh_token:
+            result = self._backend.execute("gh auth status 2>&1 || echo 'not_authenticated'")
+            gh_ok = "not_authenticated" not in result.output
+            checks.append(("github_auth", "gh auth status", gh_ok))
+
+        failures = [(name, detail) for name, detail, ok in checks if ok is not None and not ok]
+        if failures:
+            logger.warning(
+                "Sandbox runtime verification found issues",
+                sandbox_id=self._id,
+                failures={name: detail for name, detail in failures},
+            )
+        else:
+            logger.info(
+                "Sandbox runtime verification passed",
+                sandbox_id=self._id,
+                checks_count=len(checks),
+            )
 
     def _is_protected_path(self, path: str) -> bool:
         """Check if a path is protected.

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -46,6 +46,7 @@ from server.app.llm.deep_agent_service import (
     ErrorEvent,
     InterruptEvent,
     PlanningEvent,
+    SandboxLifecycleEvent,
     SessionAgentManager,
     StatusEvent,
     StepCompleteEvent,
@@ -123,6 +124,17 @@ async def agent_event_stream(
         model_used: str | None = None
         metadata: dict[str, Any] = {}
 
+        # Drain any sandbox lifecycle events queued during agent setup
+        for se in agent_manager.drain_sandbox_events(session_id):
+            yield EventBuilder.sandbox_lifecycle(
+                sandbox_id=se.sandbox_id,
+                phase=se.phase,
+                sandbox_backend=se.sandbox_backend,
+                duration_ms=se.duration_ms,
+                exit_code=se.exit_code,
+                is_warm_pool_hit=se.is_warm_pool_hit,
+            )
+
         # Stream response using DeepAgents with multi-step support
         # Pass agent_manager to enable abort functionality
         async for event in service.stream_response(
@@ -189,6 +201,16 @@ async def agent_event_stream(
                     from_agent=event.from_agent,
                     to_agent=event.to_agent,
                     task=event.task,
+                )
+
+            elif isinstance(event, SandboxLifecycleEvent):
+                yield EventBuilder.sandbox_lifecycle(
+                    sandbox_id=event.sandbox_id,
+                    phase=event.phase,
+                    sandbox_backend=event.sandbox_backend,
+                    duration_ms=event.duration_ms,
+                    exit_code=event.exit_code,
+                    is_warm_pool_hit=event.is_warm_pool_hit,
                 )
 
             elif isinstance(event, StatusEvent):

--- a/server/app/api/sse.py
+++ b/server/app/api/sse.py
@@ -514,6 +514,28 @@ class EventBuilder:
             "data": {"last_event_id": last_event_id, "resumed": True},
         }
 
+    @staticmethod
+    def sandbox_lifecycle(
+        sandbox_id: str,
+        phase: str,
+        sandbox_backend: str,
+        duration_ms: float | None = None,
+        exit_code: int | None = None,
+        is_warm_pool_hit: bool = False,
+    ) -> dict:
+        """Create a sandbox lifecycle event."""
+        return {
+            "event": "sandbox_lifecycle",
+            "data": {
+                "sandbox_id": sandbox_id,
+                "phase": phase,
+                "sandbox_backend": sandbox_backend,
+                "duration_ms": duration_ms,
+                "exit_code": exit_code,
+                "is_warm_pool_hit": is_warm_pool_hit,
+            },
+        }
+
 
 def get_last_event_id(request: Request) -> str | None:
     """Extract Last-Event-ID header from request.

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -30,6 +30,7 @@ from server.app.agent.runtime import (
     ErrorEvent,
     InterruptEvent,
     PlanningEvent,
+    SandboxLifecycleEvent,
     StatusEvent,
     StepCompleteEvent,  # noqa: F401 — re-exported for consumers of this module
     StreamEvent,
@@ -618,6 +619,8 @@ class SessionAgentManager:
         self._project_paths: dict[str, str] = {}
         self._active_runtimes: dict[str, Any] = {}
         self._sandbox_backends: dict[str, Any] = {}
+        self._sandbox_events: dict[str, asyncio.Queue[SandboxLifecycleEvent]] = {}
+        self._sandbox_backend_type: str = settings.sandbox_backend
 
     def register_session(
         self,
@@ -696,6 +699,16 @@ class SessionAgentManager:
             backend: The sandbox backend instance (must have a ``terminate()`` method).
         """
         self._sandbox_backends[session_id] = backend
+        sandbox_id = getattr(backend, "id", str(id(backend)))
+        self._emit_sandbox_event(
+            session_id,
+            SandboxLifecycleEvent(
+                sandbox_id=sandbox_id,
+                phase="provisioned",
+                sandbox_backend=self._sandbox_backend_type,
+                is_warm_pool_hit=getattr(backend, "_warm_pool", None) is not None,
+            ),
+        )
         logger.debug("Sandbox backend registered", session_id=session_id)
 
     def unregister_session(self, session_id: str) -> None:
@@ -705,16 +718,57 @@ class SessionAgentManager:
         self._active_runtimes.pop(session_id, None)
 
         backend = self._sandbox_backends.pop(session_id, None)
-        if backend is not None and hasattr(backend, "terminate"):
-            try:
-                backend.terminate()
-                logger.info("Sandbox backend terminated", session_id=session_id)
-            except Exception as e:
-                logger.warning(
-                    "Sandbox backend terminate failed", session_id=session_id, error=str(e)
-                )
+        if backend is not None:
+            sandbox_id = getattr(backend, "id", str(id(backend)))
+            self._emit_sandbox_event(
+                session_id,
+                SandboxLifecycleEvent(
+                    sandbox_id=sandbox_id,
+                    phase="teardown_started",
+                    sandbox_backend=self._sandbox_backend_type,
+                ),
+            )
+            if hasattr(backend, "terminate"):
+                try:
+                    backend.terminate()
+                    self._emit_sandbox_event(
+                        session_id,
+                        SandboxLifecycleEvent(
+                            sandbox_id=sandbox_id,
+                            phase="teardown_complete",
+                            sandbox_backend=self._sandbox_backend_type,
+                        ),
+                    )
+                    logger.info("Sandbox backend terminated", session_id=session_id)
+                except Exception as e:
+                    logger.warning(
+                        "Sandbox backend terminate failed", session_id=session_id, error=str(e)
+                    )
 
+        self._sandbox_events.pop(session_id, None)
         logger.info("Session unregistered", session_id=session_id)
+
+    def _emit_sandbox_event(self, session_id: str, event: SandboxLifecycleEvent) -> None:
+        """Queue a sandbox lifecycle event for the session."""
+        if session_id not in self._sandbox_events:
+            self._sandbox_events[session_id] = asyncio.Queue(maxsize=20)
+        try:
+            self._sandbox_events[session_id].put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+    def drain_sandbox_events(self, session_id: str) -> list[SandboxLifecycleEvent]:
+        """Drain any pending sandbox lifecycle events."""
+        queue = self._sandbox_events.get(session_id)
+        if queue is None:
+            return []
+        events: list[SandboxLifecycleEvent] = []
+        while not queue.empty():
+            try:
+                events.append(queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return events
 
 
 # Global manager instance


### PR DESCRIPTION
## Summary
Implements sandbox lifecycle observability and runtime verification for P13.

### What was added

**SandboxLifecycleEvent** — new runtime event for all sandbox phase transitions:
- phase: provisioned, teardown_started, teardown_complete (extensible)
- metadata: sandbox_id, backend type, warm_pool_hit, duration_ms, exit_code

**Event emission** — SessionAgentManager:
- Event queue per session (non-blocking, bounded to 20 events)
- Emits `provisioned` on `register_sandbox_backend()`
- Emits `teardown_started`/`teardown_complete` on `unregister_session()`
- `drain_sandbox_events()` for consumers

**SSE** — EventBuilder.sandbox_lifecycle():
- Standard SSE event format with all lifecycle metadata

**Stream integration** — messages.py:
- Drains pending sandbox events before main event loop
- Handles `SandboxLifecycleEvent` in the event stream

**Runtime verification** — K8s sandbox backend:
- Checks after lazy init: workspace root exists, writable workspace, writable /tmp
- Checks COGNITION_WORKSPACE_ROOT env var present
- Checks `gh auth status` when GitHub token configured
- Logs structured warnings on verification failure — no silent boot problems

## Validation
- [x] 640 unit tests pass
- [x] mypy: 0 errors