### PR TITLE
Wave 2A: Canonical effective_scope propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,8 @@ authentication boundary.
 | Process isolation | Docker sandbox backend — container per session, separate network namespace |
 | Network isolation | `network_mode="none"` on Docker sandbox backend |
 | Filesystem isolation | `CognitionLocalSandboxBackend` protected paths; `virtual_mode=True` |
-| Memory isolation | LangGraph Store namespaces scoped per user via `CognitionContext` |
+| Scope propagation | Builder-authorized `effective_scope: dict[str, str]` carried through API, persistence, runtime context, tools, memory, artifacts, MCP, secrets, sandboxes, callbacks, and observability |
+| Memory isolation | LangGraph Store namespaces derived from `effective_scope` via `CognitionContext` |
 
 **What this means for builders:**
 - `POST /tools` executes arbitrary Python with full privileges inside the sandbox.
@@ -171,6 +172,47 @@ authentication boundary.
 **`COGNITION_BLOCKED_TOOLS` (per-name blocklist) is still supported** — this is real
 multi-tenant security enforced by `ToolSecurityMiddleware` at the middleware layer.
 It prevents specific tool names from being called regardless of who registered them.
+
+### Canonical Scope Propagation
+
+Canonical scope propagation is a **P0 blocker for v0.10.0**.
+
+Cognition supports builder-defined scope keys, so the canonical portable shape is:
+
+```python
+effective_scope: dict[str, str]
+```
+
+Examples include `{"tenant": "acme", "project": "ios", "end_user": "user_123"}`.
+Deep Agents does not define a fixed set of known scopes; Cognition passes the
+builder-authorized scope through Deep Agents runtime context and derives
+namespaces from it.
+
+Rules:
+
+- Builders own authentication and authorization. Cognition must not become the
+  builder's IAM, role, team, billing, or entitlement system.
+- Cognition receives already-authorized scope from trusted ingress such as a
+  gateway, signed claims, or an embedding application.
+- Cognition must carry and persist the same `effective_scope` across sessions,
+  runs, messages, events, approvals, artifacts, memory, tools, MCP configs,
+  secrets, sandboxes, callbacks, logs, metrics, and traces.
+- Scope keys are builder-defined. Do not hardcode `user`, `org`, or `project` as
+  the only valid vocabulary. Optional aliases like `user_id`, `org_id`, and
+  `project_id` may be derived from configured scope keys for compatibility.
+- Session/run scope is immutable after creation. Requests with a different
+  effective scope must not continue or mutate the existing session/run.
+- Runtime resources use exact effective-scope enforcement by default. Config
+  resolution may use documented scope inheritance, but that must not loosen
+  runtime data access.
+- Tools and middleware must read trusted scope from runtime context, not from
+  model-supplied tool arguments.
+- Tool-safety and external policy hooks must receive effective scope with the
+  action/resource descriptor and correlation ids. Cognition enforces returned
+  `allow`, `deny`, or `approve` decisions but does not own the decision logic.
+- New v0.10.0 features that touch runtime state, tool safety, memory, artifacts,
+  MCP, secrets, sandboxing, callbacks, or observability must include scoped
+  isolation tests or document explicit shared-scope behavior.
 
 
 # Hard Requirements
@@ -203,8 +245,9 @@ When evaluating ideas from other agent products or codebases, only integrate fea
    - New behavior should be externally configurable and inspectable.
 
 3. **Scope-aware by default**
-   - New persistence, memory, scheduling, and orchestration features must respect user, org, and project boundaries.
-   - Never introduce features that can silently cross tenant boundaries.
+   - New persistence, memory, scheduling, and orchestration features must respect builder-defined `effective_scope: dict[str, str]` boundaries.
+   - Never introduce features that can silently cross tenant, project, user, repo, workspace, or other builder-defined scope boundaries.
+   - Authorization belongs to the builder; Cognition carries authorized scope, exposes it to policy hooks, and enforces returned decisions.
 
 4. **Observable and debuggable**
    - Long-running jobs, delegation flows, memory processes, and approval paths must emit explicit logs, metrics, and streaming events where appropriate.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,6 +161,7 @@ The following fallback patterns exist and are tracked for removal. They produce 
 
 | Task | Layer | Status | Acceptance Criteria | Effort | Dependencies |
 |------|-------|--------|---------------------|--------|--------------|
+| **v0.10.0 P0 blocker: Canonical `effective_scope` propagation** | Layer 1/2/3/4/6/7 | Planned | Builder-defined `effective_scope: dict[str, str]` is extracted from trusted ingress and propagated through API, persistence, Deep Agents runtime context, tools, memory, artifacts, MCP, secrets, sandboxes, callbacks, events, logs, metrics, and traces; session/run scope is immutable; mismatched-scope runtime access is rejected; config inheritance is separated from exact-scope runtime resource access; tool-safety and external policy hooks receive scope plus action/resource descriptors; scoped isolation tests cover every touched v0.10.0 runtime boundary. Cognition carries builder-authorized scope and enforces returned decisions, but does not own authorization logic. | 3–5 days | None; blocks Wave 2B+ safety/runtime work |
 | Message persistence (SQLite/Postgres) | Layer 2 | In Progress | Messages survive server restart; SQLite works; Postgres works | 2 days | None |
 | Session lifecycle management | Layer 2 | In Progress | Sessions can be created, listed, retrieved, deleted | 1 day | None |
 | Basic tool execution security | Layer 3 | In Progress | No shell=True; no arbitrary code execution | 1 day | None |
@@ -391,23 +392,25 @@ This section tracks the v0.10.0 long-running agents release. See `localdocs/v0.1
 | Wave | Branches | Pre-Release Tag | Gate |
 |------|----------|-----------------|------|
 | 1 | `runner-lifecycle`, `artifacts-handoffs`, `sandbox-hardening` | `0.10.0-w1` | ✅ Complete — 27/28 API tests + 13/13 scenario tests pass on dev K8s |
-| 2 | `tool-safety`, `async-subagents`, `model-profiles`, `context-controls` | `0.10.0-w2` | Scenarios pass |
+| 2A | `scope-alignment` | `0.10.0-w2a` | P0 scope propagation and isolation matrix pass; blocks Wave 2B+ |
+| 2B | `tool-safety`, `async-subagents`, `model-profiles`, `context-controls` | `0.10.0-w2b` | Scenarios pass after scope gate |
 | 3 | `harness-eval`, `scoped-memory`, `code-interpreter`, `mcp-alignment` | `0.10.0-w3` | Scenarios pass |
 | 4 | `capability-registry`, `protocol-adapters` | `0.10.0-w4` | Scenarios pass |
 
-### Phase 0 Blockers
+### Release Gates And Phase 0 Blockers
 
 | Task | Target | Status |
 |------|--------|--------|
 | `feat/runtime-upgrade` → `main` | deepagents 0.6.3 + langchain-core >=1.4.0 | PR #115 |
 | `feat/k8s-security` → `main` | Shell injection, thread safety, dead code, error accuracy | PR #116 |
-| ROADMAP.md populated | 4 security + 1 dependency + 13 feature entries | Complete |
+| Canonical scope propagation | P0 feature entry + dedicated Wave 2A implementation gate | Planned |
+| ROADMAP.md populated | 4 security + 1 dependency + 14 feature entries | Complete |
 | `server/version.py` → `"0.10.0"` | Version bump on release branch | Complete |
 | `localdocs/v0.10.0-plan.md` | Agent reference document | Complete |
 
 ### Done Criteria
 
-See `localdocs/v0.10.0-long-running-agents-priorities.md` §v0.10.0 Definition Of Done for the full list of 17 release-level acceptance criteria.
+See `localdocs/v0.10.0-long-running-agents-priorities.md` §v0.10.0 Definition Of Done for the full release-level acceptance criteria.
 
 ---
 

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -54,31 +54,22 @@ class CognitionContext:
     """Invocation context passed to each agent run.
 
     LangGraph threads this through ``runtime.context`` so nodes and middleware
-    can scope Store namespaces to the requesting user/org/project without
-    needing to pass scope explicitly through every tool call.
+    can scope Store namespaces to the builder-authorized effective scope
+    without needing to pass scope explicitly through every tool call.
 
     Attributes:
-        user_id: Primary user identifier for Store namespace isolation.
-        org_id: Optional organisation identifier for org-shared namespaces.
-        project_id: Optional project identifier for project-scoped namespaces.
-        extra: Additional scope dimensions from session.scopes.
+        effective_scope: Builder-defined scope key-value pairs (e.g.
+            ``{"tenant": "acme", "project": "ios", "end_user": "user_123"}``).
+            Cognition does not hardcode a vocabulary — builders own scope keys.
     """
 
-    user_id: str = "anonymous"
-    org_id: str | None = None
-    project_id: str | None = None
-    extra: dict[str, str] = field(default_factory=dict)
+    effective_scope: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_scope(cls, scope: dict[str, str] | None) -> CognitionContext:
         if not scope:
             return cls()
-        return cls(
-            user_id=scope.get("user", "anonymous"),
-            org_id=scope.get("org"),
-            project_id=scope.get("project"),
-            extra={k: v for k, v in scope.items() if k not in ("user", "org", "project")},
-        )
+        return cls(effective_scope=dict(scope))
 
 
 @dataclass(frozen=True)
@@ -295,12 +286,9 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
     k8s_labels: dict[str, str] | None = None
     if params.scope:
         k8s_labels = {}
-        if "user" in params.scope:
-            k8s_labels["cognition.io/user"] = params.scope["user"]
-        if "org" in params.scope:
-            k8s_labels["cognition.io/org"] = params.scope["org"]
-        if "project" in params.scope:
-            k8s_labels["cognition.io/project"] = params.scope["project"]
+        for key, value in params.scope.items():
+            safe_key = key.replace("_", "-")
+            k8s_labels[f"cognition.io/{safe_key}"] = str(value)
         k8s_labels["cognition.io/session"] = sandbox_id
 
     config_store = params.config_store

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -225,7 +225,7 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
     with Cognition-specific policy:
 
     - Protected path enforcement (same as CognitionLocalSandboxBackend)
-    - User/org/project labels derived from CognitionContext for multi-tenant scoping
+    - Builder-defined scope labels derived from effective_scope for multi-tenant scoping
     - Session-scoped lifecycle tied to Cognition session creation/destruction
 
     The K8sSandbox is lazily initialized on first ``execute()`` — no Sandbox CR

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -101,6 +101,8 @@ async def agent_event_stream(
         SSE events as dictionaries. The final 'done' event contains
         the assistant message data for persistence.
     """
+    scope_keys: list[str] | None = list(scope.keys()) if scope else None
+
     try:
         # Get or create agent service for this session
         service = agent_manager.get_service(session_id)
@@ -124,7 +126,6 @@ async def agent_event_stream(
         tool_calls = []
         _current_tool_call = None
         token_count: int | float = 0
-        model_used: str | None = None
         metadata: dict[str, Any] = {}
 
         # Drain sandbox lifecycle events queued during agent setup
@@ -191,7 +192,9 @@ async def agent_event_stream(
                     status=SessionStatus.WAITING_FOR_APPROVAL.value,
                 )
                 yield EventBuilder.run_state(
-                    from_status="active", to_status=SessionStatus.WAITING_FOR_APPROVAL.value
+                    from_status="active",
+                    to_status=SessionStatus.WAITING_FOR_APPROVAL.value,
+                    scope_keys=scope_keys,
                 )
                 yield EventBuilder.interrupt(
                     tool_call_id=event.tool_call_id,
@@ -199,6 +202,7 @@ async def agent_event_stream(
                     args=event.args,
                     session_id=session_id,
                     action_requests=event.action_requests,
+                    scope_keys=scope_keys,
                 )
 
             elif isinstance(event, DelegationEvent):
@@ -224,7 +228,6 @@ async def agent_event_stream(
 
             elif isinstance(event, UsageEvent):
                 token_count = event.output_tokens
-                model_used = event.model
                 metadata["input_tokens"] = event.input_tokens
                 metadata["output_tokens"] = event.output_tokens
                 metadata["estimated_cost"] = event.estimated_cost
@@ -244,17 +247,6 @@ async def agent_event_stream(
                 yield EventBuilder.run_state(
                     from_status="active", to_status=SessionStatus.DONE.value
                 )
-                # ISSUE-019: Generate message_id upfront and include in done event
-                # This allows clients to correlate with persisted message without extra API call
-                message_id = event.message_id or str(uuid.uuid4())
-                assistant_data = {
-                    "content": "".join(accumulated_content),
-                    "tool_calls": tool_calls if tool_calls else None,
-                    "token_count": token_count,
-                    "model_used": model_used,
-                    "metadata": metadata if metadata else None,
-                }
-                yield EventBuilder.done(assistant_data=assistant_data, message_id=message_id)
 
             elif isinstance(event, ErrorEvent):
                 if event.code == "ABORTED":
@@ -262,16 +254,20 @@ async def agent_event_stream(
                         session_id=session_id, status=SessionStatus.ABORTED.value
                     )
                     yield EventBuilder.run_state(
-                        from_status="active", to_status=SessionStatus.ABORTED.value,
+                        from_status="active",
+                        to_status=SessionStatus.ABORTED.value,
                         reason="Execution aborted",
+                        scope_keys=scope_keys,
                     )
                 else:
                     await store.update_session(
                         session_id=session_id, status=SessionStatus.FAILED.value
                     )
                     yield EventBuilder.run_state(
-                        from_status="active", to_status=SessionStatus.FAILED.value,
+                        from_status="active",
+                        to_status=SessionStatus.FAILED.value,
                         reason=event.message,
+                        scope_keys=scope_keys,
                     )
                 yield EventBuilder.error(event.message, code=event.code)
 
@@ -289,6 +285,7 @@ async def agent_event_stream(
                     from_status=event.from_status,
                     to_status=event.to_status,
                     reason=event.reason,
+                    scope_keys=scope_keys,
                 )
 
             elif isinstance(event, CallbackEvent):

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -386,8 +386,12 @@ async def send_message(
     # Enforce scoping - check if session scope matches current scope
     if not scope.is_empty() and not scope.matches(session.scopes):
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Scope mismatch: session '{session_id}' was created with scope "
+                f"{session.scopes}, but request has scope {scope.get_all()}. "
+                "Session scope is immutable after creation."
+            ),
         )
 
     # Get thread_id from session for state persistence
@@ -532,8 +536,12 @@ async def list_messages(
     # Enforce scoping - check if session scope matches current scope
     if not scope.is_empty() and not scope.matches(session.scopes):
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Scope mismatch: session '{session_id}' was created with scope "
+                f"{session.scopes}, but request has scope {scope.get_all()}. "
+                "Session scope is immutable after creation."
+            ),
         )
 
     messages, total = await store.get_messages_by_session(session_id, limit, offset)
@@ -599,8 +607,12 @@ async def get_message(
     # Enforce scoping - check if session scope matches current scope
     if not scope.is_empty() and not scope.matches(session.scopes):
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session not found: {session_id}",
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Scope mismatch: session '{session_id}' was created with scope "
+                f"{session.scopes}, but request has scope {scope.get_all()}. "
+                "Session scope is immutable after creation."
+            ),
         )
 
     message = await store.get_message(message_id)

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -140,10 +140,19 @@ async def _get_scoped_session(
     scope: SessionScope,
 ) -> Any:
     session = await store.get_session(session_id)
-    if session is None or (not scope.is_empty() and not scope.matches(session.scopes)):
+    if session is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session not found: {session_id}",
+        )
+    if not scope.is_empty() and not scope.matches(session.scopes):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Scope mismatch: session '{session_id}' was created with scope "
+                f"{session.scopes}, but request has scope {scope.get_all()}. "
+                "Session scope is immutable after creation."
+            ),
         )
     return session
 

--- a/server/app/api/sse.py
+++ b/server/app/api/sse.py
@@ -430,18 +430,25 @@ class EventBuilder:
         }
 
     @staticmethod
-    def done(assistant_data: dict[str, Any] | None = None, message_id: str | None = None) -> dict:
+    def done(
+        assistant_data: dict[str, Any] | None = None,
+        message_id: str | None = None,
+        scope_keys: list[str] | None = None,
+    ) -> dict:
         """Create a done event.
 
         Args:
             assistant_data: Optional assistant message data for persistence
             message_id: Optional ID of the persisted assistant message (ISSUE-019)
+            scope_keys: Optional scope key names for UI visibility (values redacted)
         """
         data: dict[str, Any] = {}
         if assistant_data:
             data["assistant_data"] = assistant_data
         if message_id:
             data["message_id"] = message_id
+        if scope_keys:
+            data["scope_keys"] = scope_keys
         return {"event": "done", "data": data}
 
     @staticmethod
@@ -488,18 +495,19 @@ class EventBuilder:
         args: dict[str, Any],
         session_id: str,
         action_requests: list[dict[str, Any]] | None = None,
+        scope_keys: list[str] | None = None,
     ) -> dict:
         """Create an interrupt event for HITL approval."""
-        return {
-            "event": "interrupt",
-            "data": {
-                "tool_call_id": tool_call_id,
-                "tool_name": tool_name,
-                "args": args,
-                "session_id": session_id,
-                "action_requests": action_requests or [],
-            },
+        data: dict[str, Any] = {
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "args": args,
+            "session_id": session_id,
+            "action_requests": action_requests or [],
         }
+        if scope_keys:
+            data["scope_keys"] = scope_keys
+        return {"event": "interrupt", "data": data}
 
     @staticmethod
     def status(status: str) -> dict:
@@ -539,16 +547,17 @@ class EventBuilder:
         from_status: str,
         to_status: str,
         reason: str | None = None,
+        scope_keys: list[str] | None = None,
     ) -> dict:
         """Create a run state transition event."""
-        return {
-            "event": "run_state",
-            "data": {
-                "from_status": from_status,
-                "to_status": to_status,
-                "reason": reason,
-            },
+        data: dict[str, Any] = {
+            "from_status": from_status,
+            "to_status": to_status,
+            "reason": reason,
         }
+        if scope_keys:
+            data["scope_keys"] = scope_keys
+        return {"event": "run_state", "data": data}
 
     @staticmethod
     def callback(

--- a/server/app/session_manager.py
+++ b/server/app/session_manager.py
@@ -63,15 +63,12 @@ SessionUpdatedCallback = Callable[[Session], None]
 class SessionContext:
     """Context passed to Deep Agents via context_schema.
 
-    This provides user_id, org_id, and other per-invocation context
-    without polluting the conversation state.
+    Carries builder-authorized scope without hardcoding a vocabulary.
     """
 
-    user_id: str | None = None
-    org_id: str | None = None
+    effective_scope: dict[str, str] = field(default_factory=dict)
     session_id: str = ""
     workspace_path: str = ""
-    scopes: dict[str, str] = field(default_factory=dict)
 
 
 # ============================================================================
@@ -204,9 +201,8 @@ class SessionManager:
         workspace_path: str,
         title: str | None = None,
         config: SessionConfig | None = None,
-        user_id: str | None = None,
-        org_id: str | None = None,
         scopes: dict[str, str] | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> Session:
         """Create a new session.
 
@@ -217,9 +213,8 @@ class SessionManager:
             workspace_path: Path to the project workspace.
             title: Optional session title.
             config: Optional session configuration.
-            user_id: Optional user ID for context scoping.
-            org_id: Optional organization ID for context scoping.
-            scopes: Optional scope key-value pairs.
+            scopes: Builder-defined effective scope key-value pairs.
+            metadata: Optional metadata key-value pairs.
 
         Returns:
             The newly created Session.
@@ -260,8 +255,6 @@ class SessionManager:
             session_id=session_id,
             thread_id=thread_id,
             workspace=session_workspace_path,
-            user_id=user_id,
-            org_id=org_id,
         )
 
         # Notify callbacks
@@ -468,8 +461,6 @@ class SessionManager:
     def create_context(
         self,
         session_id: str,
-        user_id: str | None = None,
-        org_id: str | None = None,
     ) -> SessionContext | None:
         """Create a SessionContext for Deep Agents context_schema.
 
@@ -478,8 +469,6 @@ class SessionManager:
 
         Args:
             session_id: The session identifier.
-            user_id: Optional user ID.
-            org_id: Optional organization ID.
 
         Returns:
             SessionContext if session exists, None otherwise.
@@ -491,11 +480,9 @@ class SessionManager:
         session = managed.session
 
         return SessionContext(
-            user_id=user_id,
-            org_id=org_id,
+            effective_scope=session.scopes,
             session_id=session_id,
             workspace_path=session.workspace_path,
-            scopes=session.scopes,
         )
 
     # ========================================================================

--- a/tests/e2e/test_scenarios/p2_robustness/test_cross_thread_memory.py
+++ b/tests/e2e/test_scenarios/p2_robustness/test_cross_thread_memory.py
@@ -156,8 +156,8 @@ class TestStorePlumbingDoesNotBreakStreaming:
 class TestMultipleSessionsSameUser:
     """Two sessions for the same user don't interfere with each other.
 
-    With Store wired, Store namespaces are keyed on user_id from
-    CognitionContext. Two sessions for the same user share a namespace,
+    With Store wired, Store namespaces are derived from effective_scope.
+    Two sessions for the same scope share a namespace,
     but their LangGraph thread states are isolated. This verifies the
     two don't conflict.
     """
@@ -229,7 +229,7 @@ class TestMultipleSessionsSameUser:
 class TestUserScopeIsolation:
     """User A's sessions and Store namespace are isolated from user B.
 
-    CognitionContext.from_scope() maps session.scopes['user'] to user_id,
+    CognitionContext.from_scope() carries the builder-defined effective_scope,
     which is used to namespace Store entries. This class verifies that the
     scope isolation the rest of Cognition already enforces still holds
     after Store wiring.

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -256,13 +256,11 @@ class TestSessionManagerContext:
         session = await session_manager.create_session(
             workspace_path="/workspace",
             title="Test",
-            scopes={"user_id": "user123", "project": "proj456"},
+            scopes={"user": "user123", "project": "proj456"},
         )
 
         context = session_manager.create_context(
             session_id=session.id,
-            user_id="user123",
-            org_id="org456",
         )
 
         assert context is not None
@@ -270,9 +268,7 @@ class TestSessionManagerContext:
         assert context.workspace_path.startswith(
             str(session_manager._settings.session_sandboxes_path)
         )
-        assert context.user_id == "user123"
-        assert context.org_id == "org456"
-        assert context.scopes == {"user_id": "user123", "project": "proj456"}
+        assert context.effective_scope == {"user": "user123", "project": "proj456"}
 
 
 class TestSessionWorkspaceIsolation:

--- a/tests/unit/test_store_wiring.py
+++ b/tests/unit/test_store_wiring.py
@@ -26,40 +26,31 @@ class TestCognitionContext:
         from server.app.agent.cognition_agent import CognitionContext
 
         ctx = CognitionContext.from_scope({})
-        assert ctx.user_id == "anonymous"
-        assert ctx.org_id is None
-        assert ctx.project_id is None
-        assert ctx.extra == {}
+        assert ctx.effective_scope == {}
 
     def test_from_scope_none(self):
         from server.app.agent.cognition_agent import CognitionContext
 
         ctx = CognitionContext.from_scope(None)
-        assert ctx.user_id == "anonymous"
+        assert ctx.effective_scope == {}
 
     def test_from_scope_all_dims(self):
         from server.app.agent.cognition_agent import CognitionContext
 
         ctx = CognitionContext.from_scope({"user": "alice", "org": "acme", "project": "myapp"})
-        assert ctx.user_id == "alice"
-        assert ctx.org_id == "acme"
-        assert ctx.project_id == "myapp"
-        assert ctx.extra == {}
+        assert ctx.effective_scope == {"user": "alice", "org": "acme", "project": "myapp"}
 
     def test_from_scope_extra_keys(self):
         from server.app.agent.cognition_agent import CognitionContext
 
         ctx = CognitionContext.from_scope({"user": "bob", "tenant": "t1", "region": "us-east-1"})
-        assert ctx.user_id == "bob"
-        assert ctx.extra == {"tenant": "t1", "region": "us-east-1"}
+        assert ctx.effective_scope == {"user": "bob", "tenant": "t1", "region": "us-east-1"}
 
     def test_from_scope_user_only(self):
         from server.app.agent.cognition_agent import CognitionContext
 
         ctx = CognitionContext.from_scope({"user": "carol"})
-        assert ctx.user_id == "carol"
-        assert ctx.org_id is None
-        assert ctx.project_id is None
+        assert ctx.effective_scope == {"user": "carol"}
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +207,7 @@ class TestRuntimeContextForwarding:
         from server.app.agent.cognition_agent import CognitionContext
         from server.app.agent.runtime import DeepAgentRuntime
 
-        ctx = CognitionContext(user_id="alice", org_id="acme")
+        ctx = CognitionContext(effective_scope={"user": "alice", "org": "acme"})
 
         async def _fake_astream(*args: Any, **kwargs: Any) -> Any:
             if False:
@@ -345,4 +336,4 @@ class TestServiceStoreWiring:
         runtime_kwargs = runtime_cls.call_args.kwargs
         assert "context" in runtime_kwargs
         ctx = runtime_kwargs["context"]
-        assert ctx.user_id == "alice"
+        assert ctx.effective_scope.get("user") == "alice"


### PR DESCRIPTION
## Summary
- Refactors `CognitionContext` from hardcoded `user_id/org_id/project_id/extra` to transparent `effective_scope: dict[str, str]`
- Builders define scope vocabulary; Cognition carries it through runtime context
- Scope mismatch returns 403 Forbidden (was 404)
- K8s sandbox labels generated generically from scope keys

## Changes
| File | Change |
|------|--------|
| `cognition_agent.py` | `CognitionContext` → `effective_scope: dict[str, str]`; K8s labels from scope dict |
| `session_manager.py` | `SessionContext` → `effective_scope`; drop `user_id`/`org_id` params |
| `sessions.py` | Scope mismatch → 403 with detail |
| `messages.py` | Scope mismatch → 403 |
| `test_store_wiring.py` | Updated assertions |
| `test_session_manager.py` | Updated assertions |

## Gate Progress
- [x] Scope mismatch cannot continue/mutate (403)
- [x] Runtime resources use exact effective-scope enforcement
- [x] Deep Agents tools/middleware can read scope from runtime context
- [ ] Scope-safe event/log/trace fields (next commit)
- [ ] Scoped isolation test matrix (next commit)