### PR TITLE
Add GET /capabilities deployment registry endpoint

### DIFF
--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -625,6 +625,33 @@ class McpServerList(BaseModel):
 
 
 # ============================================================================
+# Capability Models
+# ============================================================================
+
+
+class VersionInfo(BaseModel):
+    """Version information for installed runtime packages."""
+
+    cognition: str
+    deepagents: str
+    langgraph: str
+    langchain: str
+    langchain_core: str
+
+
+class CapabilityResponse(BaseModel):
+    """Deployment capability and compatibility report."""
+
+    versions: VersionInfo
+    stream_protocols: list[str]
+    sandbox_backends: list[str]
+    features: dict[str, bool]
+    middleware: list[str]
+    scope_keys: list[str]
+    deployment: dict[str, Any]
+
+
+# ============================================================================
 # Agent Models
 # ============================================================================
 

--- a/server/app/api/routes/__init__.py
+++ b/server/app/api/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from server.app.api.routes import (
     agents,
+    capabilities,
     config,
     mcp_servers,
     messages,
@@ -13,6 +14,7 @@ from server.app.api.routes import (
 
 __all__ = [
     "agents",
+    "capabilities",
     "config",
     "mcp_servers",
     "messages",

--- a/server/app/api/routes/capabilities.py
+++ b/server/app/api/routes/capabilities.py
@@ -1,0 +1,91 @@
+"""Capability discovery and compatibility reporting.
+
+Exposes the deployment's runtime feature set so builders and clients can
+adapt their behaviour without guessing or parsing opaque error messages.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+from fastapi import APIRouter, Depends
+
+from server.app.api.dependencies import get_settings_dep
+from server.app.api.models import CapabilityResponse, VersionInfo
+from server.app.settings import Settings
+
+router = APIRouter(prefix="/capabilities", tags=["capabilities"])
+
+
+def _get_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+@router.get("", response_model=CapabilityResponse)
+async def get_capabilities(
+    settings: Settings = Depends(get_settings_dep),  # noqa: B008
+) -> CapabilityResponse:
+    """Return deployment capability and version report.
+
+    Includes installed runtime package versions, supported stream protocols,
+    available sandbox backends, feature flags, middleware types, and scope
+    configuration.
+    """
+    stream_protocols = ["sse"]
+
+    sandbox_backends = ["local"]
+    if settings.docker_image:
+        sandbox_backends.append("docker")
+    sandbox_backends.append("kubernetes")
+
+    features: dict[str, bool] = {
+        "async_subagents": True,
+        "mcp": True,
+        "mcp_tool_name_prefix": True,
+        "hitl": True,
+        "permissions": True,
+        "artifacts": True,
+        "context_policy": True,
+        "context_controls": True,
+        "tool_safety": True,
+        "tool_argument_validation": True,
+        "trusted_runtime_context": True,
+        "checkpoint_apis": True,
+        "scope_propagation": True,
+        "provider_config_crud": True,
+        "agent_config_crud": True,
+        "model_catalog": True,
+    }
+
+    middleware = [
+        "ToolSecurityMiddleware",
+        "ToolArgumentValidationMiddleware",
+        "TrustedRuntimeContextMiddleware",
+        "CognitionObservabilityMiddleware",
+        "CognitionStreamingMiddleware",
+        "HumanInTheLoopMiddleware",
+        "FilesystemMiddleware",
+        "MemoryMiddleware",
+        "SummarizationToolMiddleware",
+    ]
+
+    return CapabilityResponse(
+        versions=VersionInfo(
+            cognition=_get_version("cognition"),
+            deepagents=_get_version("deepagents"),
+            langgraph=_get_version("langgraph"),
+            langchain=_get_version("langchain"),
+            langchain_core=_get_version("langchain-core"),
+        ),
+        stream_protocols=stream_protocols,
+        sandbox_backends=sandbox_backends,
+        features=features,
+        middleware=middleware,
+        scope_keys=list(settings.scope_keys),
+        deployment={
+            "sandbox_backend": settings.sandbox_backend,
+        },
+    )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -26,6 +26,7 @@ from server.app.api.models import HealthStatus, ReadyStatus
 from server.app.api.routes import (
     agents,
     artifacts,
+    capabilities,
     config,
     mcp_servers,
     messages,
@@ -251,6 +252,7 @@ app.include_router(skills.router)
 app.include_router(models.router)
 app.include_router(tools.router)
 app.include_router(artifacts.router)
+app.include_router(capabilities.router)
 
 
 @app.get("/health", response_model=HealthStatus, tags=["health"])

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -1,0 +1,80 @@
+"""Unit tests for the capability registry endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.app.api.models import CapabilityResponse, VersionInfo
+from server.app.api.routes.capabilities import _get_version, get_capabilities
+from server.app.settings import Settings
+
+
+class TestCapabilityVersions:
+    def test_known_package_versions_resolve(self):
+        for pkg in ("deepagents", "langgraph", "langchain", "langchain-core"):
+            v = _get_version(pkg)
+            assert v != "unknown", f"Expected known version for {pkg}"
+
+    def test_unknown_package_returns_unknown(self):
+        assert _get_version("nonexistent-package-12345") == "unknown"
+
+
+@pytest.mark.asyncio
+class TestCapabilityEndpoint:
+    async def test_returns_all_version_fields(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert isinstance(result, CapabilityResponse)
+        v = result.versions
+        assert isinstance(v, VersionInfo)
+        assert v.cognition == _get_version("cognition")
+        assert v.deepagents == _get_version("deepagents")
+        assert v.langgraph == _get_version("langgraph")
+        assert v.langchain == _get_version("langchain")
+        assert v.langchain_core == _get_version("langchain-core")
+
+    async def test_stream_protocols_includes_sse(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert "sse" in result.stream_protocols
+
+    async def test_sandbox_backends_includes_local(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert "local" in result.sandbox_backends
+
+    async def test_features_include_core_v010_flags(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert result.features["mcp"] is True
+        assert result.features["hitl"] is True
+        assert result.features["permissions"] is True
+        assert result.features["artifacts"] is True
+        assert result.features["context_policy"] is True
+        assert result.features["tool_safety"] is True
+        assert result.features["scope_propagation"] is True
+        assert result.features["async_subagents"] is True
+
+    async def test_features_do_not_include_deferred_items(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert "eval_harness" not in result.features
+        assert "code_interpreter" not in result.features
+        assert "scoped_memory" not in result.features
+
+    async def test_middleware_includes_required_names(self):
+        settings = Settings()
+        result = await get_capabilities(settings)
+        assert "ToolSecurityMiddleware" in result.middleware
+        assert "HumanInTheLoopMiddleware" in result.middleware
+        assert "FilesystemMiddleware" in result.middleware
+
+    async def test_scope_keys_from_settings(self):
+        settings = Settings(scope_keys=["user", "project"])
+        result = await get_capabilities(settings)
+        assert result.scope_keys == ["user", "project"]
+
+    async def test_deployment_includes_sandbox_backend(self):
+        settings = Settings(sandbox_backend="local")
+        result = await get_capabilities(settings)
+        assert result.deployment["sandbox_backend"] == "local"


### PR DESCRIPTION
## Summary

Adds `GET /capabilities` endpoint that reports deployment runtime information
so builders and clients can probe feature availability without guessing.

## Response shape

```json
{
  "versions": {
    "cognition": "0.10.0",
    "deepagents": "0.6.3",
    "langgraph": "1.2.0",
    "langchain": "1.3.1",
    "langchain_core": "1.4.0"
  },
  "stream_protocols": ["sse"],
  "sandbox_backends": ["local", "docker", "kubernetes"],
  "features": {
    "async_subagents": true,
    "mcp": true,
    "mcp_tool_name_prefix": true,
    "hitl": true,
    "permissions": true,
    "artifacts": true,
    "context_policy": true,
    "context_controls": true,
    "tool_safety": true,
    "tool_argument_validation": true,
    "trusted_runtime_context": true,
    "checkpoint_apis": true,
    "scope_propagation": true,
    "provider_config_crud": true,
    "agent_config_crud": true,
    "model_catalog": true
  },
  "middleware": [...],
  "scope_keys": ["user"],
  "deployment": {"sandbox_backend": "local"}
}
```

## Test Results

| Suite | Result |
|-------|--------|
| Capability unit | 10 passed |
| Full unit suite | 681 passed, 4 skipped |
| ruff | Clean |
| mypy | Clean |