### PR TITLE
Fix durable session progress during runtime activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,12 +74,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Runtime activity now updates durable session progress: assistant responses are projected into session messages, tool calls/results are persisted as message projection entries, runtime activity advances `updated_at`, tool logs include trusted `session_id`/`run_id`, and overlapping runtime turns no longer mark the session `done` while another turn is still active.
 - Postgres `ArtifactStore.delete_artifact`: `cur.rowcount` accessed after execute instead of treating `AsyncCursor` as int.
 - Shell injection prevention via `shlex.quote` in K8s sandbox commands.
 - Thread-safe lazy initialization with double-check locking in sandbox backend.
 
 ### Testing
 
+- `tests/unit/api/test_message_runtime_persistence.py` — regression coverage for assistant `done` persistence data, tool-call/tool-result message projection, durable `updated_at` movement, and overlapping runtime turns staying active.
 - `tests/unit/test_a2a_adapter.py` — 35 unit tests: A2A exposed field, per-agent card generation, scope extraction, event mapping, executor agent name, filtering logic.
 - `tests/e2e/test_scenarios/p3_protocols/test_a2a.py` — 9 e2e tests: card discovery, per-agent card, 404 for unknown agents, SendMessage/SendStreamingMessage, artifact verification, capabilities.
 - `tests/unit/test_capability_registry.py` — 10 unit tests: version resolution, feature flags, middleware, scope keys, deployment info.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 | 2026-03-30 | Fix config loading to honor workspace root and resolve env templates in YAML — `load_config()` now receives workspace-aware cwd at bootstrap/API call sites and `load_yaml_file()` resolves `${VAR}` / `${VAR:-default}` placeholders before provider bootstrap and config reads. | `COGNITION_ISSUE.md` | 1/6 | Completed |
 | 2026-03-30 | Fix agent config flow gaps — wire `AgentConfig.max_tokens` into model builders, parse nested frontmatter `config:` blocks, expose full agent config through API responses/CRUD, and stop truncating `system_prompt` in agent responses. | `COGNITION_ISSUE.md` | 4/5/6 | Completed |
 | 2026-03-30 | Fix runtime streaming error surfacing so graph execution failures emit `ErrorEvent` instead of ending with an empty assistant response. | `COGNITION_ISSUE.md` | 4/6 | In Progress |
+| 2026-05-25 | Fix Deep Agents runtime activity not updating durable session state — assistant responses are streamed but not persisted, tool activity does not advance `updated_at`, tool logs show `session_id=None`, and overlapping turns can mark a session done while earlier runtime work continues. | AEP report: session `2488ce4e-13fa-47c4-95fb-d5120d89f097` | 2/4/6/7 | In Progress |
 
 ---
 

--- a/server/app/agent/middleware.py
+++ b/server/app/agent/middleware.py
@@ -356,27 +356,25 @@ class ToolSecurityMiddleware(AgentMiddleware):
         tool_name = (
             request.tool_call.get("name", "unknown") if hasattr(request, "tool_call") else "unknown"
         )
-        session_id = (
-            getattr(request.runtime.config, "configurable", {}).get("thread_id")
-            if hasattr(request, "runtime")
-            else None
-        )
+        safe_context = _safe_tool_event_context(getattr(request, "runtime", None))
+        session_id = safe_context.get("session_id")
+        run_id = safe_context.get("run_id")
 
         logger.info(
             "tool_call",
             tool=tool_name,
             session_id=session_id,
+            run_id=run_id,
         )
 
         if tool_name in self._blocked_tools:
-            logger.warning("tool_blocked", tool=tool_name, session_id=session_id)
+            logger.warning("tool_blocked", tool=tool_name, session_id=session_id, run_id=run_id)
             tool_call_id = (
                 request.tool_call.get("id")
                 if hasattr(request, "tool_call") and isinstance(request.tool_call, dict)
                 else "unknown"
             )
             message = f"Tool '{tool_name}' is disabled by server policy."
-            safe_context = _safe_tool_event_context(getattr(request, "runtime", None))
             _audit_tool_safety(
                 action="blocked",
                 tool_name=tool_name,

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -60,13 +60,42 @@ from server.app.llm.deep_agent_service import (
     ToolSafetyEvent,
     UsageEvent,
 )
-from server.app.models import SessionStatus
+from server.app.models import SessionStatus, ToolCall
 from server.app.rate_limiter import RateLimiter
 from server.app.settings import Settings
 from server.app.storage.backend import StorageBackend
 
 router = APIRouter(prefix="/sessions/{session_id}/messages", tags=["messages"])
 logger = structlog.get_logger(__name__)
+
+
+async def _refresh_session_message_count(store: StorageBackend, session_id: str) -> int:
+    """Synchronize the durable session message_count projection."""
+    messages_for_session = await store.list_messages_for_session(session_id)
+    count = len(messages_for_session)
+    await store.update_message_count(session_id, count)
+    return count
+
+
+async def _touch_session_activity(
+    store: StorageBackend,
+    session_id: str,
+    *,
+    status_value: str | None = None,
+) -> None:
+    """Advance updated_at for durable runtime activity.
+
+    AEP and other orchestrators use session.updated_at as a progress signal, so
+    streamed runtime activity must update the durable session row even when it
+    does not create a chat message.
+    """
+    if status_value is not None:
+        await store.update_session(session_id=session_id, status=status_value)
+        return
+
+    session = await store.get_session(session_id)
+    if session is not None:
+        await store.update_session(session_id=session_id, status=session.status.value)
 
 
 async def agent_event_stream(
@@ -78,6 +107,7 @@ async def agent_event_stream(
     agent_manager: SessionAgentManager,
     store: StorageBackend,
     scope: dict[str, str] | None = None,
+    parent_message_id: str | None = None,
 ) -> AsyncGenerator[dict, None]:
     """Generate agent events as SSE using DeepAgents.
 
@@ -98,6 +128,8 @@ async def agent_event_stream(
             Propagated to the agent runtime so that scope-aware
             backends (e.g. ConfigRegistrySkillsBackend) can filter
             skills, providers, and other config by tenant.
+        parent_message_id: Optional user message ID used as the parent for
+            projected assistant tool-call messages.
 
     Yields:
         SSE events as dictionaries. The final 'done' event contains
@@ -123,9 +155,10 @@ async def agent_event_stream(
         if session and session.config.system_prompt:
             system_prompt = session.config.system_prompt
 
-        # Accumulate assistant message data for persistence
-        tool_calls = []
-        _current_tool_call = None
+        # Accumulate assistant message data for persistence.
+        assistant_content_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        tool_call_message_ids: dict[str, str] = {}
         metadata: dict[str, Any] = {}
 
         # Drain sandbox lifecycle events queued during agent setup
@@ -151,6 +184,7 @@ async def agent_event_stream(
             scope=scope,
         ):
             if isinstance(event, TokenEvent):
+                assistant_content_parts.append(event.content)
                 yield EventBuilder.token(event.content)
 
             elif isinstance(event, ToolCallEvent):
@@ -160,7 +194,24 @@ async def agent_event_stream(
                     "id": event.tool_call_id,
                 }
                 tool_calls.append(tool_call)
-                _current_tool_call = event.tool_call_id
+                tool_call_message_id = str(uuid.uuid4())
+                tool_call_message_ids[event.tool_call_id] = tool_call_message_id
+                await store.create_message(
+                    message_id=tool_call_message_id,
+                    session_id=session_id,
+                    role="assistant",
+                    content=None,
+                    parent_id=parent_message_id,
+                    tool_calls=[
+                        ToolCall(
+                            name=event.name,
+                            args=event.args,
+                            id=event.tool_call_id,
+                        )
+                    ],
+                    metadata={"projection_source": "runtime_tool_call"},
+                )
+                await _refresh_session_message_count(store, session_id)
                 yield EventBuilder.tool_call(
                     name=event.name,
                     args=event.args,
@@ -168,6 +219,19 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, ToolResultEvent):
+                await store.create_message(
+                    message_id=str(uuid.uuid4()),
+                    session_id=session_id,
+                    role="tool",
+                    content=event.output,
+                    parent_id=tool_call_message_ids.get(event.tool_call_id),
+                    tool_call_id=event.tool_call_id,
+                    metadata={
+                        "exit_code": event.exit_code,
+                        "projection_source": "runtime_tool_result",
+                    },
+                )
+                await _refresh_session_message_count(store, session_id)
                 yield EventBuilder.tool_result(
                     tool_call_id=event.tool_call_id,
                     output=event.output,
@@ -175,6 +239,7 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, ToolSafetyEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.tool_safety(
                     action=event.action,
                     tool_name=event.tool_name,
@@ -189,6 +254,7 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, ContextEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.context(
                     action=event.action,
                     session_id=event.session_id,
@@ -207,9 +273,11 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, PlanningEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.planning(event.todos)
 
             elif isinstance(event, StepCompleteEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.step_complete(
                     step_number=event.step_number,
                     total_steps=event.total_steps,
@@ -237,6 +305,7 @@ async def agent_event_stream(
 
             elif isinstance(event, DelegationEvent):
                 # ISSUE-010: Emit delegation event for UI visibility
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.delegation(
                     from_agent=event.from_agent,
                     to_agent=event.to_agent,
@@ -244,6 +313,7 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, SandboxLifecycleEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.sandbox_lifecycle(
                     sandbox_id=event.sandbox_id,
                     phase=event.phase,
@@ -254,6 +324,7 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, StatusEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.status(event.status)
 
             elif isinstance(event, UsageEvent):
@@ -261,6 +332,7 @@ async def agent_event_stream(
                 metadata["output_tokens"] = event.output_tokens
                 metadata["estimated_cost"] = event.estimated_cost
                 metadata["provider"] = event.provider
+                metadata["model"] = event.model
                 yield EventBuilder.usage(
                     input_tokens=event.input_tokens,
                     output_tokens=event.output_tokens,
@@ -270,11 +342,31 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, DoneEvent):
-                await store.update_session(
-                    session_id=session_id, status=SessionStatus.DONE.value
+                active_runtime_count = agent_manager.active_runtime_count(session_id)
+                terminal_status = (
+                    SessionStatus.ACTIVE.value
+                    if active_runtime_count > 1
+                    else SessionStatus.DONE.value
                 )
-                yield EventBuilder.run_state(
-                    from_status="active", to_status=SessionStatus.DONE.value
+                await store.update_session(session_id=session_id, status=terminal_status)
+                if terminal_status == SessionStatus.DONE.value:
+                    yield EventBuilder.run_state(
+                        from_status="active",
+                        to_status=SessionStatus.DONE.value,
+                        scope_keys=scope_keys,
+                    )
+                else:
+                    yield EventBuilder.status("active")
+                assistant_content = "".join(assistant_content_parts)
+                yield EventBuilder.done(
+                    assistant_data={
+                        "content": assistant_content,
+                        "tool_calls": tool_calls or None,
+                        "token_count": metadata.get("output_tokens"),
+                        "model_used": metadata.get("model"),
+                        "metadata": metadata,
+                    },
+                    scope_keys=scope_keys,
                 )
 
             elif isinstance(event, ErrorEvent):
@@ -301,6 +393,7 @@ async def agent_event_stream(
                 yield EventBuilder.error(event.message, code=event.code)
 
             elif isinstance(event, HeartbeatEvent):
+                await _touch_session_activity(store, session_id)
                 yield EventBuilder.heartbeat(
                     step_label=event.step_label,
                     last_model_call=event.last_model_call,
@@ -310,6 +403,10 @@ async def agent_event_stream(
                 )
 
             elif isinstance(event, RunStateEvent):
+                if event.to_status:
+                    await store.update_session(session_id=session_id, status=event.to_status)
+                else:
+                    await _touch_session_activity(store, session_id)
                 yield EventBuilder.run_state(
                     from_status=event.from_status,
                     to_status=event.to_status,
@@ -362,6 +459,7 @@ async def _post_completion_callback(
     status_code=status.HTTP_200_OK,
     responses={
         404: {"model": ErrorResponse, "description": "Session not found"},
+        409: {"model": ErrorResponse, "description": "Session already has an active run"},
         500: {"model": ErrorResponse, "description": "Agent error"},
     },
 )
@@ -420,6 +518,16 @@ async def send_message(
             ),
         )
 
+    if agent_manager.active_runtime_count(session_id) > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Session '{session_id}' already has an active runtime turn. "
+                "Poll the session state or wait for the current turn to finish before "
+                "sending another message."
+            ),
+        )
+
     # Get thread_id from session for state persistence
     # The session should have a thread_id for DeepAgents checkpointing
     thread_id = getattr(session, "thread_id", None)
@@ -436,8 +544,8 @@ async def send_message(
         parent_id=request.parent_id,
     )
 
-    messages_for_session, _ = await store.get_messages_by_session(session_id, limit=-1, offset=0)
-    await store.update_message_count(session_id, len(messages_for_session))
+    await store.update_session(session_id=session_id, status=SessionStatus.ACTIVE.value)
+    await _refresh_session_message_count(store, session_id)
 
     event_stream = agent_event_stream(
         session_id,
@@ -448,6 +556,7 @@ async def send_message(
         agent_manager,
         store=store,
         scope=scope.get_all() if not scope.is_empty() else None,
+        parent_message_id=user_message.id,
     )
 
     # Wrap the event stream to persist assistant message on completion
@@ -464,44 +573,41 @@ async def send_message(
                 # ISSUE-019: Capture message_id from done event
                 message_id = event.get("data", {}).get("message_id")
                 completion_status = "done"
+                if assistant_data:
+                    try:
+                        tc_objects = None
+                        if assistant_data.get("tool_calls"):
+                            tc_objects = [
+                                ToolCall(name=tc["name"], args=tc.get("args", {}), id=tc["id"])
+                                for tc in assistant_data["tool_calls"]
+                            ]
+
+                        persist_message_id = message_id or str(uuid.uuid4())
+                        await store.create_message(
+                            message_id=persist_message_id,
+                            session_id=session_id,
+                            role="assistant",
+                            content=assistant_data.get("content"),
+                            parent_id=user_message.id,
+                            tool_calls=tc_objects,
+                            token_count=assistant_data.get("token_count"),
+                            model_used=assistant_data.get("model_used"),
+                            metadata=assistant_data.get("metadata"),
+                        )
+                        await _refresh_session_message_count(store, session_id)
+                        message_id = persist_message_id
+                        event_data = dict(event.get("data", {}))
+                        event_data["message_id"] = persist_message_id
+                        event = {**event, "data": event_data}
+                    except Exception as e:
+                        logger.error(
+                            "Failed to persist assistant message",
+                            error=str(e),
+                            session_id=session_id,
+                        )
             elif event.get("event") == "error":
                 callback_error = event.get("data")
             yield event
-
-        # Persist assistant message after stream completes
-        if assistant_data:
-            try:
-                from server.app.models import ToolCall
-
-                # Convert tool_calls dicts to ToolCall objects
-                tc_objects = None
-                if assistant_data.get("tool_calls"):
-                    tc_objects = [
-                        ToolCall(name=tc["name"], args=tc.get("args", {}), id=tc["id"])
-                        for tc in assistant_data["tool_calls"]
-                    ]
-
-                persist_message_id = message_id or str(uuid.uuid4())
-                await store.create_message(
-                    message_id=persist_message_id,
-                    session_id=session_id,
-                    role="assistant",
-                    content=assistant_data.get("content"),
-                    parent_id=user_message.id,
-                    tool_calls=tc_objects,
-                    token_count=assistant_data.get("token_count"),
-                    model_used=assistant_data.get("model_used"),
-                    metadata=assistant_data.get("metadata"),
-                )
-
-                messages_for_session, _ = await store.get_messages_by_session(
-                    session_id, limit=-1, offset=0
-                )
-                await store.update_message_count(session_id, len(messages_for_session))
-            except Exception as e:
-                logger.error(
-                    "Failed to persist assistant message", error=str(e), session_id=session_id
-                )
 
         if request.callback_url:
             callback_payload = {

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -504,7 +504,7 @@ class DeepAgentStreamingService:
 
             finally:
                 if manager:
-                    manager.unregister_runtime(session_id)
+                    manager.unregister_runtime(session_id, runtime)
 
         except LLMProviderConfigError as e:
             logger.error(
@@ -785,7 +785,7 @@ class SessionAgentManager:
         self._config_store = config_store
         self._services: dict[str, DeepAgentStreamingService] = {}
         self._project_paths: dict[str, str] = {}
-        self._active_runtimes: dict[str, Any] = {}
+        self._active_runtimes: dict[str, list[Any]] = {}
         self._sandbox_backends: dict[str, Any] = {}
         self._sandbox_events: dict[str, asyncio.Queue[SandboxLifecycleEvent]] = {}
         self._sandbox_backend_type: str = settings.sandbox_backend
@@ -830,17 +830,52 @@ class SessionAgentManager:
 
     def get_runtime(self, session_id: str) -> Any | None:
         """Get the active runtime for a session, if any."""
-        return self._active_runtimes.get(session_id)
+        runtimes = self._active_runtimes.get(session_id) or []
+        return runtimes[-1] if runtimes else None
+
+    def active_runtime_count(self, session_id: str) -> int:
+        """Return the number of active runtime turns for a session."""
+        return len(self._active_runtimes.get(session_id) or [])
 
     def register_runtime(self, session_id: str, runtime: Any) -> None:
         """Register an active runtime for abort tracking."""
-        self._active_runtimes[session_id] = runtime
-        logger.debug("Runtime registered for abort tracking", session_id=session_id)
+        runtimes = self._active_runtimes.setdefault(session_id, [])
+        runtimes.append(runtime)
+        logger.debug(
+            "Runtime registered for abort tracking",
+            session_id=session_id,
+            active_runtime_count=len(runtimes),
+        )
 
-    def unregister_runtime(self, session_id: str) -> None:
+    def unregister_runtime(self, session_id: str, runtime: Any | None = None) -> None:
         """Unregister a runtime when streaming completes."""
-        self._active_runtimes.pop(session_id, None)
-        logger.debug("Runtime unregistered", session_id=session_id)
+        runtimes = self._active_runtimes.get(session_id)
+        if not runtimes:
+            logger.debug("Runtime unregistered", session_id=session_id, active_runtime_count=0)
+            return
+
+        if runtime is None:
+            runtimes.pop()
+        else:
+            try:
+                runtimes.remove(runtime)
+            except ValueError:
+                logger.debug(
+                    "Runtime unregister skipped for non-current runtime",
+                    session_id=session_id,
+                    active_runtime_count=len(runtimes),
+                )
+                return
+
+        if runtimes:
+            logger.debug(
+                "Runtime unregistered",
+                session_id=session_id,
+                active_runtime_count=len(runtimes),
+            )
+        else:
+            self._active_runtimes.pop(session_id, None)
+            logger.debug("Runtime unregistered", session_id=session_id, active_runtime_count=0)
 
     async def abort_session(self, session_id: str, thread_id: str | None = None) -> bool:
         """Abort the current operation for a session.
@@ -848,7 +883,7 @@ class SessionAgentManager:
         Returns:
             True if abort was signaled, False if no active runtime.
         """
-        runtime = self._active_runtimes.get(session_id)
+        runtime = self.get_runtime(session_id)
         if runtime:
             success = bool(await runtime.abort(thread_id))
             logger.info("Session abort signaled", session_id=session_id, success=success)

--- a/server/app/storage/backend.py
+++ b/server/app/storage/backend.py
@@ -75,14 +75,20 @@ class SessionStore(Protocol):
         self,
         session_id: str,
         title: str | None = None,
+        status: str | None = None,
         config: SessionConfig | None = None,
+        agent_name: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> Session | None:
         """Update a session.
 
         Args:
             session_id: The session identifier.
             title: Optional new title.
+            status: Optional lifecycle status update.
             config: Optional configuration updates.
+            agent_name: Optional bound agent definition name.
+            metadata: Optional metadata replacement.
 
         Returns:
             The updated Session if found, None otherwise.

--- a/server/app/storage/memory.py
+++ b/server/app/storage/memory.py
@@ -15,7 +15,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
 
-from server.app.models import Message, Session, SessionConfig
+from server.app.models import Message, Session, SessionConfig, SessionStatus
 from server.app.storage.common import (
     filter_sessions,
     make_message,
@@ -131,6 +131,12 @@ class MemoryStorageBackend:
 
         if title is not None:
             session.title = title
+
+        if status is not None:
+            session.status = SessionStatus(status)
+
+        if agent_name is not None:
+            session.agent_name = agent_name
 
         if config is not None:
             session.config = merge_session_config(session.config, config)

--- a/tests/unit/api/test_message_runtime_persistence.py
+++ b/tests/unit/api/test_message_runtime_persistence.py
@@ -1,0 +1,191 @@
+"""Regression tests for durable session progress during runtime activity."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from server.app.agent.runtime import DoneEvent, TokenEvent, ToolCallEvent, ToolResultEvent
+from server.app.api.models import MessageCreate
+from server.app.api.routes.messages import agent_event_stream, send_message
+from server.app.api.scoping import SessionScope
+from server.app.models import SessionConfig, SessionStatus
+from server.app.rate_limiter import RateLimitConfig, RateLimiter
+from server.app.settings import Settings
+from server.app.storage.memory import MemoryStorageBackend
+
+
+class _FakeService:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+
+    async def stream_response(self, **_kwargs: Any) -> AsyncGenerator[Any, None]:
+        for event in self._events:
+            yield event
+
+
+class _FakeAgentManager:
+    def __init__(self, service: _FakeService, active_runtime_count: int = 1) -> None:
+        self._service = service
+        self._active_runtime_count = active_runtime_count
+
+    def get_service(self, _session_id: str) -> _FakeService:
+        return self._service
+
+    def register_session(self, _session_id: str, _workspace_path: str) -> _FakeService:
+        return self._service
+
+    def drain_sandbox_events(self, _session_id: str) -> list[Any]:
+        return []
+
+    def active_runtime_count(self, _session_id: str) -> int:
+        return self._active_runtime_count
+
+
+def _settings() -> Settings:
+    settings = MagicMock(spec=Settings)
+    settings.scoping_enabled = False
+    return cast(Settings, settings)
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_done_includes_assistant_data(tmp_path) -> None:
+    store = MemoryStorageBackend(workspace_path=str(tmp_path))
+    session = await store.create_session(
+        session_id="session-runtime-assistant",
+        thread_id="thread-runtime-assistant",
+        config=SessionConfig(),
+    )
+    manager = _FakeAgentManager(
+        _FakeService(
+            [
+                TokenEvent(content="Actively working."),
+                DoneEvent(),
+            ]
+        )
+    )
+
+    events = [
+        event
+        async for event in agent_event_stream(
+            session.id,
+            session.thread_id,
+            "status?",
+            session.workspace_path,
+            _settings(),
+            manager,  # type: ignore[arg-type]
+            store,
+        )
+    ]
+
+    done = next(event for event in events if event["event"] == "done")
+    assert done["data"]["assistant_data"]["content"] == "Actively working."
+
+    updated = await store.get_session(session.id)
+    assert updated is not None
+    assert updated.status == SessionStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_tool_activity_updates_session_and_message_projection(tmp_path) -> None:
+    store = MemoryStorageBackend(workspace_path=str(tmp_path))
+    session = await store.create_session(
+        session_id="session-runtime-tools",
+        thread_id="thread-runtime-tools",
+        config=SessionConfig(),
+    )
+    original_updated_at = session.updated_at
+    manager = _FakeAgentManager(
+        _FakeService(
+            [
+                ToolCallEvent(name="execute", args={"cmd": "pytest"}, tool_call_id="call-1"),
+                ToolResultEvent(tool_call_id="call-1", output="passed", exit_code=0),
+                DoneEvent(),
+            ]
+        )
+    )
+
+    _ = [
+        event
+        async for event in agent_event_stream(
+            session.id,
+            session.thread_id,
+            "run tests",
+            session.workspace_path,
+            _settings(),
+            manager,  # type: ignore[arg-type]
+            store,
+        )
+    ]
+
+    messages = await store.list_messages_for_session(session.id)
+    assert [message.role for message in messages] == ["assistant", "tool"]
+    assert messages[0].tool_calls is not None
+    assert messages[0].tool_calls[0].name == "execute"
+    assert messages[1].tool_call_id == "call-1"
+
+    updated = await store.get_session(session.id)
+    assert updated is not None
+    assert updated.message_count == 2
+    assert updated.updated_at > original_updated_at
+
+
+@pytest.mark.asyncio
+async def test_done_does_not_mark_session_done_when_other_runtime_active(tmp_path) -> None:
+    store = MemoryStorageBackend(workspace_path=str(tmp_path))
+    session = await store.create_session(
+        session_id="session-overlap",
+        thread_id="thread-overlap",
+        config=SessionConfig(),
+    )
+    manager = _FakeAgentManager(_FakeService([DoneEvent()]), active_runtime_count=2)
+
+    _ = [
+        event
+        async for event in agent_event_stream(
+            session.id,
+            session.thread_id,
+            "ping",
+            session.workspace_path,
+            _settings(),
+            manager,  # type: ignore[arg-type]
+            store,
+        )
+    ]
+
+    updated = await store.get_session(session.id)
+    assert updated is not None
+    assert updated.status == SessionStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_concurrent_runtime_turn(tmp_path) -> None:
+    store = MemoryStorageBackend(workspace_path=str(tmp_path))
+    session = await store.create_session(
+        session_id="session-active-turn",
+        thread_id="thread-active-turn",
+        config=SessionConfig(),
+    )
+    manager = _FakeAgentManager(_FakeService([]), active_runtime_count=1)
+    rate_limiter = RateLimiter(RateLimitConfig(requests_per_minute=1000, burst_size=1000))
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            session.id,
+            MessageCreate(content="status?", parent_id=None, model=None),
+            http_request=cast(Any, SimpleNamespace(client=SimpleNamespace(host="test"))),
+            settings=_settings(),
+            agent_manager=manager,  # type: ignore[arg-type]
+            store=store,
+            rate_limiter=rate_limiter,
+            scope=SessionScope({}),
+        )
+
+    assert exc.value.status_code == 409
+    messages = await store.list_messages_for_session(session.id)
+    assert messages == []


### PR DESCRIPTION
## Summary
- Persist assistant responses from streamed done events before yielding the terminal SSE event
- Project runtime tool calls/results into durable session messages and refresh session message_count/updated_at
- Touch session updated_at on streamed runtime activity signals so orchestrators can detect progress
- Include trusted session_id/run_id in tool_call logs instead of session_id=None
- Track active runtime turns as a stack and reject concurrent POST /messages with 409 while a run is active
- Update ROADMAP/CHANGELOG for the AEP-reported v0.10 persistence bug

## Live investigation
Observed in autonomous-engineering on cognition image 0.10.0-rc1 for session 2488ce4e-13fa-47c4-95fb-d5120d89f097:
- Initial POST returned 200 immediately, then tool activity continued until 03:24:04
- Session API stayed at message_count=1 while tools executed
- Messages endpoint contained only user messages
- Tool logs emitted session_id=None
- A follow-up status POST overlapped the original runtime and marked the session done before the original turn finished

## Validation
- uv run ruff check server/app/api/routes/messages.py server/app/llm/deep_agent_service.py server/app/storage/backend.py server/app/storage/memory.py server/app/agent/middleware.py tests/unit/api/test_message_runtime_persistence.py CHANGELOG.md ROADMAP.md
- uv run mypy server/app/api/routes/messages.py server/app/agent/middleware.py server/app/llm/deep_agent_service.py server/app/storage/backend.py server/app/storage/memory.py tests/unit/api/test_message_runtime_persistence.py
- uv run pytest tests/unit/api/test_message_runtime_persistence.py tests/unit/test_rest_api.py tests/unit/test_streaming_bugs.py tests/unit/test_runtime_streaming.py tests/unit/test_abort.py -q
- uv run pytest tests/unit/test_tool_safety_middleware.py tests/unit/api/test_message_runtime_persistence.py -q
- git diff --check

## Note
- Full uv run pytest tests/unit -q is blocked in this local environment by missing optional langchain_aws; unrelated Bedrock tests fail before reaching this change.
