### PR TITLE
Release v0.10.1 HITL policy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.10.1] — 2026-05-25
+
+### Fixed
+
+- Preserved explicit empty agent `interrupt_on={}` policies so builder agents can opt out of HITL approvals instead of inheriting global defaults for runtime-injected sandbox tools such as `execute`.
+
+---
+
 ## [0.10.0] — 2026-05-25
 
 ### Highlights

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -130,10 +130,6 @@ async def create_agent(
             "async_subagents": [
                 spec.model_dump(exclude_none=True) for spec in body.async_subagents
             ],
-            "interrupt_on": {
-                name: config.model_dump(exclude_none=True)
-                for name, config in body.interrupt_on.items()
-            },
             "permissions": [p.model_dump() for p in body.permissions],
             "response_format": body.response_format,
             "middleware": body.middleware,
@@ -152,6 +148,11 @@ async def create_agent(
                 "timeout_seconds": body.timeout_seconds,
             },
         }
+        if "interrupt_on" in body.model_fields_set:
+            definition_data["interrupt_on"] = {
+                name: config.model_dump(exclude_none=True)
+                for name, config in body.interrupt_on.items()
+            }
         effective_scope = scope.get_all() or body.scope
         await config_store.upsert_agent(body.name, effective_scope, definition_data, "api")
 

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -182,6 +182,13 @@ class StreamAccumulator:
         return self._current_tool_call is not None
 
 
+def _has_explicit_agent_field(agent_def: Any, field_name: str) -> bool:
+    fields_set = getattr(agent_def, "model_fields_set", None)
+    if isinstance(fields_set, set):
+        return field_name in fields_set
+    return hasattr(agent_def, field_name)
+
+
 class DeepAgentStreamingService:
     """Streaming service using DeepAgents for multi-step completion.
 
@@ -281,7 +288,7 @@ class DeepAgentStreamingService:
         if agent_def.memory:
             resolved.memory = list(agent_def.memory)
 
-        if agent_def.interrupt_on:
+        if _has_explicit_agent_field(agent_def, "interrupt_on"):
             resolved.interrupt_on = {
                 name: config.model_dump(exclude_none=True)
                 if hasattr(config, "model_dump")

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 
 __all__ = ["VERSION"]

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -260,8 +260,8 @@ class TestInterruptOnWiring:
         }
 
     @pytest.mark.asyncio
-    async def test_empty_interrupt_on_not_passed(self):
-        """Empty interrupt_on → interrupt_on=None passed."""
+    async def test_empty_interrupt_on_is_preserved(self):
+        """Explicit empty interrupt_on disables inherited HITL defaults."""
         from server.app.agent.definition import AgentDefinition
 
         session = _make_session()
@@ -269,6 +269,26 @@ class TestInterruptOnWiring:
         patches = _base_patches(mock_runtime, session)
 
         agent_def = AgentDefinition(name="test-agent", system_prompt="test", interrupt_on={})
+        mock_def_registry = MagicMock()
+        mock_def_registry.get = MagicMock(return_value=agent_def)
+        mock_def_registry.subagents = MagicMock(return_value=[])
+
+        _, create_agent_mock = await _run(patches, session, mock_def_registry=mock_def_registry)
+
+        params = _get_params(create_agent_mock)
+        assert params is not None
+        assert params.interrupt_on == {}
+
+    @pytest.mark.asyncio
+    async def test_omitted_interrupt_on_not_passed(self):
+        """Omitted interrupt_on remains None so global defaults can apply."""
+        from server.app.agent.definition import AgentDefinition
+
+        session = _make_session()
+        mock_runtime = _make_mock_runtime(DoneEvent())
+        patches = _base_patches(mock_runtime, session)
+
+        agent_def = AgentDefinition(name="test-agent", system_prompt="test")
         mock_def_registry = MagicMock()
         mock_def_registry.get = MagicMock(return_value=agent_def)
         mock_def_registry.subagents = MagicMock(return_value=[])

--- a/tests/unit/test_pluggability.py
+++ b/tests/unit/test_pluggability.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -8,6 +9,19 @@ from server.app.agent.cognition_agent import (
     create_cognition_agent,
 )
 from server.app.agent.definition import AsyncSubagentConfig, ContextPolicy
+from server.app.storage.config_models import GlobalAgentDefaults
+
+
+class _DefaultsOnlyConfigStore:
+    config_registry = None
+
+    def __init__(self, defaults: GlobalAgentDefaults) -> None:
+        self._defaults = defaults
+
+    async def get_global_agent_defaults(
+        self, scope: dict[str, str] | None = None
+    ) -> GlobalAgentDefaults:
+        return self._defaults
 
 
 @pytest.mark.asyncio
@@ -189,6 +203,57 @@ async def test_rich_interrupt_on_changes_agent_cache_key():
         )
 
         assert mock_create.call_count == 2
+    clear_agent_cache()
+
+
+@pytest.mark.asyncio
+async def test_empty_interrupt_on_overrides_global_defaults():
+    """Explicit interrupt_on={} should not inherit default approvals."""
+    clear_agent_cache()
+    defaults = GlobalAgentDefaults(
+        interrupt_on={"execute": {"allowed_decisions": ["approve", "reject"]}}
+    )
+    with patch("server.app.agent.cognition_agent.create_deep_agent") as mock_create:
+        mock_create.return_value = AsyncMock()
+
+        await create_cognition_agent(
+            CognitionAgentParams(
+                project_path=".",
+                model="mock:model",
+                system_prompt="test",
+                interrupt_on={},
+                config_store=cast(Any, _DefaultsOnlyConfigStore(defaults)),
+            )
+        )
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["interrupt_on"] == {}
+    clear_agent_cache()
+
+
+@pytest.mark.asyncio
+async def test_omitted_interrupt_on_inherits_global_defaults():
+    """Absent interrupt_on should continue to inherit default approvals."""
+    clear_agent_cache()
+    defaults = GlobalAgentDefaults(
+        interrupt_on={"execute": {"allowed_decisions": ["approve", "reject"]}}
+    )
+    with patch("server.app.agent.cognition_agent.create_deep_agent") as mock_create:
+        mock_create.return_value = AsyncMock()
+
+        await create_cognition_agent(
+            CognitionAgentParams(
+                project_path=".",
+                model="mock:model",
+                system_prompt="test",
+                config_store=cast(Any, _DefaultsOnlyConfigStore(defaults)),
+            )
+        )
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["interrupt_on"] == {
+            "execute": {"allowed_decisions": ["approve", "reject"]}
+        }
     clear_agent_cache()
 
 


### PR DESCRIPTION
## Summary

- Fixes explicit empty agent `interrupt_on={}` being treated as unset during Deep Agents runtime config resolution.
- Preserves omitted `interrupt_on` behavior so agents without an override still inherit global HITL defaults.
- Preserves API-created agents' omitted-vs-explicit-empty `interrupt_on` distinction.
- Bumps server version and adds v0.10.1 changelog notes.

## Release notes

Fixes explicit empty agent `interrupt_on={}` being ignored, which could cause sandbox tools to inherit global HITL approval policy.

## Validation

- `uv run pytest tests/unit/test_agent_def_field_wiring.py -v` — 20 passed
- `uv run pytest tests/unit/test_pluggability.py tests/unit/test_pluggability_integration.py -v` — 14 passed
- `uv run pytest tests/unit -v` — 741 passed, 4 skipped
- `uv run mypy .` — passed
- `uv run ruff check .` — passed
- `git diff --check` — passed

## Release candidate images

Pre-release image workflow passed from exact release branch commit `6869d6e8241f828053dbdd6fe14666a68794c61c`:

https://github.com/CognicellAI/Cognition/actions/runs/26426853815

Images:

- `ghcr.io/cognicellai/cognition:0.10.1-rc1`
- `ghcr.io/cognicellai/cognition-sandbox:0.10.1-rc1`
