### PR TITLE
Release v0.10.3 A2A conformance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.10.3] — 2026-05-28
+
+### Fixed
+
+- Updated the A2A protocol surface to expose current JSON-RPC method names (`message/send`, `message/stream`), per-agent Agent Card discovery at `/a2a/{agent_name}/.well-known/agent-card.json`, current task/event response shapes, and default handling for omitted `A2A-Version` headers.
+- Fixed scoped dynamic agent lookup for A2A route resolution so same-named agents in different request scopes resolve to the correct scoped definition.
+
+---
+
 ## [0.10.2] — 2026-05-27
 
 ### Security

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 | 2026-03-30 | Fix runtime streaming error surfacing so graph execution failures emit `ErrorEvent` instead of ending with an empty assistant response. | `COGNITION_ISSUE.md` | 4/6 | In Progress |
 | 2026-05-25 | Fix Deep Agents runtime activity not updating durable session state — assistant responses are streamed but not persisted, tool activity does not advance `updated_at`, tool logs show `session_id=None`, and overlapping turns can mark a session done while earlier runtime work continues. | AEP report: session `2488ce4e-13fa-47c4-95fb-d5120d89f097`; hotfix merged as PR #131 | 2/4/6/7 | Completed |
 | 2026-05-25 | Fix K8s sandbox filesystem API compatibility and terminal run contradictions — K8s wrapper now uses Deep Agents' current `ls`/`glob`/`grep` result APIs, and runtime errors suppress later `done` events/callback success. | AEP runtime report: `RUNTIME_ERROR` with "new `ls` API" followed by `run.done` | 3/4/6/7 | Completed |
+| 2026-05-28 | Align A2A protocol surface with current JSON-RPC method names and task/event wire shapes; add per-agent Agent Card discovery under `/a2a/{agent_name}/.well-known/agent-card.json`; ensure scoped dynamic agent route lookup respects request scope. | A2A interoperability report for Cognition 0.10.2 | 2/6 | Completed |
 
 ---
 

--- a/docs/concepts/agent-runtime.md
+++ b/docs/concepts/agent-runtime.md
@@ -137,7 +137,8 @@ class AgentDefinition(BaseModel):
 
 The `a2a_exposed` field controls whether an agent is exposed via the [A2A (Agent-to-Agent)](https://google.github.io/A2A/) protocol. When `True`:
 
-- The agent appears in `GET /.well-known/agent-card.json` (scope-filtered)
+- The agent has an Agent Card at `GET /a2a/{agent_name}/.well-known/agent-card.json`
+- The agent appears in `GET /.well-known/agent-card.json` (scope-filtered list)
 - The agent gets a dedicated JSON-RPC endpoint at `POST /a2a/{agent_name}`
 - External A2A clients can discover and invoke the agent
 
@@ -164,7 +165,8 @@ curl -X POST http://localhost:8000/agents \
 
 The `a2a_exposed` field controls whether an agent is exposed via the [A2A (Agent-to-Agent)](https://google.github.io/A2A/) protocol. When `True`:
 
-- The agent appears in `GET /.well-known/agent-card.json` (scope-filtered)
+- The agent has an Agent Card at `GET /a2a/{agent_name}/.well-known/agent-card.json`
+- The agent appears in `GET /.well-known/agent-card.json` (scope-filtered list)
 - The agent gets a dedicated JSON-RPC endpoint at `POST /a2a/{agent_name}`
 - External A2A clients can discover and invoke the agent
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -165,7 +165,7 @@ Additional MCP security measures:
 
 The A2A (Agent-to-Agent) protocol adapter is a Cognition protocol surface, not an app-layer concern.
 
-**Security boundary**: A2A requests must include `X-Cognition-Scope-*` headers. Agent card discovery and JSON-RPC endpoints are both scope-filtered — only agents visible in the caller's scope are discoverable and invocable.
+**Security boundary**: A2A requests must include `X-Cognition-Scope-*` headers. Per-agent card discovery at `/a2a/{agent_name}/.well-known/agent-card.json`, root discovery, and JSON-RPC endpoints are scope-filtered — only agents visible in the caller's scope are discoverable and invocable. Dynamically registered agents remain bound to the scope used at creation time, so callers must provide the same trusted scope headers for discovery and invocation.
 
 **Builder responsibility**: Cognition does not perform end-user authentication on A2A requests. Authorization must be handled at the gateway/proxy layer before requests reach Cognition. The `a2a_exposed` flag on `AgentDefinition` controls which agents are visible — set it explicitly to `True` only for agents intended for external A2A access.
 

--- a/docs/guides/extending-agents.md
+++ b/docs/guides/extending-agents.md
@@ -493,7 +493,7 @@ curl -X POST http://localhost:8000/agents \
 
 ### How It Works
 
-1. **Agent card discovery** — `GET /.well-known/agent-card.json` returns A2A `AgentCard` objects for all agents with `a2a_exposed=True`, filtered by the caller's scope.
+1. **Agent card discovery** — `GET /a2a/{agent_name}/.well-known/agent-card.json` returns the A2A `AgentCard` for that agent. `GET /.well-known/agent-card.json` also lists exposed agents visible to the caller's scope.
 2. **JSON-RPC endpoint** — Each agent gets a dedicated endpoint at `POST /a2a/{agent_name}`. The agent is resolved at request time, so agents created after server startup are immediately available.
 3. **Scope-aware** — A2A requests must include `X-Cognition-Scope-*` headers. Only agents visible in the caller's scope are discoverable and invocable.
 4. **Bridging** — The `CognitionA2AExecutor` bridges A2A requests to Cognition's `service.stream_response()`, reusing the full agent runtime, tools, middleware, and persistence.
@@ -503,12 +503,12 @@ curl -X POST http://localhost:8000/agents \
 ```python
 import httpx
 
-# Discover agents
+# Discover a specific agent card from the agent's canonical A2A URL
 resp = httpx.get(
-    "http://localhost:8000/.well-known/agent-card.json",
+    "http://localhost:8000/a2a/deploy-agent/.well-known/agent-card.json",
     headers={"X-Cognition-Scope-User": "alice"},
 )
-cards = resp.json()["cards"]
+card = resp.json()
 
 # Send a message to an agent
 resp = httpx.post(
@@ -516,16 +516,15 @@ resp = httpx.post(
     json={
         "jsonrpc": "2.0",
         "id": "1",
-        "method": "SendMessage",
+        "method": "message/send",
         "params": {
             "message": {
                 "role": "user",
-                "parts": [{"type": "text", "text": "Deploy staging"}],
+                "parts": [{"kind": "text", "text": "Deploy staging"}],
             }
         },
     },
     headers={
-        "A2A-Version": "1.0",
         "X-Cognition-Scope-User": "alice",
     },
 )
@@ -535,7 +534,8 @@ resp = httpx.post(
 
 - Built-in agents (`default`, `readonly`) have `a2a_exposed=False` by default
 - Only `primary` and `all` mode agents can be exposed via A2A
-- The `A2A-Version: 1.0` header is required (without it, the SDK defaults to v0.3 which is unsupported)
+- If `A2A-Version` is omitted, Cognition treats the request as the current supported A2A version
+- Dynamically registered agents are scope-bound. Use the same `X-Cognition-Scope-*` headers when creating, discovering, and invoking an agent.
 - A2A does not add any additional services — endpoints are part of the main Cognition server
 
 For full A2A protocol details, see the [A2A SDK documentation](https://github.com/a2aproject/a2a-python).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     # MCP (Model Context Protocol) - Remote-only support via langchain-mcp-adapters
     "langchain-mcp-adapters>=0.2.0",
     # A2A (Agent-to-Agent Protocol) - Inbound server adapter
-    "a2a-sdk>=1.0.0",
+    "a2a-sdk>=1.0.3",
 ]
 
 [project.optional-dependencies]

--- a/server/app/protocols/a2a/executor.py
+++ b/server/app/protocols/a2a/executor.py
@@ -81,8 +81,8 @@ class CognitionA2AExecutor(AgentExecutor):
 
         # 2. Resolve scope from request metadata/context
         scope: dict[str, str] | None = None
-        if context.call_context and hasattr(context.call_context, "headers"):
-            headers = context.call_context.headers or {}
+        if context.call_context:
+            headers = context.call_context.state.get("headers", {})
             scope_keys = self._settings.scope_keys
             if scope_keys:
                 scope = {}

--- a/server/app/protocols/a2a/mapping.py
+++ b/server/app/protocols/a2a/mapping.py
@@ -66,7 +66,9 @@ def extract_text_from_parts(parts: Any) -> str:
     """Extract text content from A2A Message parts."""
     texts: list[str] = []
     for part in parts:
-        if hasattr(part, "text") and part.text:
+        if isinstance(part, dict) and part.get("text"):
+            texts.append(str(part["text"]))
+        elif hasattr(part, "text") and part.text:
             texts.append(part.text)
     return "\n".join(texts) if texts else ""
 

--- a/server/app/protocols/a2a/routes.py
+++ b/server/app/protocols/a2a/routes.py
@@ -8,12 +8,15 @@ using scope-aware ConfigRegistry lookups.
 Endpoints:
   GET  /.well-known/agent-card.json?assistant_id={name}  ->  agent card
   GET  /.well-known/agent-card.json                      ->  available agents list
+  GET  /a2a/{agent_name}/.well-known/agent-card.json      ->  agent card
   POST /a2a/{agent_name}                                 ->  JSON-RPC A2A methods
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from a2a.server.request_handlers import DefaultRequestHandler
@@ -21,12 +24,20 @@ from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from a2a.server.tasks import InMemoryTaskStore
 from fastapi import FastAPI
 from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
+from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from server.app.protocols.a2a.card import build_agent_card_for_agent
 from server.app.protocols.a2a.executor import CognitionA2AExecutor
+from server.app.protocols.a2a.wire import (
+    CURRENT_A2A_VERSION,
+    is_public_a2a_method,
+    normalize_request_for_sdk,
+    normalize_response_to_public,
+    normalize_stream_item_to_public,
+)
 
 if TYPE_CHECKING:
     from server.app.llm.deep_agent_service import SessionAgentManager
@@ -35,6 +46,9 @@ if TYPE_CHECKING:
     from server.app.storage.config_store import ConfigStore
 
 logger = structlog.get_logger(__name__)
+
+
+_JSONRPC_METHOD_NOT_FOUND = -32601
 
 
 def _extract_scope(
@@ -51,6 +65,113 @@ def _extract_scope(
         if val:
             scope[key] = val
     return scope or None
+
+
+def _request_base_url(request: Request) -> str:
+    """Return the externally visible request base URL without a trailing slash."""
+    return str(request.base_url).rstrip("/")
+
+
+def _jsonrpc_error_response(
+    request_id: str | int | None,
+    code: int,
+    message: str,
+) -> JSONResponse:
+    """Return a JSON-RPC error response with HTTP 200 transport semantics."""
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": code,
+                "message": message,
+            },
+        },
+        status_code=200,
+    )
+
+
+def _response_headers(response: Response) -> dict[str, str]:
+    """Copy response headers that remain valid after body transformation."""
+    headers = dict(response.headers)
+    headers.pop("content-length", None)
+    return headers
+
+
+async def _request_for_sdk(request: Request, payload: dict[str, object]) -> Request:
+    """Build a Starlette request for the SDK dispatcher with normalized JSON."""
+    body = json.dumps(normalize_request_for_sdk(payload)).encode("utf-8")
+    scope = dict(request.scope)
+    raw_headers = [
+        (key, value)
+        for key, value in request.scope.get("headers", [])
+        if key.lower() not in {b"a2a-version", b"content-length"}
+    ]
+    raw_headers.extend(
+        [
+            (b"a2a-version", CURRENT_A2A_VERSION.encode("ascii")),
+            (b"content-length", str(len(body)).encode("ascii")),
+        ]
+    )
+    scope["headers"] = raw_headers
+
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+async def _normalize_dispatcher_response(response: Response) -> Response:
+    """Normalize SDK response JSON/SSE data to Cognition's public A2A shape."""
+    if isinstance(response, EventSourceResponse):
+        stream = response.body_iterator
+
+        async def event_generator() -> AsyncGenerator[Any, None]:
+            async for item in stream:
+                if isinstance(item, dict):
+                    data = item.get("data")
+                    if isinstance(data, str):
+                        try:
+                            parsed = json.loads(data)
+                        except json.JSONDecodeError:
+                            yield item
+                            continue
+                        next_item = dict(item)
+                        next_item["data"] = json.dumps(
+                            normalize_stream_item_to_public(parsed)
+                        )
+                        yield next_item
+                    else:
+                        yield normalize_stream_item_to_public(item)
+                else:
+                    yield item
+
+        return EventSourceResponse(
+            event_generator(),
+            status_code=response.status_code,
+            headers=_response_headers(response),
+        )
+
+    body = getattr(response, "body", b"")
+    if not body:
+        return response
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return response
+    if not isinstance(payload, dict):
+        return response
+    return JSONResponse(
+        normalize_response_to_public(payload),
+        status_code=response.status_code,
+        headers=_response_headers(response),
+    )
 
 
 async def mount_a2a_routes(
@@ -70,7 +191,6 @@ async def mount_a2a_routes(
     Both resolve agents at request time. No restart needed when agents
     are created or have a2a_exposed toggled.
     """
-    base_url = f"http://{settings.host}:{settings.port}"
     scope_keys = list(settings.scope_keys)
 
     # --- Scope-aware card discovery route ---
@@ -100,7 +220,26 @@ async def mount_a2a_routes(
                 status_code=404,
             )
 
-        card = build_agent_card_for_agent(agent, base_url, version)
+        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
+        return JSONResponse(MessageToDict(card))
+
+    async def per_agent_card_handler(request: Request) -> JSONResponse:
+        """GET /a2a/{agent_name}/.well-known/agent-card.json."""
+        agent_name = request.path_params.get("agent_name", "")
+        scope = _extract_scope(dict(request.headers), scope_keys)
+        agent = await config_store.get_agent_definition(agent_name, scope=scope or None)
+        if (
+            agent is None
+            or not agent.a2a_exposed
+            or agent.mode == "subagent"
+            or agent.hidden
+        ):
+            return JSONResponse(
+                {"error": "Agent not found"},
+                status_code=404,
+            )
+
+        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
         return JSONResponse(MessageToDict(card))
 
     # --- Catch-all JSON-RPC endpoint ---
@@ -124,6 +263,24 @@ async def mount_a2a_routes(
                 status_code=404,
             )
 
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            return _jsonrpc_error_response(None, -32700, "Parse error")
+        if not isinstance(payload, dict):
+            return _jsonrpc_error_response(None, -32600, "Invalid request")
+
+        request_id = payload.get("id")
+        if not isinstance(request_id, str | int | None):
+            request_id = None
+        method = payload.get("method")
+        if not is_public_a2a_method(method if isinstance(method, str) else None):
+            return _jsonrpc_error_response(
+                request_id,
+                _JSONRPC_METHOD_NOT_FOUND,
+                "Method not found",
+            )
+
         # Build executor and handler per-request
         executor = CognitionA2AExecutor(
             settings=settings,
@@ -131,19 +288,28 @@ async def mount_a2a_routes(
             store=store,
             agent_name=agent.name,
         )
-        card = build_agent_card_for_agent(agent, base_url, version)
+        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
         handler = DefaultRequestHandler(
             agent_executor=executor,
             task_store=InMemoryTaskStore(),
             agent_card=card,
         )
         dispatcher = JsonRpcDispatcher(request_handler=handler)
-        return await dispatcher.handle_requests(request)
+        sdk_request = await _request_for_sdk(request, payload)
+        sdk_response = await dispatcher.handle_requests(sdk_request)
+        return await _normalize_dispatcher_response(sdk_response)
 
     app.routes.append(
         Route(
             path="/.well-known/agent-card.json",
             endpoint=agent_card_handler,
+            methods=["GET"],
+        )
+    )
+    app.routes.append(
+        Route(
+            path="/a2a/{agent_name}/.well-known/agent-card.json",
+            endpoint=per_agent_card_handler,
             methods=["GET"],
         )
     )
@@ -158,6 +324,7 @@ async def mount_a2a_routes(
     logger.info(
         "A2A adapter mounted",
         card_endpoint="/.well-known/agent-card.json",
+        per_agent_card_endpoint="/a2a/{agent_name}/.well-known/agent-card.json",
         rpc_endpoint="/a2a/{agent_name}",
         mode="dynamic-dispatch",
     )

--- a/server/app/protocols/a2a/wire.py
+++ b/server/app/protocols/a2a/wire.py
@@ -1,0 +1,218 @@
+"""A2A JSON-RPC wire-shape helpers.
+
+The installed Python SDK still exposes a protobuf-oriented JSON-RPC dispatcher
+whose method names and enum values differ from the public A2A JSON binding.
+Cognition keeps those details private and exposes the current A2A shape at the
+HTTP boundary.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+CURRENT_A2A_VERSION = "1.0"
+
+_PUBLIC_TO_SDK_METHOD = {
+    "message/send": "SendMessage",
+    "message/stream": "SendStreamingMessage",
+}
+
+_STATE_TO_CURRENT = {
+    "TASK_STATE_SUBMITTED": "submitted",
+    "TASK_STATE_WORKING": "working",
+    "TASK_STATE_INPUT_REQUIRED": "input-required",
+    "TASK_STATE_COMPLETED": "completed",
+    "TASK_STATE_CANCELED": "canceled",
+    "TASK_STATE_FAILED": "failed",
+    "TASK_STATE_REJECTED": "rejected",
+    "TASK_STATE_AUTH_REQUIRED": "auth-required",
+    1: "submitted",
+    2: "working",
+    3: "completed",
+    4: "canceled",
+    5: "failed",
+    6: "rejected",
+    7: "input-required",
+    8: "auth-required",
+}
+
+_ROLE_TO_SDK = {
+    "user": "ROLE_USER",
+    "agent": "ROLE_AGENT",
+    "assistant": "ROLE_AGENT",
+}
+
+_ROLE_TO_CURRENT = {
+    "ROLE_USER": "user",
+    "ROLE_AGENT": "agent",
+}
+
+
+def is_public_a2a_method(method: str | None) -> bool:
+    """Return true when the JSON-RPC method is part of Cognition's public A2A API."""
+    return method in _PUBLIC_TO_SDK_METHOD
+
+
+def normalize_request_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate a public A2A JSON-RPC request into the SDK's internal shape."""
+    normalized = deepcopy(payload)
+    method = normalized.get("method")
+    if method in _PUBLIC_TO_SDK_METHOD:
+        normalized["method"] = _PUBLIC_TO_SDK_METHOD[method]
+
+    params = normalized.get("params")
+    if not isinstance(params, dict):
+        return normalized
+
+    message = params.get("message")
+    if not isinstance(message, dict):
+        return normalized
+
+    role = message.get("role")
+    if isinstance(role, str):
+        message["role"] = _ROLE_TO_SDK.get(role.lower(), role)
+
+    parts = message.get("parts")
+    if isinstance(parts, list):
+        message["parts"] = [_normalize_part_for_sdk(part) for part in parts]
+
+    return normalized
+
+
+def normalize_response_to_public(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate SDK JSON-RPC response data into the current public A2A shape."""
+    normalized = deepcopy(payload)
+    result = normalized.get("result")
+    if isinstance(result, dict):
+        normalized["result"] = _normalize_result_to_public(result)
+    return normalized
+
+
+def normalize_stream_item_to_public(item: dict[str, Any]) -> dict[str, Any]:
+    """Translate one SDK SSE JSON-RPC item into the current public A2A shape."""
+    return normalize_response_to_public(item)
+
+
+def _normalize_part_for_sdk(part: Any) -> Any:
+    if not isinstance(part, dict):
+        return part
+
+    if part.get("kind") == "text" and "text" in part:
+        normalized = {k: v for k, v in part.items() if k != "kind"}
+        normalized.setdefault("mediaType", "text/plain")
+        return normalized
+
+    return part
+
+
+def _normalize_result_to_public(result: dict[str, Any]) -> dict[str, Any]:
+    if "task" in result and isinstance(result["task"], dict):
+        return _normalize_task_to_public(result["task"])
+    if "message" in result and isinstance(result["message"], dict):
+        return _normalize_message_to_public(result["message"])
+    if _looks_like_status_update(result):
+        return _normalize_status_update_to_public(result)
+    if _looks_like_artifact_update(result):
+        return _normalize_artifact_update_to_public(result)
+    if _looks_like_task(result):
+        return _normalize_task_to_public(result)
+    return result
+
+
+def _normalize_task_to_public(task: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(task)
+    normalized["kind"] = "task"
+    status = normalized.get("status")
+    if isinstance(status, dict):
+        normalized["status"] = _normalize_status_to_public(status)
+    artifacts = normalized.get("artifacts")
+    if isinstance(artifacts, list):
+        normalized["artifacts"] = [
+            _normalize_artifact_to_public(artifact) for artifact in artifacts
+        ]
+    history = normalized.get("history")
+    if isinstance(history, list):
+        normalized["history"] = [
+            _normalize_message_to_public(message) for message in history
+        ]
+    return normalized
+
+
+def _normalize_message_to_public(message: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(message)
+    normalized["kind"] = "message"
+    role = normalized.get("role")
+    if isinstance(role, str):
+        normalized["role"] = _ROLE_TO_CURRENT.get(role, role.lower())
+    parts = normalized.get("parts")
+    if isinstance(parts, list):
+        normalized["parts"] = [_normalize_part_to_public(part) for part in parts]
+    return normalized
+
+
+def _normalize_status_update_to_public(update: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(update)
+    normalized["kind"] = "status-update"
+    status = normalized.get("status")
+    if isinstance(status, dict):
+        normalized["status"] = _normalize_status_to_public(status)
+    return normalized
+
+
+def _normalize_artifact_update_to_public(update: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(update)
+    normalized["kind"] = "artifact-update"
+    artifact = normalized.get("artifact")
+    if isinstance(artifact, dict):
+        normalized["artifact"] = _normalize_artifact_to_public(artifact)
+    return normalized
+
+
+def _normalize_status_to_public(status: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(status)
+    state = normalized.get("state")
+    normalized["state"] = _normalize_state_to_public(state)
+    message = normalized.get("message")
+    if isinstance(message, dict):
+        normalized["message"] = _normalize_message_to_public(message)
+    return normalized
+
+
+def _normalize_artifact_to_public(artifact: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(artifact)
+    normalized.setdefault("kind", "artifact")
+    parts = normalized.get("parts")
+    if isinstance(parts, list):
+        normalized["parts"] = [_normalize_part_to_public(part) for part in parts]
+    return normalized
+
+
+def _normalize_part_to_public(part: Any) -> Any:
+    if not isinstance(part, dict):
+        return part
+    normalized = deepcopy(part)
+    if "text" in normalized:
+        normalized.setdefault("kind", "text")
+    return normalized
+
+
+def _normalize_state_to_public(state: Any) -> Any:
+    if isinstance(state, str):
+        mapped = _STATE_TO_CURRENT.get(state)
+        if mapped:
+            return mapped
+        return state.lower().replace("task_state_", "").replace("_", "-")
+    return _STATE_TO_CURRENT.get(state, state)
+
+
+def _looks_like_task(value: dict[str, Any]) -> bool:
+    return "id" in value and "contextId" in value and "status" in value
+
+
+def _looks_like_status_update(value: dict[str, Any]) -> bool:
+    return "taskId" in value and "status" in value
+
+
+def _looks_like_artifact_update(value: dict[str, Any]) -> bool:
+    return "taskId" in value and "artifact" in value

--- a/server/app/storage/config_store.py
+++ b/server/app/storage/config_store.py
@@ -238,6 +238,7 @@ class DefaultConfigStore:
         self._config_registry = config_registry
         self._workspace_path = Path(workspace_path) if workspace_path else Path.cwd()
         self._agent_definitions: dict[str, AgentDefinition] = {}
+        self._file_agent_names: set[str] = set()
         self._init_builtin_agents()
         self.reload_file_agents()
 
@@ -322,6 +323,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
         self._agent_definitions = {
             name: agent for name, agent in self._agent_definitions.items() if agent.native
         }
+        self._file_agent_names.clear()
         agents_dir = self._workspace_path / ".cognition" / "agents"
         if not agents_dir.exists():
             return
@@ -331,6 +333,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
                 definition = load_agent_definition(yaml_path)
                 definition.native = False
                 self._agent_definitions[definition.name] = definition
+                self._file_agent_names.add(definition.name)
             except Exception as exc:
                 logger.warning("Failed to load agent from YAML %s: %s", yaml_path, exc)
 
@@ -339,6 +342,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
                 definition = load_agent_definition(yml_path)
                 definition.native = False
                 self._agent_definitions[definition.name] = definition
+                self._file_agent_names.add(definition.name)
             except Exception as exc:
                 logger.warning("Failed to load agent from YAML %s: %s", yml_path, exc)
 
@@ -346,6 +350,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
             try:
                 definition = load_agent_definition_from_markdown(md_path)
                 self._agent_definitions[definition.name] = definition
+                self._file_agent_names.add(definition.name)
             except Exception as exc:
                 logger.warning("Failed to load agent from Markdown %s: %s", md_path, exc)
 
@@ -354,10 +359,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
         for definition in rows:
             if definition.name.startswith("__"):
                 continue
-            existing = self._agent_definitions.get(definition.name)
-            if existing and existing.native:
-                continue
-            self._agent_definitions[definition.name] = definition
+            AgentDefinition.model_validate(definition)
 
     async def on_config_change(self, event: ConfigChangeEvent) -> None:
         if event.entity_type != "agent":
@@ -366,27 +368,13 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
             return
         if event.operation == "delete":
             existing = self._agent_definitions.get(event.name)
-            if existing and not existing.native:
+            if existing and not existing.native and event.name not in self._file_agent_names:
                 del self._agent_definitions[event.name]
             return
 
-        data = await self._config_registry.get_agent_raw(event.name, event.scope)
-        if not data:
-            return
-        try:
-            definition = AgentDefinition.model_validate(data)
-        except Exception:
-            logger.warning(
-                "Invalid agent definition in DB for %s — skipping cache update",
-                event.name,
-                exc_info=True,
-            )
-            return
-        definition.native = False
         existing = self._agent_definitions.get(event.name)
-        if existing and existing.native:
-            return
-        self._agent_definitions[event.name] = definition
+        if existing and not existing.native and event.name not in self._file_agent_names:
+            del self._agent_definitions[event.name]
 
     # ------------------------------------------------------------------
     # Provider CRUD
@@ -467,13 +455,13 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
         definition: dict[str, Any],
         source: str = "api",
     ) -> None:
-        agent_def = AgentDefinition.model_validate(definition)
-        agent_def.native = False
+        AgentDefinition.model_validate(definition)
         existing = self._agent_definitions.get(name)
         if existing and existing.native:
             return
         await self._config_registry.upsert_agent(name, scope, definition, source)
-        self._agent_definitions[name] = agent_def
+        if name not in self._file_agent_names:
+            self._agent_definitions.pop(name, None)
 
     async def get_agent_raw(
         self, name: str, scope: dict[str, str] | None = None
@@ -493,7 +481,7 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
         result = bool(await self._config_registry.delete_agent(name, scope))
         if result:
             existing = self._agent_definitions.get(name)
-            if existing and not existing.native:
+            if existing and not existing.native and name not in self._file_agent_names:
                 del self._agent_definitions[name]
         return result
 
@@ -504,18 +492,37 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
     async def get_agent_definition(
         self, name: str, scope: dict[str, str] | None = None
     ) -> AgentDefinition | None:
-        return self._agent_definitions.get(name)
+        existing = self._agent_definitions.get(name)
+        if existing and existing.native:
+            return existing
+
+        raw = await self._config_registry.get_agent_raw(name, scope)
+        if raw is not None:
+            definition = AgentDefinition.model_validate(raw)
+            definition.native = False
+            return definition
+
+        return existing
 
     async def list_agent_definitions(
         self, include_hidden: bool = False, scope: dict[str, str] | None = None
     ) -> list[AgentDefinition]:
-        agents = list(self._agent_definitions.values())
+        agents_by_name = dict(self._agent_definitions)
+        for definition in await self._config_registry.list_agents(scope):
+            if definition.name.startswith("__"):
+                continue
+            existing = agents_by_name.get(definition.name)
+            if existing and existing.native:
+                continue
+            definition.native = False
+            agents_by_name[definition.name] = definition
+        agents = list(agents_by_name.values())
         if not include_hidden:
             agents = [agent for agent in agents if not agent.hidden]
         return sorted(agents, key=lambda agent: agent.name)
 
     async def is_valid_primary(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        agent = self._agent_definitions.get(name)
+        agent = await self.get_agent_definition(name, scope)
         if agent is None or agent.hidden:
             return False
         return agent.mode in ("primary", "all")

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.10.2"
+VERSION = "0.10.3"
 
 __all__ = ["VERSION"]

--- a/tests/e2e/test_scenarios/p3_protocols/test_a2a.py
+++ b/tests/e2e/test_scenarios/p3_protocols/test_a2a.py
@@ -80,8 +80,7 @@ class TestAgentCardDiscovery:
         self, api_client: ScenarioTestClient
     ) -> None:
         response = await api_client.client.get(
-            f"{api_client.base_url}/.well-known/agent-card.json",
-            params={"assistant_id": _A2A_AGENT_NAME},
+            f"{api_client.base_url}/a2a/{_A2A_AGENT_NAME}/.well-known/agent-card.json",
             headers=api_client.scope_header,
         )
         assert response.status_code == 200, response.text
@@ -95,8 +94,7 @@ class TestAgentCardDiscovery:
         self, api_client: ScenarioTestClient
     ) -> None:
         response = await api_client.client.get(
-            f"{api_client.base_url}/.well-known/agent-card.json",
-            params={"assistant_id": "nonexistent-agent-xyz"},
+            f"{api_client.base_url}/a2a/nonexistent-agent-xyz/.well-known/agent-card.json",
             headers=api_client.scope_header,
         )
         assert response.status_code == 404
@@ -105,8 +103,7 @@ class TestAgentCardDiscovery:
         self, api_client: ScenarioTestClient
     ) -> None:
         response = await api_client.client.get(
-            f"{api_client.base_url}/.well-known/agent-card.json",
-            params={"assistant_id": _A2A_AGENT_NAME},
+            f"{api_client.base_url}/a2a/{_A2A_AGENT_NAME}/.well-known/agent-card.json",
             headers=api_client.scope_header,
         )
         card = response.json()
@@ -123,14 +120,14 @@ class TestA2AMessageSend:
         self, api_client: ScenarioTestClient
     ) -> None:
         message = {
-            "role": "ROLE_USER",
-            "parts": [{"text": "Say hello in exactly 3 words.", "mediaType": "text/plain"}],
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Say hello in exactly 3 words."}],
             "messageId": str(uuid.uuid4()),
         }
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
-            "method": "SendMessage",
+            "method": "message/send",
             "params": {"message": message},
         }
         response = await api_client.client.post(
@@ -139,7 +136,6 @@ class TestA2AMessageSend:
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/json",
-                "A2A-Version": "1.0",
                 **api_client.scope_header,
             },
             timeout=60.0,
@@ -147,25 +143,24 @@ class TestA2AMessageSend:
         assert response.status_code == 200, response.text
         result = response.json()
         assert "result" in result, f"No result in response: {result}"
-        wrapper = result["result"]
-        assert "task" in wrapper
-        task = wrapper["task"]
+        task = result["result"]
+        assert task["kind"] == "task"
         assert "id" in task
         assert "contextId" in task
-        assert task["status"]["state"] in ["TASK_STATE_COMPLETED", 3]
+        assert task["status"]["state"] == "completed"
 
     async def test_send_message_returns_artifact(
         self, api_client: ScenarioTestClient
     ) -> None:
         message = {
-            "role": "ROLE_USER",
-            "parts": [{"text": "Reply with exactly: A2A_WORKS", "mediaType": "text/plain"}],
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Reply with exactly: A2A_WORKS"}],
             "messageId": str(uuid.uuid4()),
         }
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
-            "method": "SendMessage",
+            "method": "message/send",
             "params": {"message": message},
         }
         response = await api_client.client.post(
@@ -174,15 +169,13 @@ class TestA2AMessageSend:
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/json",
-                "A2A-Version": "1.0",
                 **api_client.scope_header,
             },
             timeout=60.0,
         )
         assert response.status_code == 200, response.text
         result = response.json()
-        wrapper = result["result"]
-        task = wrapper.get("task", wrapper)
+        task = result["result"]
         artifacts = task.get("artifacts", [])
         assert len(artifacts) >= 1, f"No artifacts in task: {task}"
         artifact = artifacts[0]
@@ -199,14 +192,14 @@ class TestA2AStreaming:
         self, api_client: ScenarioTestClient
     ) -> None:
         message = {
-            "role": "ROLE_USER",
-            "parts": [{"text": "Count from 1 to 3.", "mediaType": "text/plain"}],
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Count from 1 to 3."}],
             "messageId": str(uuid.uuid4()),
         }
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
-            "method": "SendStreamingMessage",
+            "method": "message/stream",
             "params": {"message": message},
         }
         events = []
@@ -218,7 +211,6 @@ class TestA2AStreaming:
             headers={
                 "Accept": "text/event-stream",
                 "Content-Type": "application/json",
-                "A2A-Version": "1.0",
                 **api_client.scope_header,
             },
             timeout=60.0,
@@ -235,14 +227,14 @@ class TestA2AStreaming:
         self, api_client: ScenarioTestClient
     ) -> None:
         message = {
-            "role": "ROLE_USER",
-            "parts": [{"text": "Say OK.", "mediaType": "text/plain"}],
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Say OK."}],
             "messageId": str(uuid.uuid4()),
         }
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
-            "method": "SendStreamingMessage",
+            "method": "message/stream",
             "params": {"message": message},
         }
         events = []
@@ -254,7 +246,6 @@ class TestA2AStreaming:
             headers={
                 "Accept": "text/event-stream",
                 "Content-Type": "application/json",
-                "A2A-Version": "1.0",
                 **api_client.scope_header,
             },
             timeout=60.0,

--- a/tests/unit/test_a2a_adapter.py
+++ b/tests/unit/test_a2a_adapter.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import httpx
+import pytest
 from a2a.types import TaskState
+from fastapi import FastAPI
 
 from server.app.agent.definition import AgentDefinition
 from server.app.agent.runtime import (
@@ -19,6 +22,11 @@ from server.app.protocols.a2a.mapping import (
     event_to_a2a_state,
     extract_text_from_parts,
     is_hitl_pause,
+)
+from server.app.protocols.a2a.wire import (
+    normalize_request_for_sdk,
+    normalize_response_to_public,
+    normalize_stream_item_to_public,
 )
 
 
@@ -105,6 +113,95 @@ class TestBuildAgentCardForAgent:
         card_str = str(card)
         assert "tool1" not in card_str
         assert "tool2" not in card_str
+
+
+class TestA2APerAgentCardRoute:
+    @pytest.mark.asyncio
+    async def test_per_agent_card_uses_request_base_url_and_scope(self):
+        from server.app.protocols.a2a.routes import mount_a2a_routes
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
+
+        app = FastAPI()
+        settings = MagicMock()
+        settings.scope_keys = ["user"]
+        config_store = DefaultConfigStore(MemoryConfigRegistry())
+        await config_store.upsert_agent(
+            "scoped-agent",
+            {"user": "alice"},
+            {
+                "name": "scoped-agent",
+                "system_prompt": "test",
+                "mode": "primary",
+                "a2a_exposed": True,
+            },
+        )
+        await mount_a2a_routes(
+            app,
+            settings=settings,
+            config_store=config_store,
+            session_agent_manager=MagicMock(),
+            store=MagicMock(),
+            version="0.10.3",
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://example.test",
+        ) as client:
+            response = await client.get(
+                "/a2a/scoped-agent/.well-known/agent-card.json",
+                headers={"X-Cognition-Scope-User": "alice"},
+            )
+
+        assert response.status_code == 200
+        card = response.json()
+        assert card["name"] == "Cognition (scoped-agent)"
+        assert card["supportedInterfaces"][0]["url"] == (
+            "http://example.test/a2a/scoped-agent"
+        )
+
+    @pytest.mark.asyncio
+    async def test_per_agent_card_respects_request_scope(self):
+        from server.app.protocols.a2a.routes import mount_a2a_routes
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
+
+        app = FastAPI()
+        settings = MagicMock()
+        settings.scope_keys = ["user"]
+        config_store = DefaultConfigStore(MemoryConfigRegistry())
+        await config_store.upsert_agent(
+            "scoped-agent",
+            {"user": "alice"},
+            {
+                "name": "scoped-agent",
+                "system_prompt": "test",
+                "mode": "primary",
+                "a2a_exposed": True,
+            },
+        )
+        await mount_a2a_routes(
+            app,
+            settings=settings,
+            config_store=config_store,
+            session_agent_manager=MagicMock(),
+            store=MagicMock(),
+            version="0.10.3",
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://example.test",
+        ) as client:
+            response = await client.get(
+                "/a2a/scoped-agent/.well-known/agent-card.json",
+                headers={"X-Cognition-Scope-User": "bob"},
+            )
+
+        assert response.status_code == 404
 
 
 class TestA2AExposureFiltering:
@@ -202,6 +299,108 @@ class TestExtractTextFromParts:
 
     def test_empty_parts(self):
         assert extract_text_from_parts([]) == ""
+
+    def test_current_text_part_shape(self):
+        parts = [{"kind": "text", "text": "hello world"}]
+        assert extract_text_from_parts(parts) == "hello world"
+
+
+class TestA2AWireShape:
+    def test_message_send_request_normalizes_to_sdk_shape(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "hello"}],
+                }
+            },
+        }
+
+        normalized = normalize_request_for_sdk(payload)
+
+        assert normalized["method"] == "SendMessage"
+        message = normalized["params"]["message"]
+        assert message["role"] == "ROLE_USER"
+        assert message["parts"] == [{"text": "hello", "mediaType": "text/plain"}]
+
+    def test_message_stream_request_normalizes_to_sdk_shape(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "message/stream",
+            "params": {"message": {"role": "agent", "parts": [{"text": "hello"}]}},
+        }
+
+        normalized = normalize_request_for_sdk(payload)
+
+        assert normalized["method"] == "SendStreamingMessage"
+        assert normalized["params"]["message"]["role"] == "ROLE_AGENT"
+
+    def test_task_response_normalizes_to_current_shape(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "task": {
+                    "id": "task-1",
+                    "contextId": "ctx-1",
+                    "status": {
+                        "state": "TASK_STATE_COMPLETED",
+                        "message": {
+                            "role": "ROLE_AGENT",
+                            "parts": [{"text": "Done"}],
+                        },
+                    },
+                }
+            },
+        }
+
+        normalized = normalize_response_to_public(payload)
+
+        task = normalized["result"]
+        assert task["kind"] == "task"
+        assert task["status"]["state"] == "completed"
+        assert task["status"]["message"]["kind"] == "message"
+        assert task["status"]["message"]["role"] == "agent"
+        assert task["status"]["message"]["parts"][0]["kind"] == "text"
+
+    def test_stream_status_event_normalizes_to_current_shape(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "taskId": "task-1",
+                "contextId": "ctx-1",
+                "status": {"state": 3},
+            },
+        }
+
+        normalized = normalize_stream_item_to_public(payload)
+
+        event = normalized["result"]
+        assert event["kind"] == "status-update"
+        assert event["status"]["state"] == "completed"
+
+    def test_stream_artifact_event_normalizes_to_current_shape(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "taskId": "task-1",
+                "contextId": "ctx-1",
+                "artifact": {"parts": [{"text": "hello"}]},
+            },
+        }
+
+        normalized = normalize_stream_item_to_public(payload)
+
+        event = normalized["result"]
+        assert event["kind"] == "artifact-update"
+        assert event["artifact"]["kind"] == "artifact"
+        assert event["artifact"]["parts"][0]["kind"] == "text"
 
 
 class TestEventToA2AState:

--- a/tests/unit/test_config_store_agent_definitions.py
+++ b/tests/unit/test_config_store_agent_definitions.py
@@ -152,6 +152,76 @@ class TestScopePreservation:
         result = await store.get_agent_raw_with_scope("no-such-agent")
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_get_agent_definition_respects_scope_for_same_name(
+        self, store: DefaultConfigStore
+    ):
+        await store.upsert_agent(
+            "shared-agent",
+            {"user": "alice"},
+            {
+                "name": "shared-agent",
+                "system_prompt": "alice prompt",
+                "mode": "primary",
+                "a2a_exposed": True,
+            },
+            "api",
+        )
+        await store.upsert_agent(
+            "shared-agent",
+            {"user": "bob"},
+            {
+                "name": "shared-agent",
+                "system_prompt": "bob prompt",
+                "mode": "primary",
+                "a2a_exposed": True,
+            },
+            "api",
+        )
+
+        alice_agent = await store.get_agent_definition("shared-agent", {"user": "alice"})
+        bob_agent = await store.get_agent_definition("shared-agent", {"user": "bob"})
+        missing_agent = await store.get_agent_definition("shared-agent", {"user": "carol"})
+
+        assert alice_agent is not None
+        assert bob_agent is not None
+        assert alice_agent.system_prompt == "alice prompt"
+        assert bob_agent.system_prompt == "bob prompt"
+        assert missing_agent is None
+
+    @pytest.mark.asyncio
+    async def test_list_agent_definitions_respects_scope_for_same_name(
+        self, store: DefaultConfigStore
+    ):
+        await store.upsert_agent(
+            "shared-agent",
+            {"user": "alice"},
+            {
+                "name": "shared-agent",
+                "system_prompt": "alice prompt",
+                "mode": "primary",
+            },
+            "api",
+        )
+        await store.upsert_agent(
+            "shared-agent",
+            {"user": "bob"},
+            {
+                "name": "shared-agent",
+                "system_prompt": "bob prompt",
+                "mode": "primary",
+            },
+            "api",
+        )
+
+        alice_agents = await store.list_agent_definitions(scope={"user": "alice"})
+        bob_agents = await store.list_agent_definitions(scope={"user": "bob"})
+
+        alice_agent = next(agent for agent in alice_agents if agent.name == "shared-agent")
+        bob_agent = next(agent for agent in bob_agents if agent.name == "shared-agent")
+        assert alice_agent.system_prompt == "alice prompt"
+        assert bob_agent.system_prompt == "bob prompt"
+
 
 class TestValidationPropagation:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=1.0.0" },
+    { name = "a2a-sdk", specifier = ">=1.0.3" },
     { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.30.0" },
     { name = "asyncpg", marker = "extra == 'deploy'", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },


### PR DESCRIPTION
## Summary
- Align Cognition's public A2A surface with current A2A JSON-RPC method names: `message/send` and `message/stream`.
- Add per-agent Agent Card discovery at `/a2a/{agent_name}/.well-known/agent-card.json`.
- Normalize current A2A request roles/parts and task/event response shapes while keeping a2a-sdk translation private.
- Fix scoped dynamic agent route lookup so same-named scoped agents resolve from the request scope.
- Bump version metadata to `0.10.3` and update changelog, roadmap, and A2A docs.

## Validation
- `uv run pytest tests/unit -v` — 751 passed, 4 skipped
- `uv run mypy .` — passed
- `uv run ruff check .` — passed
- `uv lock --check` — passed
- Rebuilt local docker compose `cognition` service; `/health` reported version `0.10.3`
- `COGNITION_E2E_URL=http://localhost:8000 uv run pytest tests/e2e/test_scenarios/p3_protocols/test_a2a.py -q -rs` — passed once before rebase: 9 passed
- After rebase, full A2A scenario had one transient real-model timeout in `test_send_message_returns_artifact`; direct rerun of that failed test passed: 1 passed

## Release note
Release-critical protocol fix for current A2A/a2a-sdk conformance. Multi-replica registry/cache synchronization is intentionally out of scope.