### PR TITLE
Fix per-agent blocked_tools persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.10.4] — 2026-06-15
+
+### Fixed
+
+- Fixed per-agent `blocked_tools` persistence for `POST /agents` and `PATCH /agents/{name}` so API-provided tool blocklists are stored in ConfigRegistry, returned by `GET /agents/{name}`, and forwarded into runtime tool security alongside global `COGNITION_BLOCKED_TOOLS`.
+- Fixed scoped `PATCH /agents/{name}` responses to reload the same scoped agent row that was updated.
+
+---
+
 ## [0.10.3] — 2026-05-28
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 | 2026-05-25 | Fix Deep Agents runtime activity not updating durable session state — assistant responses are streamed but not persisted, tool activity does not advance `updated_at`, tool logs show `session_id=None`, and overlapping turns can mark a session done while earlier runtime work continues. | AEP report: session `2488ce4e-13fa-47c4-95fb-d5120d89f097`; hotfix merged as PR #131 | 2/4/6/7 | Completed |
 | 2026-05-25 | Fix K8s sandbox filesystem API compatibility and terminal run contradictions — K8s wrapper now uses Deep Agents' current `ls`/`glob`/`grep` result APIs, and runtime errors suppress later `done` events/callback success. | AEP runtime report: `RUNTIME_ERROR` with "new `ls` API" followed by `run.done` | 3/4/6/7 | Completed |
 | 2026-05-28 | Align A2A protocol surface with current JSON-RPC method names and task/event wire shapes; add per-agent Agent Card discovery under `/a2a/{agent_name}/.well-known/agent-card.json`; ensure scoped dynamic agent route lookup respects request scope. | A2A interoperability report for Cognition 0.10.2 | 2/6 | Completed |
+| 2026-06-15 | Fix per-agent `blocked_tools` API persistence and scoped PATCH reload — `PATCH /agents/{name}` accepted unknown `blocked_tools` input with 200 but dropped it before ConfigRegistry persistence and runtime tool security. | Wá Salon Builder Starter dev report | 2/4/6 | Completed |
 
 ---
 

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -558,6 +558,17 @@ List all non-hidden agents available in the registry.
       "native": true,
       "model": null,
       "temperature": null,
+      "config": {
+        "temperature": null,
+        "max_tokens": null,
+        "recursion_limit": null,
+        "tool_token_limit_before_evict": null,
+        "context_policy": null,
+        "blocked_tools": [],
+        "provider": null,
+        "model": null,
+        "timeout_seconds": null
+      },
       "response_format": null,
       "interrupt_on": {},
       "tools": [],
@@ -598,6 +609,7 @@ Create or replace an agent definition in the ConfigRegistry.
   "interrupt_on": {},
   "model": "gpt-4o",
   "temperature": 0.1,
+  "blocked_tools": ["execute"],
   "scope": {}
 }
 ```
@@ -614,6 +626,7 @@ Create or replace an agent definition in the ConfigRegistry.
 | `interrupt_on` | dict | Tool names mapped to `true` for HITL confirmation |
 | `model` | string | Model override (overrides global default for this agent's sessions) |
 | `temperature` | float | Temperature override |
+| `blocked_tools` | list[string] | Tool names blocked for this agent in addition to global `COGNITION_BLOCKED_TOOLS` |
 | `scope` | dict | Scope restriction; empty `{}` = global |
 
 **Response `201 Created`:** Agent object  
@@ -636,7 +649,8 @@ Partially update an agent definition. Only provided fields are changed.
 {
   "system_prompt": "Updated prompt.",
   "model": "claude-sonnet-4-6",
-  "temperature": 0.5
+  "temperature": 0.5,
+  "blocked_tools": ["execute", "glob", "grep"]
 }
 ```
 

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -117,6 +117,7 @@ class RuntimeContext:
     response_format: str
     tool_token_limit_before_evict: int | None
     context_policy: str
+    blocked_tools: tuple[str, ...]
     middleware_count: int
     tools_count: int
     sandbox_backend: str
@@ -138,6 +139,7 @@ class RuntimeContext:
         response_format: str | type[Any] | None,
         tool_token_limit_before_evict: int | None,
         context_policy: Any | None,
+        blocked_tools: Sequence[str] | None,
         middleware: Sequence[Any] | None,
         tools: Sequence[Any] | None,
         settings: Settings,
@@ -163,6 +165,7 @@ class RuntimeContext:
             else "None",
             tool_token_limit_before_evict=tool_token_limit_before_evict,
             context_policy=_json_cache_key(context_policy),
+            blocked_tools=tuple(sorted(str(tool) for tool in (blocked_tools or []))),
             middleware_count=len(middleware) if middleware else 0,
             tools_count=len(tools) if tools else 0,
             sandbox_backend=settings.sandbox_backend,
@@ -366,6 +369,7 @@ class CognitionAgentParams:
     response_format: str | type[Any] | None = None
     tool_token_limit_before_evict: int | None = None
     context_policy: Any | None = None
+    blocked_tools: Sequence[str] | None = None
     middleware: Sequence[Any] | None = None
     tools: Sequence[Any] | None = None
     settings: Settings | None = None
@@ -476,6 +480,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
         response_format=params.response_format,
         tool_token_limit_before_evict=params.tool_token_limit_before_evict,
         context_policy=params.context_policy,
+        blocked_tools=params.blocked_tools,
         middleware=params.middleware,
         tools=params.tools,
         settings=settings,
@@ -614,7 +619,13 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
             prompt = SYSTEM_PROMPT
 
     agent_middleware = list(params.middleware) if params.middleware else []
-    blocked_tools = list(settings.blocked_tools) if hasattr(settings, "blocked_tools") else []
+    settings_blocked_tools = settings.blocked_tools if hasattr(settings, "blocked_tools") else []
+    blocked_tools = sorted(
+        {
+            *(str(tool) for tool in settings_blocked_tools),
+            *(str(tool) for tool in (params.blocked_tools or [])),
+        }
+    )
 
     built_in_tools = [BrowserTool(), SearchTool(), InspectPackageTool()]
     agent_tools = list(params.tools) if params.tools else []

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -87,6 +87,7 @@ class AgentConfig(BaseModel):
     recursion_limit: int | None = Field(default=None, gt=0)
     tool_token_limit_before_evict: int | None = Field(default=None, gt=0)
     context_policy: ContextPolicy | None = Field(default=None)
+    blocked_tools: list[str] = Field(default_factory=list)
     provider: str | None = Field(default=None)
     model: str | None = Field(default=None)
     timeout_seconds: float | None = Field(default=None, gt=0)
@@ -564,6 +565,7 @@ def load_agent_definition_from_markdown(path: str | Path) -> AgentDefinition:
             "recursion_limit",
             "tool_token_limit_before_evict",
             "context_policy",
+            "blocked_tools",
             "provider",
             "model",
             "timeout_seconds",

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -836,6 +836,7 @@ class AgentConfigResponse(BaseModel):
     recursion_limit: int | None = None
     tool_token_limit_before_evict: int | None = None
     context_policy: ContextPolicy | None = None
+    blocked_tools: list[str] | None = None
     provider: str | None = None
     model: str | None = None
     timeout_seconds: float | None = None
@@ -1168,6 +1169,7 @@ class AgentCreate(BaseModel):
     recursion_limit: int | None = Field(default=None)
     tool_token_limit_before_evict: int | None = Field(default=None)
     context_policy: ContextPolicy | None = Field(default=None)
+    blocked_tools: list[str] = Field(default_factory=list)
     provider: str | None = Field(default=None)
     timeout_seconds: float | None = Field(default=None)
     middleware: list[Any] = Field(default_factory=list)
@@ -1198,6 +1200,7 @@ class AgentUpdate(BaseModel):
     recursion_limit: int | None = None
     tool_token_limit_before_evict: int | None = None
     context_policy: ContextPolicy | None = None
+    blocked_tools: list[str] | None = None
     provider: str | None = None
     timeout_seconds: float | None = None
     middleware: list[Any] | None = None

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -36,6 +36,7 @@ def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
             recursion_limit=agent.config.recursion_limit,
             tool_token_limit_before_evict=agent.config.tool_token_limit_before_evict,
             context_policy=agent.config.context_policy,
+            blocked_tools=list(agent.config.blocked_tools),
             provider=agent.config.provider,
             model=agent.config.model,
             timeout_seconds=agent.config.timeout_seconds,
@@ -144,6 +145,7 @@ async def create_agent(
                     if body.context_policy
                     else None
                 ),
+                "blocked_tools": body.blocked_tools,
                 "provider": body.provider,
                 "timeout_seconds": body.timeout_seconds,
             },
@@ -215,6 +217,7 @@ async def update_agent(
             "recursion_limit",
             "tool_token_limit_before_evict",
             "context_policy",
+            "blocked_tools",
             "provider",
             "timeout_seconds",
         }
@@ -229,7 +232,7 @@ async def update_agent(
 
         await config_store.upsert_agent(name, agent_scope, data, "api")
 
-        agent_def = await config_store.get_agent_definition(name)
+        agent_def = await config_store.get_agent_definition(name, agent_scope or None)
         if agent_def is None:
             raise HTTPException(status_code=500, detail="Agent not found after update")
         return _agent_to_response(agent_def)

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -156,6 +156,7 @@ class ResolvedAgentConfig:
     response_format: str | None = None
     tool_token_limit_before_evict: int | None = None
     context_policy: Any | None = None
+    blocked_tools: list[str] = field(default_factory=list)
     subagents: list[Any] = field(default_factory=list)
     async_subagents: list[Any] = field(default_factory=list)
     agent_def: Any = None
@@ -311,6 +312,9 @@ class DeepAgentStreamingService:
         if agent_def.config.context_policy is not None:
             resolved.context_policy = agent_def.config.context_policy
 
+        if agent_def.config.blocked_tools:
+            resolved.blocked_tools = list(agent_def.config.blocked_tools)
+
         if agent_def.middleware:
             resolved.middleware = _resolve_middleware(agent_def.middleware)
 
@@ -403,6 +407,7 @@ class DeepAgentStreamingService:
                 or agent_cfg.response_format,
                 tool_token_limit_before_evict=agent_cfg.tool_token_limit_before_evict,
                 context_policy=agent_cfg.context_policy,
+                blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
                 mcp_configs=mcp_configs or None,
                 scope=scope,
@@ -606,6 +611,7 @@ class DeepAgentStreamingService:
                 or agent_cfg.response_format,
                 tool_token_limit_before_evict=agent_cfg.tool_token_limit_before_evict,
                 context_policy=agent_cfg.context_policy,
+                blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
                 mcp_configs=mcp_configs or None,
                 scope=scope,

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -6,11 +6,14 @@ agent management.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi.testclient import TestClient
 
-from server.app.api.dependencies import set_config_store
+from server.app.api.dependencies import get_config_store, get_settings_dep, set_config_store
 from server.app.main import app
+from server.app.settings import Settings
 from server.app.storage.config_store import DefaultConfigStore
 
 client = TestClient(app)
@@ -142,6 +145,28 @@ class TestCreateAgent:
         assert data["async_subagents"][0]["name"] == "researcher"
         assert data["async_subagents"][0]["graph_id"] == "research_graph"
 
+    def test_create_agent_persists_blocked_tools(self):
+        response = client.post(
+            "/agents",
+            json={
+                "name": "test-create-blocked-tools-agent",
+                "system_prompt": "blocked tools create test",
+                "blocked_tools": ["glob", "grep", "ls"],
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["config"]["blocked_tools"] == ["glob", "grep", "ls"]
+
+        get_resp = client.get("/agents/test-create-blocked-tools-agent")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["config"]["blocked_tools"] == ["glob", "grep", "ls"]
+
+        raw = asyncio.run(
+            get_config_store().get_agent_raw("test-create-blocked-tools-agent")
+        )
+        assert raw is not None
+        assert raw["config"]["blocked_tools"] == ["glob", "grep", "ls"]
+
     def test_get_preserves_top_level_provider(self):
         client.post(
             "/agents",
@@ -265,6 +290,93 @@ class TestUpdateAgent:
         assert response.json()["config"]["recursion_limit"] == 100
         assert response.json()["config"]["provider"] == "openai"
         assert response.json()["config"]["timeout_seconds"] == 30
+
+    def test_patch_agent_persists_blocked_tools(self):
+        client.post(
+            "/agents",
+            json={
+                "name": "test-patch-blocked-tools-agent",
+                "system_prompt": "blocked tools patch test",
+            },
+        )
+        response = client.patch(
+            "/agents/test-patch-blocked-tools-agent",
+            json={"blocked_tools": ["execute", "task", "write_todos"]},
+        )
+        assert response.status_code == 200
+        assert response.json()["config"]["blocked_tools"] == [
+            "execute",
+            "task",
+            "write_todos",
+        ]
+
+        get_resp = client.get("/agents/test-patch-blocked-tools-agent")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["config"]["blocked_tools"] == [
+            "execute",
+            "task",
+            "write_todos",
+        ]
+
+        raw = asyncio.run(get_config_store().get_agent_raw("test-patch-blocked-tools-agent"))
+        assert raw is not None
+        assert raw["config"]["blocked_tools"] == ["execute", "task", "write_todos"]
+
+    def test_patch_scoped_agent_persists_blocked_tools(self):
+        scoped_settings = Settings(scoping_enabled=True, scope_keys=["tenant"])
+        headers = {"X-Cognition-Scope-Tenant": "wasaloon"}
+        app.dependency_overrides[get_settings_dep] = lambda: scoped_settings
+        try:
+            create_resp = client.post(
+                "/agents",
+                json={
+                    "name": "test-scoped-blocked-tools-agent",
+                    "system_prompt": "scoped blocked tools test",
+                },
+                headers=headers,
+            )
+            assert create_resp.status_code == 201
+
+            response = client.patch(
+                "/agents/test-scoped-blocked-tools-agent",
+                json={"blocked_tools": ["glob", "grep", "inspect_package", "ls"]},
+                headers=headers,
+            )
+            assert response.status_code == 200
+            assert response.json()["config"]["blocked_tools"] == [
+                "glob",
+                "grep",
+                "inspect_package",
+                "ls",
+            ]
+
+            get_resp = client.get(
+                "/agents/test-scoped-blocked-tools-agent",
+                headers=headers,
+            )
+            assert get_resp.status_code == 200
+            assert get_resp.json()["config"]["blocked_tools"] == [
+                "glob",
+                "grep",
+                "inspect_package",
+                "ls",
+            ]
+
+            raw = asyncio.run(
+                get_config_store().get_agent_raw(
+                    "test-scoped-blocked-tools-agent",
+                    {"tenant": "wasaloon"},
+                )
+            )
+            assert raw is not None
+            assert raw["config"]["blocked_tools"] == [
+                "glob",
+                "grep",
+                "inspect_package",
+                "ls",
+            ]
+        finally:
+            app.dependency_overrides.pop(get_settings_dep, None)
 
     def test_patch_unrelated_field_preserves_top_level_provider(self):
         client.post(

--- a/tests/unit/test_agent_def_field_wiring.py
+++ b/tests/unit/test_agent_def_field_wiring.py
@@ -444,6 +444,30 @@ class TestStructuredOutputAndContextControls:
         assert params.context_policy == policy
 
     @pytest.mark.asyncio
+    async def test_blocked_tools_passed_to_create_cognition_agent(self):
+        """blocked_tools from AgentConfig must be forwarded to tool security."""
+        from server.app.agent.definition import AgentConfig, AgentDefinition
+
+        session = _make_session()
+        mock_runtime = _make_mock_runtime(DoneEvent())
+        patches = _base_patches(mock_runtime, session)
+
+        agent_def = AgentDefinition(
+            name="test-agent",
+            system_prompt="test",
+            config=AgentConfig(blocked_tools=["glob", "grep", "ls"]),
+        )
+        mock_def_registry = MagicMock()
+        mock_def_registry.get = MagicMock(return_value=agent_def)
+        mock_def_registry.subagents = MagicMock(return_value=[])
+
+        _, create_agent_mock = await _run(patches, session, mock_def_registry=mock_def_registry)
+
+        params = _get_params(create_agent_mock)
+        assert params is not None
+        assert params.blocked_tools == ["glob", "grep", "ls"]
+
+    @pytest.mark.asyncio
     async def test_async_subagents_passed_to_create_cognition_agent(self):
         """async_subagents from AgentDefinition must be forwarded."""
         from server.app.agent.definition import AgentDefinition, AsyncSubagentConfig


### PR DESCRIPTION
## Summary
- Add per-agent `blocked_tools` to the public agent API/config contract.
- Persist and return `config.blocked_tools` for POST, PATCH, GET, including scoped PATCH reloads.
- Forward resolved blocked tools into runtime tool security and include them in the runtime graph cache key.
- Document the `/agents` field and add v0.10.4 changelog/roadmap bug-fix entries.

## Validation
- `PYTHONPATH=. uv run pytest tests/unit/api/test_agents_crud.py -q`
- `PYTHONPATH=. uv run pytest tests/unit/test_agent_def_field_wiring.py::TestStructuredOutputAndContextControls::test_blocked_tools_passed_to_create_cognition_agent -q`
- `PYTHONPATH=. uv run pytest tests/unit -q`
- `PYTHONPATH=. uv run ruff check .`
- `PYTHONPATH=. uv run mypy .`
- `git diff --check`

## Release Prep
After this lands on `main`, create `release/v0.10.4` from fresh `origin/main`, bump release metadata only, run the release checklist validation, and dispatch `.github/workflows/pre-release-images.yml` with `version=0.10.4` and `prerelease_tag=rc1`. Do not tag or publish the final release yet.