### PR TITLE
Fix scoped session agent resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## Unreleased
+## [0.11.0-rc.3] — 2026-06-27
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Fixed scoped API-created primary agents being visible through `GET /agents/{name}` but rejected by `POST /sessions` and `PATCH /sessions/{id}` because session agent validation did not use the request scope.
+
+---
+
 ## [0.11.0-rc.2] — 2026-06-26
 
 ### Security

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-06-27 | Fix scoped API-created agents being rejected by `POST /sessions` and `PATCH /sessions/{id}` agent validation because session routes checked primary-agent eligibility without request scope. | Kennel rc.2 Lambda MicroVM smoke report | 4/6 | Completed |
 | 2026-03-06 | Fix dead code (duplicate kwargs block) in `llm/registry.py` | - | 5 | Completed |
 | 2026-03-06 | Fix `StorageBackend` protocol — `create_message` missing `tool` role and `tool_call_id`; `MemoryStorageBackend` missing `status`/`agent_name` in `update_session` | - | 2 | Completed |
 | 2026-03-06 | Fix `agent_definition_registry.py` — `.list()` method shadowing builtin `list` type, causing mypy `valid-type` errors; renamed to `.get_all()` | - | 4 | Completed |

--- a/server/app/api/routes/sessions.py
+++ b/server/app/api/routes/sessions.py
@@ -227,7 +227,7 @@ async def create_session(
     Note: Server uses global settings exclusively. No per-session configuration.
     """
     # Validate agent_name is a valid primary agent
-    if not await config_store.is_valid_primary(request.agent_name):
+    if not await config_store.is_valid_primary(request.agent_name, scope.get_all() or None):
         raise _unprocessable_entity(f"Invalid or unknown agent: {request.agent_name}")
 
     # Idempotency: return existing session if idempotency_key matches
@@ -490,7 +490,7 @@ async def update_session(
     )
 
     if request.agent_name:
-        if not await config_store.is_valid_primary(request.agent_name):
+        if not await config_store.is_valid_primary(request.agent_name, scope.get_all() or None):
             raise _unprocessable_entity(f"Invalid or unknown agent: {request.agent_name}")
 
     session = await store.update_session(

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.11.0-rc.2"
+VERSION = "0.11.0-rc.3"
 
 __all__ = ["VERSION"]

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -708,6 +708,86 @@ class TestSessionAgentName:
         assert data["agent_name"] == "readonly"
 
 
+class TestScopedSessionAgentName:
+    """Test scoped API-created agent resolution for session binding."""
+
+    def test_scoped_api_created_agent_can_create_and_update_sessions(self):
+        """Session agent validation must use the same scope as the agent API."""
+        scoped_settings = Settings(
+            scoping_enabled=True,
+            scope_keys=["tenant", "user"],
+        )
+        app.dependency_overrides[get_settings_dep] = lambda: scoped_settings
+        name = f"kennel-testing-lab-lambda-microvm-smoke-{uuid.uuid4().hex[:8]}"
+        headers = {
+            "X-Cognition-Scope-Tenant": "kennel-testing-lab",
+            "X-Cognition-Scope-User": "kennel-surface-lambda-microvm-smoke",
+        }
+        wrong_headers = {
+            "X-Cognition-Scope-Tenant": "kennel-testing-lab",
+            "X-Cognition-Scope-User": "other-user",
+        }
+
+        try:
+            create_agent_resp = client.post(
+                "/agents",
+                headers=headers,
+                json={
+                    "name": name,
+                    "description": "Kennel scoped Lambda MicroVM smoke agent",
+                    "system_prompt": "You are a scoped smoke-test agent.",
+                    "mode": "primary",
+                    "sandbox_profile": "lambda-microvm-smoke",
+                },
+            )
+            assert create_agent_resp.status_code == 201, create_agent_resp.text
+
+            same_scope_get = client.get(f"/agents/{name}", headers=headers)
+            assert same_scope_get.status_code == 200
+
+            wrong_scope_get = client.get(f"/agents/{name}", headers=wrong_headers)
+            assert wrong_scope_get.status_code == 404
+
+            missing_scope_session = client.post(
+                "/sessions",
+                json={"title": "missing-scope", "agent_name": name},
+            )
+            assert missing_scope_session.status_code == 403
+
+            wrong_scope_session = client.post(
+                "/sessions",
+                headers=wrong_headers,
+                json={"title": "wrong-scope", "agent_name": name},
+            )
+            assert wrong_scope_session.status_code == 422
+
+            create_session_resp = client.post(
+                "/sessions",
+                headers=headers,
+                json={"title": "direct generated agent probe", "agent_name": name},
+            )
+            assert create_session_resp.status_code == 201, create_session_resp.text
+            assert create_session_resp.json()["agent_name"] == name
+
+            patch_target_resp = client.post(
+                "/sessions",
+                headers=headers,
+                json={"title": "patch generated agent probe"},
+            )
+            assert patch_target_resp.status_code == 201, patch_target_resp.text
+
+            patch_session_resp = client.patch(
+                f"/sessions/{patch_target_resp.json()['id']}",
+                headers=headers,
+                json={"agent_name": name},
+            )
+            assert patch_session_resp.status_code == 200, patch_session_resp.text
+            assert patch_session_resp.json()["agent_name"] == name
+        finally:
+            app.dependency_overrides.pop(get_settings_dep, None)
+            client.delete(f"/agents/{name}", headers=headers)
+
+
 class TestAgentEndpoints:
     """Test agent management API endpoints."""
 


### PR DESCRIPTION
## Summary

- Fixes scoped API-created agents being visible through `GET /agents/{name}` but rejected by `POST /sessions` with `Invalid or unknown agent`.
- Passes the request `effective_scope` into session `agent_name` validation for both session creation and session update.
- Adds a Kennel-shaped regression covering scoped agent creation, same-scope readback, wrong-scope isolation, `POST /sessions`, and `PATCH /sessions/{id}`.
- Adds roadmap and unreleased changelog entries.

## Root Cause

`GET /agents/{name}` resolved agents with request scope, but `POST /sessions` and `PATCH /sessions/{id}` called `config_store.is_valid_primary(agent_name)` without scope. Scoped API-created agents therefore looked absent to session validation even though the agent API could read them.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv sync --all-extras --dev` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_rest_api.py::TestScopedSessionAgentName -q` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit -q` — 785 passed, 4 skipped
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run mypy .` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run mkdocs build --strict` — passed
- `git diff --check` — passed

## Release Note

This is not included in the existing `v0.11.0-rc.2` tag. It is marked as Unreleased until the next RC/final release tag is cut.
