### PR TITLE
fix: verify Lambda MicroVM teardown observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.11.0-rc.5] — 2026-07-10
+
+### Fixed
+
+- Verified Lambda MicroVM teardown before reporting completion, with bounded AWS `GetMicrovm` polling and explicit `teardown_complete`, `teardown_pending`, and `teardown_failed` lifecycle phases.
+
+### Added
+
+- Added token-free Lambda MicroVM lifecycle observability for launch, auth token creation, runtime healthchecks, runtime snapshots, teardown status, timing metadata, and scope/role fingerprints.
+
+---
+
 ## [0.11.0-rc.3] — 2026-06-27
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,8 +29,9 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
-| 2026-06-27 | Fix scoped API-created agents being rejected by `POST /sessions` and `PATCH /sessions/{id}` agent validation because session routes checked primary-agent eligibility without request scope. | Kennel rc.2 Lambda MicroVM smoke report | 4/6 | Completed |
+| 2026-07-10 | Verify Lambda MicroVM teardown before reporting completion and emit token-free lifecycle events/logs for launch, auth token creation, healthchecks, runtime snapshots, and teardown outcomes. | v0.11 rc Lambda MicroVM operator observability follow-up | 3/6/7 | Completed |
 | 2026-07-02 | Fix rc.3 scoped agent execution and Lambda MicroVM quota leaks — session validation/runtime resolution now use effective scope, runtime no longer silently falls back to `default`, completed runs return sessions to `idle`, terminal session cleanup releases sandbox quota, and health counts non-terminal sessions. | Kennel rc.3 production-pilot findings | 3/4/6/7 | Completed |
+| 2026-06-27 | Fix scoped API-created agents being rejected by `POST /sessions` and `PATCH /sessions/{id}` agent validation because session routes checked primary-agent eligibility without request scope. | Kennel rc.2 Lambda MicroVM smoke report | 4/6 | Completed |
 | 2026-03-06 | Fix dead code (duplicate kwargs block) in `llm/registry.py` | - | 5 | Completed |
 | 2026-03-06 | Fix `StorageBackend` protocol — `create_message` missing `tool` role and `tool_call_id`; `MemoryStorageBackend` missing `status`/`agent_name` in `update_session` | - | 2 | Completed |
 | 2026-03-06 | Fix `agent_definition_registry.py` — `.list()` method shadowing builtin `list` type, causing mypy `valid-type` errors; renamed to `.get_all()` | - | 4 | Completed |

--- a/docs/concepts/sandboxes/aws-lambda-microvm/lifecycle-and-observability.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/lifecycle-and-observability.md
@@ -17,10 +17,17 @@ sequenceDiagram
     User->>Cognition: POST /sessions/{id}/messages
     Cognition->>Cognition: run status active
     Cognition->>AWS: RunMicroVM(image, role, connectors)
+    Cognition-->>User: sandbox_lifecycle launch_started
+    AWS-->>Cognition: MicroVM RUNNING
+    Cognition-->>User: sandbox_lifecycle launch_running
     Cognition->>AWS: CreateMicroVMAuthToken(port)
+    Cognition-->>User: sandbox_lifecycle auth_token_created
+    Cognition-->>User: sandbox_lifecycle runtime_healthcheck_started
     Cognition->>Runtime: GET /healthz
+    Cognition-->>User: sandbox_lifecycle runtime_healthcheck_passed
     Cognition->>Runtime: POST /execute
     Runtime-->>Cognition: command result
+    Cognition-->>User: sandbox_lifecycle runtime_snapshot
     Cognition-->>User: run done, session idle
 ```
 
@@ -39,11 +46,34 @@ Cognition releases sandbox resources when the session is:
 - expired
 - otherwise explicitly cleaned up by the backend lifecycle
 
-Successful run completion does not automatically terminate the sandbox.
+Successful run completion does not automatically terminate the sandbox. When
+Cognition releases a Lambda MicroVM sandbox, it calls `TerminateMicrovm`, polls
+`GetMicrovm` for a bounded period, and then emits the observed teardown result.
+Cognition does not run a separate MicroVM controller or expose AWS cleanup
+actions to end users.
 
 ## Lifecycle Events
 
-The backend emits `sandbox_lifecycle` events. Lambda MicroVM metadata includes:
+The backend emits `sandbox_lifecycle` events. Lambda MicroVM phases are:
+
+- `launch_started`
+- `launch_running`
+- `auth_token_created`
+- `runtime_healthcheck_started`
+- `runtime_healthcheck_passed`
+- `runtime_snapshot`
+- `teardown_started`
+- `teardown_complete`
+- `teardown_pending`
+- `teardown_failed`
+
+`teardown_complete` means AWS confirmed `TERMINATED`. `teardown_pending` means
+Cognition requested termination but AWS had not reported a terminal state before
+the bounded poll window ended. It frees Cognition-side quota and is operator
+telemetry, not a user action. `teardown_failed` means the AWS control-plane call
+or verification failed.
+
+Lambda MicroVM metadata includes:
 
 - `microvm_id`
 - `endpoint`
@@ -51,12 +81,17 @@ The backend emits `sandbox_lifecycle` events. Lambda MicroVM metadata includes:
 - `image`
 - `image_version`
 - `status`
+- `aws_state`
 - `region`
 - `port`
 - `maximum_duration_seconds`
 - `logging_mode`
 - `quota`
 - `execution_role_fingerprint`
+- `launch_duration_ms`
+- `healthcheck_duration_ms`
+- `teardown_duration_ms`
+- `teardown_status`
 - `correlation` with session id, run id, agent name, profile, scope keys, and a
   scope fingerprint
 

--- a/docs/concepts/sandboxes/aws-lambda-microvm/troubleshooting.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/troubleshooting.md
@@ -14,6 +14,8 @@ or clean up as expected.
 | `/healthz` fails | Confirm the image starts the runtime command server on the profile `port` |
 | Commands hang | Check runtime server logs, command timeout, and network connector reachability |
 | `SANDBOX_QUOTA_EXCEEDED` | Raise or relax profile `quota`, delete/abort/expire idle sessions, or wait for start history to age out |
+| `teardown_pending` | Cognition requested termination, freed its own quota, and AWS had not yet confirmed `TERMINATED`; inspect `GetMicrovm`, idle policy, and CloudWatch service logs |
+| `teardown_failed` | Inspect `teardown_error_code`, Cognition control-plane IAM permissions, and AWS Lambda MicroVM API errors |
 | CloudWatch cost is high | Disable runtime logging by default or reduce log volume and retention |
 
 ## Debug Checklist
@@ -23,10 +25,14 @@ or clean up as expected.
    role, networking, idle policy, logging, and quota settings.
 3. Confirm the agent has the expected `sandbox_profile` and optional
    `sandbox_execution_role_arn`.
-4. Watch `sandbox_lifecycle` SSE events for `provisioned`,
-   `runtime_snapshot`, and teardown phases.
+4. Watch `sandbox_lifecycle` SSE events for launch, auth token, runtime
+   healthcheck, `runtime_snapshot`, and teardown phases.
 5. Inspect AWS service errors for control-plane permission, image, connector,
    and runtime health failures.
+
+`teardown_pending` is not an end-user remediation step. It is operator telemetry
+that says Cognition stopped waiting after its bounded verification window. AWS
+idle policy and `maximum_duration_seconds` remain the final cleanup backstops.
 
 ## Related
 

--- a/packages/langchain-aws-lambda-microvms/langchain_aws_lambda_microvms/sandbox.py
+++ b/packages/langchain-aws-lambda-microvms/langchain_aws_lambda_microvms/sandbox.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 300
 DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS = 60
+DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 5.0
+DEFAULT_TEARDOWN_POLL_INTERVAL_SECONDS = 1.0
 RUNNING_STATE = "RUNNING"
 SUSPENDED_STATE = "SUSPENDED"
 TERMINATED_STATE = "TERMINATED"
@@ -88,6 +90,8 @@ class LambdaMicroVmSandbox(BaseSandbox):
         sandbox_id: Stable local identifier before AWS returns a MicroVM id.
         launch_timeout_seconds: Maximum time to wait for RUNNING state.
         healthcheck_timeout_seconds: Maximum time to wait for /healthz.
+        teardown_timeout_seconds: Maximum time to wait for TERMINATED state.
+        teardown_poll_interval_seconds: Time between GetMicrovm teardown polls.
         client: Optional prebuilt boto3 lambda-microvms client, for tests.
         client_factory: Optional boto3 client factory, for tests.
         http_client: Optional sync httpx-compatible client, for tests.
@@ -112,6 +116,8 @@ class LambdaMicroVmSandbox(BaseSandbox):
         sandbox_id: str | None = None,
         launch_timeout_seconds: int = 120,
         healthcheck_timeout_seconds: int = DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS,
+        teardown_timeout_seconds: float = DEFAULT_TEARDOWN_TIMEOUT_SECONDS,
+        teardown_poll_interval_seconds: float = DEFAULT_TEARDOWN_POLL_INTERVAL_SECONDS,
         client: Any | None = None,
         client_factory: Callable[..., Any] | None = None,
         http_client: Any | None = None,
@@ -132,6 +138,8 @@ class LambdaMicroVmSandbox(BaseSandbox):
         self._sandbox_id = sandbox_id or f"lambda-microvm-{id(self):x}"
         self._launch_timeout_seconds = launch_timeout_seconds
         self._healthcheck_timeout_seconds = healthcheck_timeout_seconds
+        self._teardown_timeout_seconds = teardown_timeout_seconds
+        self._teardown_poll_interval_seconds = teardown_poll_interval_seconds
         self._client = client
         self._client_factory = client_factory
         self._http_client: Any | None = http_client or httpx.Client()
@@ -145,6 +153,14 @@ class LambdaMicroVmSandbox(BaseSandbox):
         self._created_client_token: str | None = None
         self._image_arn: str | None = None
         self._resolved_image_version: str | None = image_version
+        self._launch_duration_ms: float | None = None
+        self._healthcheck_duration_ms: float | None = None
+        self._teardown_duration_ms: float | None = None
+        self._teardown_status: str | None = None
+        self._teardown_attempt = 0
+        self._teardown_error_code: str | None = None
+        self._teardown_error_message: str | None = None
+        self._lifecycle_phases: list[str] = []
 
     @property
     def id(self) -> str:
@@ -154,12 +170,13 @@ class LambdaMicroVmSandbox(BaseSandbox):
     @property
     def runtime_metadata(self) -> dict[str, Any]:
         """Return token-free runtime metadata suitable for logs or persistence."""
-        return {
+        metadata: dict[str, Any] = {
             "microvm_id": self._microvm_id,
             "endpoint": self._endpoint,
             "image": self._image_arn or self._image_identifier,
             "image_version": self._resolved_image_version,
             "status": self._state,
+            "aws_state": self._state,
             "execution_role_fingerprint": _role_fingerprint(self._execution_role_arn),
             "region": self._region_name,
             "port": self._port,
@@ -168,7 +185,23 @@ class LambdaMicroVmSandbox(BaseSandbox):
             "ingress_network_connector_count": len(self._ingress_network_connector_arns),
             "egress_network_connector_count": len(self._egress_network_connector_arns),
             "logging_mode": self._logging_mode(),
+            "lifecycle_phases": list(self._lifecycle_phases),
         }
+        optional = {
+            "launch_duration_ms": self._launch_duration_ms,
+            "healthcheck_duration_ms": self._healthcheck_duration_ms,
+            "teardown_duration_ms": self._teardown_duration_ms,
+            "teardown_status": self._teardown_status,
+            "teardown_attempt": self._teardown_attempt or None,
+            "teardown_error_code": self._teardown_error_code,
+            "teardown_error_message": self._teardown_error_message,
+        }
+        metadata.update({key: value for key, value in optional.items() if value is not None})
+        return metadata
+
+    def _record_lifecycle_phase(self, phase: str) -> None:
+        if phase not in self._lifecycle_phases:
+            self._lifecycle_phases.append(phase)
 
     def _logging_mode(self) -> str | None:
         if self._logging_config is None:
@@ -264,6 +297,26 @@ class LambdaMicroVmSandbox(BaseSandbox):
             f"Timed out waiting for Lambda MicroVM {self._microvm_id} to enter RUNNING"
         )
 
+    def _wait_for_terminated(self) -> bool:
+        if self._state == TERMINATED_STATE:
+            return True
+
+        if not self._microvm_id:
+            return False
+
+        client = self._get_client()
+        deadline = time.monotonic() + self._teardown_timeout_seconds
+        while True:
+            response = client.get_microvm(microvmIdentifier=self._microvm_id)
+            self._update_state_from_response(response)
+            if self._state == TERMINATED_STATE:
+                return True
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                break
+            time.sleep(min(self._teardown_poll_interval_seconds, remaining_seconds))
+        return False
+
     def _create_auth_headers(self) -> None:
         if not self._microvm_id:
             raise RuntimeError("Cannot create MicroVM auth token before launch")
@@ -280,6 +333,13 @@ class LambdaMicroVmSandbox(BaseSandbox):
             for key, value in token_parts.items()
         }
         self._auth_headers[PORT_HEADER_NAME] = str(self._port)
+        self._record_lifecycle_phase("auth_token_created")
+        logger.info(
+            "Lambda MicroVM auth token created microvm_id=%s port=%s expiration_minutes=%s",
+            self._microvm_id,
+            self._port,
+            self._token_expiration_minutes,
+        )
 
     def _runtime_url(self, path: str) -> str:
         if not self._endpoint:
@@ -314,6 +374,13 @@ class LambdaMicroVmSandbox(BaseSandbox):
         return data
 
     def _healthcheck(self) -> None:
+        started = time.monotonic()
+        self._record_lifecycle_phase("runtime_healthcheck_started")
+        logger.info(
+            "Lambda MicroVM runtime healthcheck started microvm_id=%s port=%s",
+            self._microvm_id,
+            self._port,
+        )
         deadline = time.monotonic() + self._healthcheck_timeout_seconds
         last_error: Exception | None = None
         while time.monotonic() < deadline:
@@ -322,6 +389,13 @@ class LambdaMicroVmSandbox(BaseSandbox):
                 workspace_root = data.get("workspace_root")
                 if isinstance(workspace_root, str) and workspace_root.strip():
                     self._workspace_root = workspace_root.rstrip("/") or self._workspace_root
+                self._healthcheck_duration_ms = (time.monotonic() - started) * 1000
+                self._record_lifecycle_phase("runtime_healthcheck_passed")
+                logger.info(
+                    "Lambda MicroVM runtime healthcheck passed microvm_id=%s duration_ms=%.2f",
+                    self._microvm_id,
+                    self._healthcheck_duration_ms,
+                )
                 return
             except Exception as e:
                 last_error = e
@@ -342,9 +416,32 @@ class LambdaMicroVmSandbox(BaseSandbox):
                 client.resume_microvm(microvmIdentifier=self._microvm_id)
                 self._wait_for_running()
             else:
+                launch_started = time.monotonic()
+                self._record_lifecycle_phase("launch_started")
+                logger.info(
+                    "Lambda MicroVM launch started sandbox_id=%s image=%s "
+                    "image_version=%s region=%s role_fingerprint=%s",
+                    self._sandbox_id,
+                    self._image_identifier,
+                    self._image_version,
+                    self._region_name,
+                    _role_fingerprint(self._execution_role_arn),
+                )
                 response = client.run_microvm(**self._run_request())
                 self._update_state_from_response(response)
                 self._wait_for_running()
+                self._launch_duration_ms = (time.monotonic() - launch_started) * 1000
+                self._record_lifecycle_phase("launch_running")
+                logger.info(
+                    "Lambda MicroVM launch running microvm_id=%s image=%s "
+                    "image_version=%s region=%s aws_state=%s duration_ms=%.2f",
+                    self._microvm_id,
+                    self._image_arn or self._image_identifier,
+                    self._resolved_image_version,
+                    self._region_name,
+                    self._state,
+                    self._launch_duration_ms,
+                )
 
             self._create_auth_headers()
             self._healthcheck()
@@ -355,6 +452,16 @@ class LambdaMicroVmSandbox(BaseSandbox):
                 self._resolved_image_version,
                 _role_fingerprint(self._execution_role_arn),
             )
+
+    def _exception_code(self, exc: Exception) -> str:
+        response = getattr(exc, "response", None)
+        if isinstance(response, Mapping):
+            error = response.get("Error")
+            if isinstance(error, Mapping):
+                code = error.get("Code")
+                if code:
+                    return str(code)
+        return exc.__class__.__name__
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         """Execute a shell command through the MicroVM command server."""
@@ -480,21 +587,64 @@ class LambdaMicroVmSandbox(BaseSandbox):
 
     def terminate(self) -> None:
         """Terminate the Lambda MicroVM and clear in-memory auth material."""
+        started = time.monotonic()
+        self._teardown_attempt += 1
+        self._teardown_error_code = None
+        self._teardown_error_message = None
         try:
-            if self._microvm_id and self._state != TERMINATED_STATE:
-                self._get_client().terminate_microvm(microvmIdentifier=self._microvm_id)
-                logger.info("Lambda MicroVM sandbox terminated microvm_id=%s", self._microvm_id)
-        except Exception:
+            if not self._microvm_id:
+                self._teardown_status = "skipped"
+                return
+
+            if self._state == TERMINATED_STATE:
+                self._teardown_status = "complete"
+                self._record_lifecycle_phase("teardown_complete")
+                return
+
+            self._record_lifecycle_phase("teardown_started")
+            logger.info(
+                "Lambda MicroVM teardown started microvm_id=%s image=%s "
+                "image_version=%s region=%s aws_state=%s role_fingerprint=%s attempt=%s",
+                self._microvm_id,
+                self._image_arn or self._image_identifier,
+                self._resolved_image_version,
+                self._region_name,
+                self._state,
+                _role_fingerprint(self._execution_role_arn),
+                self._teardown_attempt,
+            )
+            self._get_client().terminate_microvm(microvmIdentifier=self._microvm_id)
+            if self._wait_for_terminated():
+                self._teardown_status = "complete"
+                self._record_lifecycle_phase("teardown_complete")
+                logger.info(
+                    "Lambda MicroVM teardown complete microvm_id=%s aws_state=%s",
+                    self._microvm_id,
+                    self._state,
+                )
+            else:
+                self._teardown_status = "pending"
+                self._record_lifecycle_phase("teardown_pending")
+                logger.warning(
+                    "Lambda MicroVM teardown pending microvm_id=%s aws_state=%s",
+                    self._microvm_id,
+                    self._state,
+                )
+        except Exception as exc:
+            self._teardown_status = "failed"
+            self._teardown_error_code = self._exception_code(exc)
+            self._teardown_error_message = str(exc)
+            self._record_lifecycle_phase("teardown_failed")
             logger.warning(
                 "Lambda MicroVM terminate failed microvm_id=%s",
                 self._microvm_id,
                 exc_info=True,
             )
         finally:
+            self._teardown_duration_ms = (time.monotonic() - started) * 1000
             self._auth_headers = None
             self._endpoint = None
             self._created_client_token = None
-            self._state = TERMINATED_STATE if self._microvm_id else self._state
             if self._owns_http_client and self._http_client is not None:
                 self._http_client.close()
                 self._http_client = None

--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -264,7 +264,7 @@ class SandboxLifecycleEvent(AgentEvent):
     """
 
     sandbox_id: str
-    phase: str  # provisioned, verified, teardown_started, teardown_complete
+    phase: str  # provisioned, runtime_snapshot, launch_*, healthcheck_*, teardown_*
     sandbox_backend: str  # local, docker, kubernetes, aws_lambda_microvm
     duration_ms: float | None = None
     exit_code: int | None = None

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -357,6 +357,7 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
             "image": profile.image_arn,
             "image_version": profile.image_version,
             "status": None,
+            "aws_state": None,
             "execution_role_fingerprint": _role_fingerprint(self.execution_role_arn),
             "region": profile.region,
             "port": profile.port,
@@ -560,12 +561,36 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
                     self._last_runtime_metadata = cast(
                         dict[str, Any], self._backend.runtime_metadata
                     )
-                logger.info(
-                    "AWS Lambda MicroVM sandbox terminated",
-                    sandbox_id=self._id,
-                    profile=self._profile,
-                )
+                log_args = {
+                    "sandbox_id": self._id,
+                    "profile": self._profile,
+                    "microvm_id": self._last_runtime_metadata.get("microvm_id"),
+                    "image": self._last_runtime_metadata.get("image"),
+                    "image_version": self._last_runtime_metadata.get("image_version"),
+                    "region": self._last_runtime_metadata.get("region"),
+                    "aws_state": self._last_runtime_metadata.get("aws_state"),
+                    "teardown_status": self._last_runtime_metadata.get("teardown_status"),
+                    "teardown_attempt": self._last_runtime_metadata.get("teardown_attempt"),
+                    "execution_role_fingerprint": self._last_runtime_metadata.get(
+                        "execution_role_fingerprint"
+                    ),
+                }
+                if log_args["teardown_status"] in {"pending", "failed"}:
+                    logger.warning("AWS Lambda MicroVM sandbox teardown incomplete", **log_args)
+                else:
+                    logger.info("AWS Lambda MicroVM sandbox teardown finished", **log_args)
             except Exception as e:
+                if hasattr(self._backend, "runtime_metadata"):
+                    self._last_runtime_metadata = cast(
+                        dict[str, Any], self._backend.runtime_metadata
+                    )
+                self._last_runtime_metadata.update(
+                    {
+                        "teardown_status": "failed",
+                        "teardown_error_code": e.__class__.__name__,
+                        "teardown_error_message": str(e),
+                    }
+                )
                 logger.warning("AWS Lambda MicroVM sandbox terminate failed", error=str(e))
             finally:
                 self._backend = None

--- a/server/app/api/routes/messages.py
+++ b/server/app/api/routes/messages.py
@@ -567,8 +567,9 @@ async def agent_event_stream(
                 yield sse
 
             elif isinstance(event, DoneEvent):
-                sandbox_snapshot = agent_manager.snapshot_sandbox_backend(session_id)
-                if sandbox_snapshot is not None:
+                for sandbox_snapshot in agent_manager.snapshot_sandbox_backend_events(
+                    session_id
+                ):
                     yield await _sandbox_lifecycle_sse(
                         sandbox_snapshot,
                         projection=projection,

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -531,6 +531,12 @@ class DeepAgentStreamingService:
 
                         elif isinstance(event, ToolResultEvent):
                             acc.set_tool_call(None)
+                            if manager:
+                                for sandbox_event in manager.snapshot_sandbox_backend_events(
+                                    session_id,
+                                    include_runtime_snapshot=False,
+                                ):
+                                    yield sandbox_event
                             yield event
 
                         elif isinstance(event, PlanningEvent) or isinstance(
@@ -716,6 +722,8 @@ class DeepAgentStreamingService:
                 mcp_configs=mcp_configs or None,
                 scope=effective_scope,
                 config_store=self._get_config_store(),
+                sandbox_profile=agent_cfg.sandbox_profile,
+                sandbox_execution_role_arn=agent_cfg.sandbox_execution_role_arn,
             )
             agent = await create_cognition_agent(agent_params)
 
@@ -920,6 +928,7 @@ class SessionAgentManager:
         self._sandbox_events: dict[str, asyncio.Queue[SandboxLifecycleEvent]] = {}
         self._sandbox_correlations: dict[str, dict[str, Any]] = {}
         self._sandbox_start_history: dict[str, deque[float]] = {}
+        self._sandbox_emitted_lifecycle_phases: dict[str, set[str]] = {}
         self._sandbox_backend_type: str = settings.sandbox_backend
 
     def register_session(
@@ -1072,6 +1081,7 @@ class SessionAgentManager:
                 metadata=self._sandbox_runtime_metadata(backend, session_id=session_id),
             ),
         )
+        self._sandbox_emitted_lifecycle_phases.setdefault(session_id, set()).add("provisioned")
         logger.debug("Sandbox backend registered", session_id=session_id)
 
     def _sandbox_correlation(
@@ -1170,11 +1180,98 @@ class SessionAgentManager:
             metadata=metadata,
         )
 
+    def snapshot_sandbox_backend_events(
+        self,
+        session_id: str,
+        *,
+        include_runtime_snapshot: bool = True,
+    ) -> list[SandboxLifecycleEvent]:
+        """Build lifecycle events for newly observed backend phases."""
+        backend = self._sandbox_backends.get(session_id)
+        if backend is None:
+            return []
+        metadata = self._sandbox_runtime_metadata(backend, session_id=session_id)
+        if not metadata:
+            return []
+
+        sandbox_id = getattr(backend, "id", str(id(backend)))
+        emitted = self._sandbox_emitted_lifecycle_phases.setdefault(session_id, set())
+        events: list[SandboxLifecycleEvent] = []
+        lifecycle_phases = metadata.get("lifecycle_phases")
+        if isinstance(lifecycle_phases, list):
+            for raw_phase in lifecycle_phases:
+                phase = str(raw_phase)
+                if phase in emitted:
+                    continue
+                emitted.add(phase)
+                event = SandboxLifecycleEvent(
+                    sandbox_id=sandbox_id,
+                    phase=phase,
+                    sandbox_backend=self._sandbox_backend_type,
+                    metadata=metadata,
+                )
+                self._log_sandbox_lifecycle_event(event)
+                events.append(event)
+
+        if include_runtime_snapshot:
+            event = SandboxLifecycleEvent(
+                sandbox_id=sandbox_id,
+                phase="runtime_snapshot",
+                sandbox_backend=self._sandbox_backend_type,
+                metadata=metadata,
+            )
+            self._log_sandbox_lifecycle_event(event)
+            events.append(event)
+        return events
+
+    def _teardown_phase_from_metadata(self, metadata: Mapping[str, Any]) -> str:
+        teardown_status = metadata.get("teardown_status")
+        if teardown_status == "pending":
+            return "teardown_pending"
+        if teardown_status == "failed":
+            return "teardown_failed"
+        if teardown_status in {"complete", "skipped"}:
+            return "teardown_complete"
+        aws_state = metadata.get("aws_state") or metadata.get("status")
+        if aws_state == "TERMINATED":
+            return "teardown_complete"
+        return "teardown_complete"
+
+    def _log_sandbox_lifecycle_event(self, event: SandboxLifecycleEvent) -> None:
+        metadata = event.metadata or {}
+        correlation = metadata.get("correlation")
+        if not isinstance(correlation, Mapping):
+            correlation = {}
+        fields = {
+            "session_id": correlation.get("session_id"),
+            "run_id": correlation.get("run_id"),
+            "agent_name": correlation.get("agent_name"),
+            "sandbox_profile": metadata.get("profile") or correlation.get("profile"),
+            "sandbox_backend": event.sandbox_backend,
+            "sandbox_id": event.sandbox_id,
+            "microvm_id": metadata.get("microvm_id"),
+            "image": metadata.get("image"),
+            "image_version": metadata.get("image_version"),
+            "region": metadata.get("region"),
+            "aws_state": metadata.get("aws_state") or metadata.get("status"),
+            "execution_role_fingerprint": metadata.get("execution_role_fingerprint"),
+            "scope_fingerprint": correlation.get("scope_fingerprint"),
+            "teardown_status": metadata.get("teardown_status"),
+            "teardown_attempt": metadata.get("teardown_attempt"),
+            "teardown_error_code": metadata.get("teardown_error_code"),
+        }
+        fields = {key: value for key, value in fields.items() if value is not None}
+        if event.phase in {"teardown_pending", "teardown_failed"}:
+            logger.warning("Sandbox lifecycle event", phase=event.phase, **fields)
+        else:
+            logger.info("Sandbox lifecycle event", phase=event.phase, **fields)
+
     def release_sandbox_backend(self, session_id: str) -> None:
         """Release only the sandbox backend and quota state for a session."""
         backend = self._sandbox_backends.pop(session_id, None)
         if backend is None:
             self._sandbox_correlations.pop(session_id, None)
+            self._sandbox_emitted_lifecycle_phases.pop(session_id, None)
             logger.debug("Sandbox backend release skipped", session_id=session_id)
             return
 
@@ -1188,28 +1285,47 @@ class SessionAgentManager:
                 metadata=self._sandbox_runtime_metadata(backend, session_id=session_id),
             ),
         )
+        self._sandbox_emitted_lifecycle_phases.setdefault(session_id, set()).add(
+            "teardown_started"
+        )
         if hasattr(backend, "terminate"):
             try:
                 backend.terminate()
+                metadata = self._sandbox_runtime_metadata(
+                    backend,
+                    session_id=session_id,
+                )
+                phase = self._teardown_phase_from_metadata(metadata)
                 self._emit_sandbox_event(
                     session_id,
                     SandboxLifecycleEvent(
                         sandbox_id=sandbox_id,
-                        phase="teardown_complete",
+                        phase=phase,
                         sandbox_backend=self._sandbox_backend_type,
-                        metadata=self._sandbox_runtime_metadata(
-                            backend,
-                            session_id=session_id,
-                        ),
+                        metadata=metadata,
                     ),
                 )
-                logger.info("Sandbox backend terminated", session_id=session_id)
+                logger.info("Sandbox backend released", session_id=session_id, phase=phase)
             except Exception as e:
+                metadata = self._sandbox_runtime_metadata(backend, session_id=session_id)
+                metadata["teardown_status"] = "failed"
+                metadata["teardown_error_code"] = e.__class__.__name__
+                metadata["teardown_error_message"] = str(e)
+                self._emit_sandbox_event(
+                    session_id,
+                    SandboxLifecycleEvent(
+                        sandbox_id=sandbox_id,
+                        phase="teardown_failed",
+                        sandbox_backend=self._sandbox_backend_type,
+                        metadata=metadata,
+                    ),
+                )
                 logger.warning(
                     "Sandbox backend terminate failed", session_id=session_id, error=str(e)
                 )
 
         self._sandbox_correlations.pop(session_id, None)
+        self._sandbox_emitted_lifecycle_phases.pop(session_id, None)
 
     def unregister_session(self, session_id: str) -> None:
         """Unregister a session and clean up resources."""
@@ -1219,6 +1335,7 @@ class SessionAgentManager:
 
         self.release_sandbox_backend(session_id)
         self._sandbox_events.pop(session_id, None)
+        self._sandbox_emitted_lifecycle_phases.pop(session_id, None)
         logger.info("Session unregistered", session_id=session_id)
 
     def _emit_sandbox_event(self, session_id: str, event: SandboxLifecycleEvent) -> None:
@@ -1227,6 +1344,7 @@ class SessionAgentManager:
             self._sandbox_events[session_id] = asyncio.Queue(maxsize=20)
         try:
             self._sandbox_events[session_id].put_nowait(event)
+            self._log_sandbox_lifecycle_event(event)
         except asyncio.QueueFull:
             pass
 

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.11.0-rc.3"
+VERSION = "0.11.0-rc.5"
 
 __all__ = ["VERSION"]

--- a/tests/unit/api/test_message_runtime_persistence.py
+++ b/tests/unit/api/test_message_runtime_persistence.py
@@ -89,6 +89,19 @@ class _FakeAgentManager:
             self._sandbox_snapshot.phase = phase
         return self._sandbox_snapshot
 
+    def snapshot_sandbox_backend_events(
+        self,
+        _session_id: str,
+        *,
+        include_runtime_snapshot: bool = True,
+    ) -> list[Any]:
+        if not include_runtime_snapshot:
+            return []
+        if self._sandbox_snapshot is None:
+            return []
+        self._sandbox_snapshot.phase = "runtime_snapshot"
+        return [self._sandbox_snapshot]
+
     def active_runtime_count(self, _session_id: str) -> int:
         return self._active_runtime_count
 

--- a/tests/unit/test_aws_lambda_microvm_sandbox.py
+++ b/tests/unit/test_aws_lambda_microvm_sandbox.py
@@ -33,6 +33,8 @@ class FakeLambdaMicroVmsClient:
         self.run_kwargs: dict[str, Any] | None = None
         self.auth_kwargs: dict[str, Any] | None = None
         self.terminated: list[str] = []
+        self.get_states: list[str] = []
+        self.terminate_error: Exception | None = None
 
     def run_microvm(self, **kwargs: Any) -> dict[str, Any]:
         self.run_kwargs = kwargs
@@ -48,9 +50,15 @@ class FakeLambdaMicroVmsClient:
 
     def get_microvm(self, **kwargs: Any) -> dict[str, Any]:
         microvm_identifier = str(kwargs["microvmIdentifier"])
+        if self.get_states:
+            state = self.get_states.pop(0)
+        elif microvm_identifier in self.terminated:
+            state = "TERMINATED"
+        else:
+            state = "RUNNING"
         return {
             "microvmId": microvm_identifier,
-            "state": "RUNNING",
+            "state": state,
             "endpoint": "mv-123.lambda-url.aws",
             "imageArn": IMAGE_ARN,
             "imageVersion": "1.0",
@@ -66,6 +74,8 @@ class FakeLambdaMicroVmsClient:
         del kwargs
 
     def terminate_microvm(self, **kwargs: Any) -> None:
+        if self.terminate_error is not None:
+            raise self.terminate_error
         self.terminated.append(str(kwargs["microvmIdentifier"]))
 
 
@@ -205,6 +215,16 @@ class TestLambdaMicroVmSandboxAdapter:
         assert metadata["maximum_duration_seconds"] == 3600
         assert metadata["token_expiration_minutes"] == 17
         assert metadata["logging_mode"] == "cloud_watch"
+        assert metadata["aws_state"] == "RUNNING"
+        assert metadata["launch_duration_ms"] >= 0
+        assert metadata["healthcheck_duration_ms"] >= 0
+        assert metadata["lifecycle_phases"] == [
+            "launch_started",
+            "launch_running",
+            "auth_token_created",
+            "runtime_healthcheck_started",
+            "runtime_healthcheck_passed",
+        ]
 
         execute_request = http_client.requests[-1]
         assert execute_request["url"] == "https://mv-123.lambda-url.aws/execute"
@@ -213,6 +233,20 @@ class TestLambdaMicroVmSandboxAdapter:
         assert execute_request["json"]["command"] == ["sh", "-c", "echo hello"]
         assert execute_request["json"]["timeout_seconds"] == 12
         assert "secret-token" not in str(sandbox.runtime_metadata)
+
+    def test_execute_omits_execution_role_when_not_configured(self) -> None:
+        client = FakeLambdaMicroVmsClient()
+        http_client = FakeHttpClient()
+        sandbox = LambdaMicroVmSandbox(
+            image_identifier=IMAGE_ARN,
+            client=client,
+            http_client=http_client,
+        )
+
+        sandbox.execute("echo hello")
+
+        assert client.run_kwargs is not None
+        assert "executionRoleArn" not in client.run_kwargs
 
     def test_upload_and_download_workspace_paths_use_runtime_file_routes(self) -> None:
         client = FakeLambdaMicroVmsClient()
@@ -244,7 +278,73 @@ class TestLambdaMicroVmSandboxAdapter:
 
         assert client.terminated == ["mv-123"]
         assert sandbox.runtime_metadata["status"] == "TERMINATED"
+        assert sandbox.runtime_metadata["aws_state"] == "TERMINATED"
+        assert sandbox.runtime_metadata["teardown_status"] == "complete"
+        assert sandbox.runtime_metadata["teardown_attempt"] == 1
+        assert sandbox.runtime_metadata["teardown_duration_ms"] >= 0
+        assert "teardown_error_code" not in sandbox.runtime_metadata
         assert "secret-token" not in str(sandbox.runtime_metadata)
+
+    def test_terminate_reports_pending_when_aws_does_not_confirm_terminal(self) -> None:
+        client = FakeLambdaMicroVmsClient()
+        client.get_states = ["RUNNING"]
+        http_client = FakeHttpClient()
+        sandbox = LambdaMicroVmSandbox(
+            image_identifier=IMAGE_ARN,
+            client=client,
+            http_client=http_client,
+            teardown_timeout_seconds=0,
+            teardown_poll_interval_seconds=0,
+        )
+
+        sandbox.execute("true")
+        sandbox.terminate()
+
+        assert client.terminated == ["mv-123"]
+        assert sandbox.runtime_metadata["status"] == "RUNNING"
+        assert sandbox.runtime_metadata["aws_state"] == "RUNNING"
+        assert sandbox.runtime_metadata["teardown_status"] == "pending"
+        assert "teardown_pending" in sandbox.runtime_metadata["lifecycle_phases"]
+        assert "secret-token" not in str(sandbox.runtime_metadata)
+
+    def test_terminate_reports_failed_on_control_plane_error(self) -> None:
+        client = FakeLambdaMicroVmsClient()
+        client.terminate_error = RuntimeError("boom")
+        http_client = FakeHttpClient()
+        sandbox = LambdaMicroVmSandbox(
+            image_identifier=IMAGE_ARN,
+            client=client,
+            http_client=http_client,
+        )
+
+        sandbox.execute("true")
+        sandbox.terminate()
+
+        assert client.terminated == []
+        assert sandbox.runtime_metadata["status"] == "RUNNING"
+        assert sandbox.runtime_metadata["teardown_status"] == "failed"
+        assert sandbox.runtime_metadata["teardown_error_code"] == "RuntimeError"
+        assert sandbox.runtime_metadata["teardown_error_message"] == "boom"
+        assert "teardown_failed" in sandbox.runtime_metadata["lifecycle_phases"]
+        assert "secret-token" not in str(sandbox.runtime_metadata)
+
+    def test_terminate_is_idempotent_after_verified_terminal_state(self) -> None:
+        client = FakeLambdaMicroVmsClient()
+        http_client = FakeHttpClient()
+        sandbox = LambdaMicroVmSandbox(
+            image_identifier=IMAGE_ARN,
+            client=client,
+            http_client=http_client,
+        )
+
+        sandbox.execute("true")
+        sandbox.terminate()
+        sandbox.terminate()
+
+        assert client.terminated == ["mv-123"]
+        assert sandbox.runtime_metadata["status"] == "TERMINATED"
+        assert sandbox.runtime_metadata["teardown_status"] == "complete"
+        assert sandbox.runtime_metadata["teardown_attempt"] == 2
 
 
 class TestCognitionAwsLambdaMicroVmSandboxBackend:

--- a/tests/unit/test_sandbox_lifecycle_quotas.py
+++ b/tests/unit/test_sandbox_lifecycle_quotas.py
@@ -31,12 +31,19 @@ class FakeSandboxBackend:
         sandbox_id: str,
         profile: str = "lambda-default",
         quota: LambdaMicroVmQuota | None = None,
+        lifecycle_phases: list[str] | None = None,
+        teardown_status: str = "complete",
+        raise_on_terminate: Exception | None = None,
     ) -> None:
         self.id = sandbox_id
         self.profile = profile
         self.quota = quota
         self.terminated = False
         self.terminate_calls = 0
+        self.lifecycle_phases = lifecycle_phases or []
+        self.teardown_status = teardown_status
+        self.raise_on_terminate = raise_on_terminate
+        self.status = "RUNNING"
 
     @property
     def runtime_metadata(self) -> dict[str, Any]:
@@ -44,12 +51,21 @@ class FakeSandboxBackend:
             "backend": "aws_lambda_microvm",
             "profile": self.profile,
             "microvm_id": self.id,
-            "status": "RUNNING",
+            "status": self.status,
+            "aws_state": self.status,
+            "lifecycle_phases": list(self.lifecycle_phases),
+            "teardown_status": self.teardown_status if self.terminated else None,
         }
 
     def terminate(self) -> None:
         self.terminate_calls += 1
+        if self.raise_on_terminate is not None:
+            raise self.raise_on_terminate
         self.terminated = True
+        if self.teardown_status == "complete":
+            self.status = "TERMINATED"
+        elif self.teardown_status == "pending":
+            self.status = "RUNNING"
 
 
 def _manager() -> SessionAgentManager:
@@ -160,6 +176,85 @@ def test_release_sandbox_backend_frees_concurrent_quota_and_is_idempotent() -> N
     )
 
     assert second.terminated is False
+
+
+def test_release_sandbox_backend_pending_teardown_frees_concurrent_quota() -> None:
+    manager = _manager()
+    quota = LambdaMicroVmQuota(max_concurrent_sessions=1)
+    first = FakeSandboxBackend(
+        sandbox_id="microvm-1",
+        quota=quota,
+        teardown_status="pending",
+    )
+
+    manager.register_sandbox_backend(
+        "session-1",
+        first,
+        scope={"tenant": "acme"},
+    )
+    manager.release_sandbox_backend("session-1")
+
+    phases = [event.phase for event in manager.drain_sandbox_events("session-1")]
+    assert phases == ["provisioned", "teardown_started", "teardown_pending"]
+
+    second = FakeSandboxBackend(sandbox_id="microvm-2", quota=quota)
+    manager.register_sandbox_backend(
+        "session-2",
+        second,
+        scope={"tenant": "acme"},
+    )
+
+    assert first.terminated is True
+    assert second.terminated is False
+
+
+def test_release_sandbox_backend_failed_teardown_emits_failure_event() -> None:
+    manager = _manager()
+    backend = FakeSandboxBackend(
+        sandbox_id="microvm-1",
+        raise_on_terminate=RuntimeError("control plane failed"),
+    )
+
+    manager.register_sandbox_backend("session-1", backend, scope={"tenant": "acme"})
+    manager.release_sandbox_backend("session-1")
+
+    events = manager.drain_sandbox_events("session-1")
+    assert [event.phase for event in events] == [
+        "provisioned",
+        "teardown_started",
+        "teardown_failed",
+    ]
+    assert events[-1].metadata["teardown_status"] == "failed"
+    assert events[-1].metadata["teardown_error_code"] == "RuntimeError"
+
+
+def test_snapshot_sandbox_backend_events_emits_new_microvm_phases_once() -> None:
+    manager = _manager()
+    backend = FakeSandboxBackend(
+        sandbox_id="microvm-1",
+        lifecycle_phases=[
+            "launch_started",
+            "launch_running",
+            "auth_token_created",
+            "runtime_healthcheck_started",
+            "runtime_healthcheck_passed",
+        ],
+    )
+
+    manager.register_sandbox_backend("session-1", backend, scope={"tenant": "acme"})
+
+    first = manager.snapshot_sandbox_backend_events("session-1")
+    second = manager.snapshot_sandbox_backend_events("session-1")
+
+    assert [event.phase for event in first] == [
+        "launch_started",
+        "launch_running",
+        "auth_token_created",
+        "runtime_healthcheck_started",
+        "runtime_healthcheck_passed",
+        "runtime_snapshot",
+    ]
+    assert [event.phase for event in second] == ["runtime_snapshot"]
 
 
 def test_release_sandbox_backend_preserves_start_rate_history() -> None:


### PR DESCRIPTION
## Summary

- verifies Lambda MicroVM teardown before reporting completion
- emits token-free launch/auth/healthcheck/runtime/teardown lifecycle phases
- reports teardown_complete, teardown_pending, or teardown_failed based on adapter metadata
- frees Cognition-side quota even when teardown is pending
- prepares 0.11.0-rc.5 source metadata for the next pre-release image

## Validation

- PYTHONPATH=/tmp/cognition-microvm-teardown-pr UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_aws_lambda_microvm_sandbox.py tests/unit/test_sandbox_lifecycle_quotas.py tests/unit/api/test_message_runtime_persistence.py -q
- PYTHONPATH=/tmp/cognition-microvm-teardown-pr UV_CACHE_DIR=/tmp/uv-cache uv run ruff check packages/langchain-aws-lambda-microvms server/app tests/unit
- PYTHONPATH=/tmp/cognition-microvm-teardown-pr UV_CACHE_DIR=/tmp/uv-cache uv run mkdocs build --strict
- PYTHONPATH=/tmp/cognition-microvm-teardown-pr UV_CACHE_DIR=/tmp/uv-cache uv run mypy .
- git diff --check

## Notes

After this PR is merged, run the pre-release image workflow for version 0.11.0 with prerelease tag rc5, then deploy ghcr.io/cognicellai/cognition:0.11.0-rc5 into the local k3d Lambda MicroVM test environment.