### PR TITLE
docs: add default Lambda MicroVM runtime image example

### DIFF
--- a/docs/concepts/sandboxes/aws-lambda-microvm/default-runtime-image.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/default-runtime-image.md
@@ -1,0 +1,88 @@
+# Lambda MicroVM Default Runtime Image
+
+Cognition provides a default Lambda MicroVM runtime source example for builders
+who need a starting image for the `aws_lambda_microvm` sandbox backend.
+
+This is similar in purpose to the `cognition-sandbox` container image, but AWS
+Lambda MicroVMs use builder-owned image resources. Cognition provides runtime
+source; the builder packages it, creates the image in their AWS account, and
+uses the resulting image ARN in a `SandboxProfile`.
+
+## Build Flow
+
+```mermaid
+flowchart LR
+    Source["Runtime source files"] --> Zip["Source zip"]
+    Zip --> S3["Builder S3 artifact"]
+    S3 --> Image["CreateMicrovmImage / awscc_lambda_microvm_image"]
+    Image --> Arn["Builder-owned image ARN"]
+    Arn --> Profile["Cognition SandboxProfile"]
+```
+
+The example at
+[`examples/aws-lambda-microvm-default-runtime`](https://github.com/CognicellAI/Cognition/tree/main/examples/aws-lambda-microvm-default-runtime)
+contains the runtime source, packaging script, and Terraform.
+
+## Zipped Runtime Files
+
+The runtime zip contains only files needed by AWS to build the MicroVM image.
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Builds the MicroVM application layer, installs baseline tools, creates `/workspace`, and starts the command server. |
+| `server.py` | Implements `/healthz`, `/execute`, `/upload`, `/download`, and lifecycle hook acknowledgements. |
+| `README.md` | Documents the runtime source for builders. It is included for inspection and is not used by Cognition at runtime. |
+
+The source files are intentionally commented so builders can inspect, fork, and
+harden the runtime before building their own image.
+
+## Terraform Outputs
+
+After packaging the runtime and applying the example Terraform, builders use:
+
+```bash
+terraform output microvm_image_arn
+terraform output microvm_image_version
+terraform output -raw sandbox_profiles_yaml
+```
+
+The generated YAML can be copied into `.cognition/config.yaml` or registered
+with `/sandbox/profiles`.
+
+## Builder Ownership
+
+Cognition does not create or mutate Lambda MicroVM images at runtime. Builders
+own:
+
+- the artifact bucket used for image source zips
+- the image build role
+- the Lambda MicroVM image ARN and versions
+- runtime dependency patching and security hardening
+- any extra CLIs, language runtimes, or observability agents in the image
+
+Cognition owns consuming the image ARN, launching MicroVMs from the selected
+profile, creating in-memory proxy auth tokens, and emitting token-free lifecycle
+metadata.
+
+## Runtime Contract
+
+The default runtime listens on port `8080` and uses `/workspace` as the writable
+workspace root. It exposes:
+
+- `GET /healthz`
+- `POST /execute`
+- `POST /upload`
+- `GET` and `POST /download`
+- AWS Lambda MicroVM lifecycle hook endpoints
+
+The command server has no application-level public auth. Cognition reaches it
+through the AWS Lambda MicroVM proxy with short-lived proxy auth tokens.
+
+## Related
+
+- [Setup](./setup.md)
+- [Runtime Command Server](./runtime-command-server.md)
+- [Sandbox Profiles](./profiles.md)
+- [Troubleshooting](./troubleshooting.md)
+- [AWS MicroVM images](https://docs.aws.amazon.com/lambda/latest/dg/microvms-images.html)
+- [CreateMicrovmImage API](https://docs.aws.amazon.com/lambda/latest/microvm-api/API_CreateMicrovmImage.html)

--- a/docs/concepts/sandboxes/aws-lambda-microvm/index.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/index.md
@@ -6,7 +6,8 @@ execution roles, and profile-controlled networking without running Docker or
 Kubernetes sandbox infrastructure yourself.
 
 Cognition consumes prebuilt Lambda MicroVM image ARNs. It does not build,
-publish, or mutate MicroVM images.
+publish, or mutate MicroVM images at runtime. Builders who need a starting image
+can build one from Cognition's [default runtime image source](./default-runtime-image.md).
 
 ## Architecture
 
@@ -46,6 +47,7 @@ deleted, aborted, failed, expired, or released by backend policy.
 ## Start Here
 
 - [Setup](./setup.md)
+- [Default Runtime Image](./default-runtime-image.md)
 - [Sandbox Profiles](./profiles.md)
 - [IAM and Networking](./iam-and-networking.md)
 - [Runtime Command Server](./runtime-command-server.md)

--- a/docs/concepts/sandboxes/aws-lambda-microvm/profiles.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/profiles.md
@@ -36,8 +36,10 @@ V1 profiles consume prebuilt Lambda MicroVM image ARNs:
 image_arn: arn:aws:lambda:us-west-2:123456789012:microvm-image:cognition-runtime
 ```
 
-Cognition does not create or update images. Builders own image contents,
-publishing, patching, and runtime command server compatibility.
+Cognition does not create or update images at runtime. Builders own image
+contents, publishing, patching, and runtime command server compatibility. If you
+need a starter image, use the [default runtime image](./default-runtime-image.md)
+example to create a builder-owned image ARN.
 
 ## Cost-Sensitive Settings
 
@@ -66,5 +68,6 @@ no longer need so concurrent-session quota is released.
 ## Related
 
 - [Setup](./setup.md)
+- [Default Runtime Image](./default-runtime-image.md)
 - [Lifecycle and Observability](./lifecycle-and-observability.md)
 - [API Reference](../../../guides/api-reference.md#sandbox-profiles)

--- a/docs/concepts/sandboxes/aws-lambda-microvm/runtime-command-server.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/runtime-command-server.md
@@ -16,6 +16,10 @@ the MicroVM and issues a proxy auth token.
 
 The server should listen on the `SandboxProfile.port`, usually `8080`.
 
+Builders who need a ready starting point can use the
+[default runtime image](./default-runtime-image.md) example. Its zipped runtime
+source includes a commented `Dockerfile`, `server.py`, and runtime `README.md`.
+
 ## Auth Boundary
 
 The command server does not need its own application-level public auth when it
@@ -51,5 +55,6 @@ and reject path traversal outside the workspace.
 ## Related
 
 - [Setup](./setup.md)
+- [Default Runtime Image](./default-runtime-image.md)
 - [IAM and Networking](./iam-and-networking.md)
 - [Lifecycle and Observability](./lifecycle-and-observability.md)

--- a/docs/concepts/sandboxes/aws-lambda-microvm/setup.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/setup.md
@@ -13,6 +13,10 @@ You need:
 - at least one IAM execution role for sandboxed agent work
 - optional Lambda Network Connector ARNs for VPC egress
 
+If you do not already have a Lambda MicroVM image, start with the
+[default runtime image](./default-runtime-image.md) example. It creates a
+builder-owned image ARN from Cognition's commented runtime source files.
+
 The Terraform example in
 [`examples/aws-lambda-microvm-sandbox`](https://github.com/CognicellAI/Cognition/tree/main/examples/aws-lambda-microvm-sandbox)
 creates IAM roles, an optional VPC egress connector, and Cognition-ready
@@ -110,5 +114,6 @@ include auth tokens.
 ## Related
 
 - [Sandbox Profiles](./profiles.md)
+- [Default Runtime Image](./default-runtime-image.md)
 - [IAM and Networking](./iam-and-networking.md)
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/concepts/sandboxes/aws-lambda-microvm/troubleshooting.md
+++ b/docs/concepts/sandboxes/aws-lambda-microvm/troubleshooting.md
@@ -12,6 +12,7 @@ or clean up as expected.
 | `AccessDenied` on `iam:PassRole` | Add the agent execution role ARN to the allowed role list |
 | Auth token creation fails | Allow `lambda:CreateMicroVMAuthToken` for approved MicroVM and image resources |
 | `/healthz` fails | Confirm the image starts the runtime command server on the profile `port` |
+| Image creation fails | Rebuild the default runtime zip, confirm the S3 artifact exists, and inspect the Lambda MicroVM image build logs |
 | Commands hang | Check runtime server logs, command timeout, and network connector reachability |
 | `SANDBOX_QUOTA_EXCEEDED` | Raise or relax profile `quota`, delete/abort/expire idle sessions, or wait for start history to age out |
 | `teardown_pending` | Cognition requested termination, freed its own quota, and AWS had not yet confirmed `TERMINATED`; inspect `GetMicrovm`, idle policy, and CloudWatch service logs |
@@ -37,5 +38,6 @@ idle policy and `maximum_duration_seconds` remain the final cleanup backstops.
 ## Related
 
 - [Setup](./setup.md)
+- [Default Runtime Image](./default-runtime-image.md)
 - [IAM and Networking](./iam-and-networking.md)
 - [Runtime Command Server](./runtime-command-server.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,8 @@ These examples are intentionally split by purpose:
 - `aws-lambda-microvm-sandbox/`: AWS Lambda MicroVM sandbox prerequisites,
   Cognition profile config, and reusable Terraform for consuming a prebuilt
   MicroVM image ARN.
+- `aws-lambda-microvm-default-runtime/`: commented default runtime source and
+  Terraform for creating a builder-owned Lambda MicroVM image ARN.
 - `scoped-multi-tenant/`: scoping and multi-tenant configuration example.
 - `a2a-exposed-agent/`: A2A protocol exposure for agent-to-agent interoperability.
 

--- a/examples/aws-lambda-microvm-default-runtime/.gitignore
+++ b/examples/aws-lambda-microvm-default-runtime/.gitignore
@@ -1,0 +1,6 @@
+dist/
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.*
+terraform/terraform.tfvars

--- a/examples/aws-lambda-microvm-default-runtime/README.md
+++ b/examples/aws-lambda-microvm-default-runtime/README.md
@@ -1,0 +1,131 @@
+# AWS Lambda MicroVM Default Runtime
+
+This example builds a builder-owned AWS Lambda MicroVM image from Cognition's
+default runtime source. Use it when you need a starting image for the
+`aws_lambda_microvm` sandbox backend.
+
+The output is a Lambda MicroVM image ARN in your AWS account. Cognition then
+uses that ARN from a `SandboxProfile`.
+
+## What This Example Provides
+
+- commented runtime image source under `runtime/`
+- a packaging script that creates the AWS source zip
+- Terraform that uploads the zip to S3 and creates the MicroVM image
+- `sandbox_profiles_yaml` output for direct Cognition configuration
+
+This is the Lambda MicroVM equivalent of a default `cognition-sandbox` image,
+but the final AWS image is owned by the builder account.
+
+## Prerequisites
+
+You need:
+
+- Terraform `>= 1.5`
+- AWS provider credentials with IAM, S3, CloudWatch Logs, and Lambda MicroVM
+  image permissions
+- an AWS region where Lambda MicroVMs are available
+- `zip` available locally
+
+The AWS identity running Terraform must be able to create the image build role,
+upload the source artifact, and call the Lambda MicroVM image APIs.
+
+## Build The Runtime Source Zip
+
+```bash
+cd examples/aws-lambda-microvm-default-runtime
+./scripts/package-runtime.sh
+```
+
+This creates:
+
+```text
+dist/cognition-lambda-microvm-runtime.zip
+```
+
+The zip contains only the files Lambda needs to build the image:
+
+- `Dockerfile`
+- `server.py`
+- `README.md`
+
+## Create The MicroVM Image
+
+Copy the example variables:
+
+```bash
+cd examples/aws-lambda-microvm-default-runtime/terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` for your account and region, then run:
+
+```bash
+terraform init
+terraform validate
+terraform plan
+terraform apply
+```
+
+After apply, get the image outputs:
+
+```bash
+terraform output microvm_image_arn
+terraform output microvm_image_version
+terraform output -raw sandbox_profiles_yaml
+```
+
+Copy `sandbox_profiles_yaml` into `.cognition/config.yaml` or register it with
+`POST /sandbox/profiles`.
+
+## Use With Cognition
+
+The generated profile uses the `aws_lambda_microvm` backend and points to the
+builder-owned image ARN.
+
+```yaml
+sandbox_profiles:
+  default-lambda:
+    backend: aws_lambda_microvm
+    image_arn: arn:aws:lambda:us-west-2:123456789012:microvm-image:cognition-default-runtime
+    image_version: "1.0"
+    region: us-west-2
+    port: 8080
+```
+
+You still need the normal sandbox prerequisites from
+[`examples/aws-lambda-microvm-sandbox`](../aws-lambda-microvm-sandbox/):
+
+- Cognition control-plane permissions
+- an agent execution role
+- optional VPC egress connector
+
+## Customize Safely
+
+Fork `runtime/` when your agents need more tools. Common additions include:
+
+- language runtimes such as Node.js, Go, or Java
+- package managers and CLIs
+- organization CA certificates
+- observability agents
+- stricter command policy inside `server.py`
+
+After changing runtime files, rerun `./scripts/package-runtime.sh`, then apply
+Terraform again to create a new MicroVM image version.
+
+## Cleanup
+
+Destroy the image and artifact resources with:
+
+```bash
+cd examples/aws-lambda-microvm-default-runtime/terraform
+terraform destroy
+```
+
+Generated zips, Terraform state, and local variable files are ignored by git.
+
+## Related Docs
+
+- [Default runtime image](../../docs/concepts/sandboxes/aws-lambda-microvm/default-runtime-image.md)
+- [Runtime command server](../../docs/concepts/sandboxes/aws-lambda-microvm/runtime-command-server.md)
+- [Lambda MicroVM setup](../../docs/concepts/sandboxes/aws-lambda-microvm/setup.md)

--- a/examples/aws-lambda-microvm-default-runtime/runtime/Dockerfile
+++ b/examples/aws-lambda-microvm-default-runtime/runtime/Dockerfile
@@ -1,0 +1,52 @@
+# This Dockerfile defines the application layer that AWS Lambda MicroVMs builds
+# and snapshots. The Lambda-managed MicroVM base image is selected separately in
+# Terraform with `base_image_arn`; this `FROM` line is the container image used
+# for the runtime files and tools layered into that MicroVM build.
+FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
+
+# Install a conservative set of tools that coding agents usually expect.
+# Builders should remove tools they do not need and add organization-approved
+# language runtimes, CLIs, CA certificates, or observability agents here.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        coreutils \
+        curl \
+        findutils \
+        git \
+        grep \
+        gzip \
+        openssh-client \
+        procps \
+        sed \
+        tar \
+        unzip \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep the runtime command server in a fixed location outside the writable
+# workspace. Agent commands run in /workspace by default.
+WORKDIR /opt/cognition-runtime
+COPY server.py .
+
+# Cognition's sandbox protocol treats this directory as the workspace root.
+# Uploads, downloads, and commands are constrained to this directory unless a
+# builder intentionally changes the server implementation.
+RUN mkdir -p /workspace
+
+# These defaults match the generated SandboxProfile. Builders may override them
+# as image environment variables during MicroVM image creation.
+ENV COGNITION_WORKSPACE_ROOT=/workspace
+ENV COGNITION_MAX_BODY_BYTES=52428800
+ENV COGNITION_MAX_CAPTURE_BYTES=2097152
+ENV PORT=8080
+ENV PYTHONUNBUFFERED=1
+
+# The Lambda MicroVM proxy forwards authenticated requests from Cognition to
+# this port. The command server itself does not implement public app-level auth.
+EXPOSE 8080
+
+# AWS starts this command during image creation, then snapshots the initialized
+# application. Each MicroVM launched from the image resumes from that snapshot.
+CMD ["python", "/opt/cognition-runtime/server.py"]

--- a/examples/aws-lambda-microvm-default-runtime/runtime/README.md
+++ b/examples/aws-lambda-microvm-default-runtime/runtime/README.md
@@ -1,0 +1,39 @@
+# Cognition Lambda MicroVM Runtime Source
+
+These files are zipped and passed to AWS Lambda MicroVM image creation.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Builds the MicroVM application layer, installs baseline tools, creates `/workspace`, and starts the command server. |
+| `server.py` | Implements the HTTP command server used by Cognition after AWS launches a MicroVM. |
+| `README.md` | Documents the runtime source for builders. It is not used by Cognition at runtime. |
+
+## Runtime Routes
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/healthz` | `GET` | Readiness check before Cognition sends commands. |
+| `/execute` | `POST` | Runs an argv command in `/workspace` and returns stdout, stderr, exit code, timeout state, and duration. |
+| `/upload` | `POST` | Writes a file under `/workspace` from `content_base64` or text `content`. |
+| `/download` | `GET` or `POST` | Reads a file under `/workspace` and returns `content_base64`. |
+| `/aws/lambda-microvms/runtime/v1/*` | `GET` or `POST` | Acknowledges AWS lifecycle hooks. |
+
+## Security Assumptions
+
+- The command server has no application-level auth because requests arrive
+  through the AWS Lambda MicroVM proxy with Cognition-managed proxy auth tokens.
+- The server rejects file paths that escape `COGNITION_WORKSPACE_ROOT`.
+- Command execution is intentionally powerful. The MicroVM boundary, execution
+  role, and network connectors are the security boundary.
+- Builders should fork this runtime if they need stricter command policy,
+  additional auditing, or organization-specific hardening.
+
+## Safe Customization Points
+
+- Add tools in `Dockerfile`.
+- Change `COGNITION_MAX_CAPTURE_BYTES` to tune command output size.
+- Change `COGNITION_MAX_BODY_BYTES` to tune upload limits.
+- Add lifecycle-hook behavior in `server.py` if the image needs per-run setup or
+  cleanup.

--- a/examples/aws-lambda-microvm-default-runtime/runtime/server.py
+++ b/examples/aws-lambda-microvm-default-runtime/runtime/server.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import subprocess
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+# The runtime listens on the same port configured in the Cognition
+# SandboxProfile. AWS Lambda MicroVM proxy auth controls access to this port.
+PORT = int(os.environ.get("PORT", "8080"))
+
+# All file operations and default command execution are confined to this
+# workspace root. Builders can change the path through image environment
+# variables, but Cognition profiles should match that choice.
+WORKSPACE_ROOT = Path(os.environ.get("COGNITION_WORKSPACE_ROOT", "/workspace")).resolve()
+
+# Keep request bodies and command output bounded. These limits prevent accidental
+# large uploads or stdout floods from making Cognition streams and logs painful.
+MAX_BODY_BYTES = int(os.environ.get("COGNITION_MAX_BODY_BYTES", str(50 * 1024 * 1024)))
+MAX_CAPTURE_BYTES = int(os.environ.get("COGNITION_MAX_CAPTURE_BYTES", str(2 * 1024 * 1024)))
+
+# AWS can call lifecycle hooks while building, running, resuming, suspending, or
+# terminating a MicroVM. The default runtime acknowledges them without side
+# effects. Builders may add setup/cleanup behavior here when needed.
+LIFECYCLE_HOOKS = {
+    "/aws/lambda-microvms/runtime/v1/ready",
+    "/aws/lambda-microvms/runtime/v1/validate",
+    "/aws/lambda-microvms/runtime/v1/run",
+    "/aws/lambda-microvms/runtime/v1/resume",
+    "/aws/lambda-microvms/runtime/v1/suspend",
+    "/aws/lambda-microvms/runtime/v1/terminate",
+    "/ready",
+    "/validate",
+    "/run",
+    "/resume",
+    "/suspend",
+    "/terminate",
+}
+
+
+def _json_bytes(payload: dict[str, Any]) -> bytes:
+    """Encode compact JSON responses so Content-Length is exact."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _safe_workspace_path(raw_path: str | None) -> Path:
+    """Resolve a request path and reject traversal outside the workspace."""
+    if not raw_path:
+        raise ValueError("path is required")
+    relative = raw_path.lstrip("/")
+    resolved = (WORKSPACE_ROOT / relative).resolve()
+    if resolved != WORKSPACE_ROOT and WORKSPACE_ROOT not in resolved.parents:
+        raise ValueError("path escapes workspace root")
+    return resolved
+
+
+def _trim_output(data: bytes) -> str:
+    """Decode command output and mark it when capture limits truncate it."""
+    truncated = data[:MAX_CAPTURE_BYTES]
+    text = truncated.decode("utf-8", errors="replace")
+    if len(data) > MAX_CAPTURE_BYTES:
+        text += "\n[truncated]"
+    return text
+
+
+class Handler(BaseHTTPRequestHandler):
+    """Small JSON HTTP server implementing Cognition's sandbox protocol."""
+
+    server_version = "cognition-lambda-microvm-command-server/0.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Runtime logs may be forwarded to CloudWatch depending on the
+        # SandboxProfile. Keep logs operational and avoid printing request bodies.
+        print(f"{self.address_string()} - {fmt % args}", flush=True)
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = _json_bytes(payload)
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        if content_length > MAX_BODY_BYTES:
+            raise ValueError("request body too large")
+        if content_length == 0:
+            return {}
+        data = self.rfile.read(content_length)
+        parsed = json.loads(data.decode("utf-8"))
+        if not isinstance(parsed, dict):
+            raise ValueError("JSON body must be an object")
+        return parsed
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/healthz":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "status": "ok",
+                    "workspace_root": str(WORKSPACE_ROOT),
+                    "time": time.time(),
+                },
+            )
+            return
+        if parsed.path == "/download":
+            query = parse_qs(parsed.query)
+            self._handle_download({"path": query.get("path", [None])[0]})
+            return
+        if parsed.path in LIFECYCLE_HOOKS:
+            self._send_json(HTTPStatus.OK, {"status": "ok", "hook": parsed.path})
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        try:
+            if parsed.path in LIFECYCLE_HOOKS:
+                self._send_json(HTTPStatus.OK, {"status": "ok", "hook": parsed.path})
+                return
+            body = self._read_json()
+            if parsed.path == "/execute":
+                self._handle_execute(body)
+            elif parsed.path == "/upload":
+                self._handle_upload(body)
+            elif parsed.path == "/download":
+                self._handle_download(body)
+            else:
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+        except Exception as exc:
+            # Cognition treats non-2xx responses as command-server failures. Keep
+            # this response structured and token-free.
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": type(exc).__name__, "message": str(exc)},
+            )
+
+    def _handle_execute(self, body: dict[str, Any]) -> None:
+        # Cognition currently sends {"command": ["sh", "-c", "..."], "cwd": ".",
+        # "timeout_seconds": N}. This also accepts a command string for manual
+        # testing and future-compatible clients.
+        command = body.get("command", body.get("cmd"))
+        if isinstance(command, list) and command:
+            argv = [str(part) for part in command]
+        elif isinstance(command, str) and command.strip():
+            args = body.get("args", [])
+            argv = [command, *[str(arg) for arg in args]] if isinstance(args, list) else shlex.split(command)
+        else:
+            raise ValueError("command must be a non-empty string or list")
+
+        cwd = _safe_workspace_path(str(body.get("cwd", ".")))
+        cwd.mkdir(parents=True, exist_ok=True)
+        timeout = float(body.get("timeout_seconds", body.get("timeout", 60)))
+
+        # Optional env values are trusted runtime input from Cognition, not model
+        # output. Builders who expose this server to other callers should add
+        # policy checks before accepting arbitrary env overrides.
+        extra_env = body.get("env", {})
+        if extra_env is not None and not isinstance(extra_env, dict):
+            raise ValueError("env must be an object")
+        env = os.environ.copy()
+        env.update({str(key): str(value) for key, value in (extra_env or {}).items()})
+
+        start = time.monotonic()
+        timed_out = False
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=str(cwd),
+                env=env,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+            )
+            exit_code = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            exit_code = 124
+            stdout = exc.stdout or b""
+            stderr = (exc.stderr or b"") + b"\ncommand timed out"
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "exit_code": exit_code,
+                "stdout": _trim_output(stdout),
+                "stderr": _trim_output(stderr),
+                "timed_out": timed_out,
+                "duration_ms": int((time.monotonic() - start) * 1000),
+            },
+        )
+
+    def _handle_upload(self, body: dict[str, Any]) -> None:
+        # Uploads are relative to WORKSPACE_ROOT. Cognition sends base64 so binary
+        # files round-trip without JSON encoding loss.
+        destination = _safe_workspace_path(str(body.get("path", "")))
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        if "content_base64" in body:
+            raw = base64.b64decode(str(body["content_base64"]), validate=True)
+        elif "content" in body:
+            raw = str(body["content"]).encode(str(body.get("encoding", "utf-8")))
+        else:
+            raise ValueError("content_base64 or content is required")
+
+        destination.write_bytes(raw)
+        self._send_json(
+            HTTPStatus.OK,
+            {"status": "ok", "path": str(destination.relative_to(WORKSPACE_ROOT)), "bytes": len(raw)},
+        )
+
+    def _handle_download(self, body: dict[str, Any]) -> None:
+        # Downloads return base64 for exact binary preservation. Cognition decodes
+        # this into Deep Agents file download responses.
+        source = _safe_workspace_path(str(body.get("path", "")))
+        raw = source.read_bytes()
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "path": str(source.relative_to(WORKSPACE_ROOT)),
+                "bytes": len(raw),
+                "content_base64": base64.b64encode(raw).decode("ascii"),
+            },
+        )
+
+
+def main() -> None:
+    WORKSPACE_ROOT.mkdir(parents=True, exist_ok=True)
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    print(f"cognition Lambda MicroVM command server listening on {PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aws-lambda-microvm-default-runtime/scripts/package-runtime.sh
+++ b/examples/aws-lambda-microvm-default-runtime/scripts/package-runtime.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNTIME_DIR="${EXAMPLE_DIR}/runtime"
+DIST_DIR="${EXAMPLE_DIR}/dist"
+ZIP_PATH="${DIST_DIR}/cognition-lambda-microvm-runtime.zip"
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "zip is required to package the Lambda MicroVM runtime artifact." >&2
+  exit 1
+fi
+
+mkdir -p "${DIST_DIR}"
+rm -f "${ZIP_PATH}"
+
+(
+  cd "${RUNTIME_DIR}"
+  zip -X -r "${ZIP_PATH}" Dockerfile server.py README.md
+)
+
+echo "Wrote ${ZIP_PATH}"

--- a/examples/aws-lambda-microvm-default-runtime/terraform/artifacts.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/artifacts.tf
@@ -1,0 +1,46 @@
+resource "random_id" "artifact_bucket" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket        = local.artifact_bucket_name
+  force_destroy = var.artifact_bucket_force_destroy
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "runtime_artifact" {
+  bucket                 = aws_s3_bucket.artifacts.bucket
+  key                    = var.runtime_artifact_key
+  source                 = local.runtime_artifact_path
+  source_hash            = filebase64sha256(local.runtime_artifact_path)
+  content_type           = "application/zip"
+  server_side_encryption = "AES256"
+  tags                   = local.tags
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/iam.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/iam.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "microvm_build" {
+  name               = "${var.prefix}-build"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "microvm_build" {
+  statement {
+    sid = "ReadMicrovmBuildArtifacts"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+
+    resources = ["${aws_s3_bucket.artifacts.arn}/*"]
+  }
+
+  statement {
+    sid = "CreateMicrovmBuildLogGroups"
+
+    actions = [
+      "logs:CreateLogGroup",
+    ]
+
+    resources = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda-microvms/${var.prefix}*"]
+  }
+
+  statement {
+    sid = "WriteMicrovmBuildLogStreams"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda-microvms/${var.prefix}*:log-stream:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "microvm_build" {
+  name   = "${var.prefix}-build"
+  role   = aws_iam_role.microvm_build.id
+  policy = data.aws_iam_policy_document.microvm_build.json
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/image.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/image.tf
@@ -1,0 +1,81 @@
+resource "aws_cloudwatch_log_group" "microvm_build" {
+  name              = "/aws/lambda-microvms/${var.prefix}"
+  retention_in_days = var.build_log_retention_days
+  tags              = local.tags
+}
+
+resource "awscc_lambda_microvm_image" "default_runtime" {
+  name               = var.microvm_image_name
+  base_image_arn     = local.microvm_base_image_arn
+  base_image_version = var.microvm_base_image_version
+  build_role_arn     = aws_iam_role.microvm_build.arn
+  description        = var.microvm_image_description
+
+  code_artifact = {
+    uri = "s3://${aws_s3_bucket.artifacts.bucket}/${aws_s3_object.runtime_artifact.key}"
+  }
+
+  logging = {
+    cloudwatch = {
+      log_group  = aws_cloudwatch_log_group.microvm_build.name
+      log_stream = "${var.prefix}-image-build"
+    }
+    disabled = false
+  }
+
+  egress_network_connectors = [local.aws_managed_internet_egress_connector_arn]
+
+  cpu_configurations = [
+    {
+      architecture = "ARM_64"
+    }
+  ]
+
+  resources = [
+    {
+      minimum_memory_in_mi_b = var.runtime_minimum_memory_mib
+    }
+  ]
+
+  additional_os_capabilities = ["ALL"]
+
+  environment_variables = [
+    {
+      key   = "COGNITION_WORKSPACE_ROOT"
+      value = "/workspace"
+    },
+    {
+      key   = "COGNITION_MAX_BODY_BYTES"
+      value = "52428800"
+    },
+    {
+      key   = "COGNITION_MAX_CAPTURE_BYTES"
+      value = "2097152"
+    },
+    {
+      key   = "PORT"
+      value = tostring(var.runtime_port)
+    },
+  ]
+
+  hooks = {
+    microvm_image_hooks = {
+      ready    = "DISABLED"
+      validate = "DISABLED"
+    }
+
+    microvm_hooks = {
+      run       = "DISABLED"
+      resume    = "DISABLED"
+      suspend   = "DISABLED"
+      terminate = "DISABLED"
+    }
+  }
+
+  tags = local.awscc_tags
+
+  depends_on = [
+    aws_iam_role_policy.microvm_build,
+    aws_s3_object.runtime_artifact,
+  ]
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/locals.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/locals.tf
@@ -1,0 +1,72 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  tags = merge(
+    {
+      Project     = "cognition"
+      Component   = "aws-lambda-microvm-default-runtime"
+      Environment = "example"
+      ManagedBy   = "terraform"
+    },
+    var.tags,
+  )
+
+  awscc_tags = [
+    for key, value in local.tags : {
+      key   = key
+      value = value
+    }
+  ]
+
+  artifact_bucket_name  = lower(replace("${var.prefix}-${random_id.artifact_bucket.hex}-artifacts", "_", "-"))
+  runtime_artifact_path = abspath("${path.module}/${var.runtime_artifact_path}")
+
+  microvm_base_image_arn = coalesce(
+    var.microvm_base_image_arn,
+    "arn:aws:lambda:${var.aws_region}:aws:microvm-image:al2023-1",
+  )
+
+  aws_managed_all_ingress_connector_arn     = "arn:aws:lambda:${var.aws_region}:aws:network-connector:aws-network-connector:ALL_INGRESS"
+  aws_managed_internet_egress_connector_arn = "arn:aws:lambda:${var.aws_region}:aws:network-connector:aws-network-connector:INTERNET_EGRESS"
+
+  sandbox_profile_base = {
+    name                           = var.profile_name
+    backend                        = "aws_lambda_microvm"
+    image_arn                      = awscc_lambda_microvm_image.default_runtime.image_arn
+    image_version                  = awscc_lambda_microvm_image.default_runtime.latest_active_image_version
+    region                         = var.aws_region
+    ingress_network_connector_arns = [local.aws_managed_all_ingress_connector_arn]
+    egress_mode                    = "internet"
+    egress_network_connector_arns  = [local.aws_managed_internet_egress_connector_arn]
+    idle_policy = {
+      max_idle_duration_seconds  = var.max_idle_duration_seconds
+      suspended_duration_seconds = var.suspended_duration_seconds
+      auto_resume_enabled        = true
+    }
+    logging = {
+      disabled = {}
+    }
+    quota = {
+      max_concurrent_sessions       = var.max_concurrent_sessions
+      max_session_starts_per_minute = var.max_session_starts_per_minute
+    }
+    maximum_duration_seconds = var.maximum_duration_seconds
+    port                     = var.runtime_port
+    token_expiration_minutes = var.token_expiration_minutes
+    scope                    = {}
+    extra                    = {}
+  }
+
+  sandbox_profile = merge(
+    local.sandbox_profile_base,
+    var.default_execution_role_arn == null ? {} : {
+      default_execution_role_arn = var.default_execution_role_arn
+    },
+  )
+
+  cognition_sandbox_profiles = {
+    (var.profile_name) = local.sandbox_profile
+  }
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/outputs.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/outputs.tf
@@ -1,0 +1,36 @@
+output "artifact_bucket_name" {
+  description = "S3 bucket containing the Lambda MicroVM runtime source artifact."
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
+output "runtime_artifact_s3_uri" {
+  description = "S3 URI for the packaged runtime source artifact."
+  value       = "s3://${aws_s3_bucket.artifacts.bucket}/${aws_s3_object.runtime_artifact.key}"
+}
+
+output "microvm_build_role_arn" {
+  description = "IAM role ARN assumed by Lambda during MicroVM image builds."
+  value       = aws_iam_role.microvm_build.arn
+}
+
+output "microvm_image_arn" {
+  description = "Builder-owned Lambda MicroVM image ARN for Cognition sandbox profiles."
+  value       = awscc_lambda_microvm_image.default_runtime.image_arn
+}
+
+output "microvm_image_version" {
+  description = "Latest active version of the Lambda MicroVM image."
+  value       = awscc_lambda_microvm_image.default_runtime.latest_active_image_version
+}
+
+output "microvm_image_state" {
+  description = "Current Lambda MicroVM image state."
+  value       = awscc_lambda_microvm_image.default_runtime.state
+}
+
+output "sandbox_profiles_yaml" {
+  description = "Cognition sandbox_profiles YAML generated from the created image."
+  value = yamlencode({
+    sandbox_profiles = local.cognition_sandbox_profiles
+  })
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/providers.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  profile             = var.aws_profile
+  region              = var.aws_region
+  allowed_account_ids = var.allowed_account_ids
+}
+
+provider "awscc" {
+  profile = var.aws_profile
+  region  = var.aws_region
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/terraform.tfvars.example
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/terraform.tfvars.example
@@ -1,0 +1,37 @@
+# Copy to terraform.tfvars and edit for your AWS account.
+
+aws_region = "us-west-2"
+
+# Optional. Leave null to use ambient AWS credentials.
+aws_profile = null
+
+# Optional provider safety check. Example:
+# allowed_account_ids = ["123456789012"]
+allowed_account_ids = []
+
+prefix              = "cognition-microvm-runtime"
+microvm_image_name  = "cognition-default-runtime"
+profile_name        = "default-lambda"
+
+# Leave null to use the Lambda-managed AL2023 MicroVM base image in aws_region.
+microvm_base_image_arn     = null
+microvm_base_image_version = null
+
+runtime_port               = 8080
+runtime_minimum_memory_mib = 2048
+build_log_retention_days   = 14
+
+maximum_duration_seconds      = 3600
+token_expiration_minutes      = 30
+max_concurrent_sessions       = 10
+max_session_starts_per_minute = 30
+max_idle_duration_seconds     = 900
+suspended_duration_seconds    = 300
+
+# Optional. Set this after creating an agent execution role, or leave null and
+# set sandbox_execution_role_arn per agent.
+default_execution_role_arn = null
+
+tags = {
+  Environment = "dev"
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/variables.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/variables.tf
@@ -1,0 +1,151 @@
+variable "aws_profile" {
+  description = "Optional AWS CLI profile used by Terraform. Leave null for ambient credentials."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "aws_region" {
+  description = "AWS region with Lambda MicroVM support."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "allowed_account_ids" {
+  description = "Optional allow-list of AWS account IDs for provider safety."
+  type        = list(string)
+  default     = []
+}
+
+variable "prefix" {
+  description = "Name prefix for AWS resources created by this example."
+  type        = string
+  default     = "cognition-microvm-runtime"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$", var.prefix))
+    error_message = "prefix must be 3-44 characters and contain only letters, numbers, and hyphens."
+  }
+}
+
+variable "artifact_bucket_force_destroy" {
+  description = "Allow Terraform to delete a non-empty artifact bucket during destroy."
+  type        = bool
+  default     = false
+}
+
+variable "runtime_artifact_path" {
+  description = "Path to the packaged runtime source zip, relative to this Terraform directory."
+  type        = string
+  default     = "../dist/cognition-lambda-microvm-runtime.zip"
+}
+
+variable "runtime_artifact_key" {
+  description = "S3 object key for the packaged runtime source zip."
+  type        = string
+  default     = "microvm-images/cognition-lambda-microvm-runtime.zip"
+}
+
+variable "microvm_image_name" {
+  description = "Name of the Lambda MicroVM image to create."
+  type        = string
+  default     = "cognition-default-runtime"
+}
+
+variable "microvm_image_description" {
+  description = "Description for the Lambda MicroVM image."
+  type        = string
+  default     = "Default Cognition command-server runtime for Lambda MicroVM sandboxes."
+}
+
+variable "microvm_base_image_arn" {
+  description = "Optional Lambda-managed MicroVM base image ARN. Leave null to use al2023-1 in aws_region."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "microvm_base_image_version" {
+  description = "Optional Lambda-managed MicroVM base image version."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "runtime_port" {
+  description = "Runtime command server port inside the MicroVM."
+  type        = number
+  default     = 8080
+
+  validation {
+    condition     = var.runtime_port >= 1 && var.runtime_port <= 65535
+    error_message = "runtime_port must be between 1 and 65535."
+  }
+}
+
+variable "runtime_minimum_memory_mib" {
+  description = "Baseline memory for the default runtime MicroVM image."
+  type        = number
+  default     = 2048
+}
+
+variable "build_log_retention_days" {
+  description = "Retention for Lambda MicroVM image build logs."
+  type        = number
+  default     = 14
+}
+
+variable "profile_name" {
+  description = "Name of the generated Cognition sandbox profile."
+  type        = string
+  default     = "default-lambda"
+}
+
+variable "maximum_duration_seconds" {
+  description = "Maximum MicroVM duration for generated Cognition profile YAML."
+  type        = number
+  default     = 3600
+}
+
+variable "token_expiration_minutes" {
+  description = "AWS proxy auth token TTL requested by Cognition."
+  type        = number
+  default     = 30
+}
+
+variable "max_concurrent_sessions" {
+  description = "Cognition-side maximum active sandbox sessions for the generated profile/scope pair."
+  type        = number
+  default     = 10
+}
+
+variable "max_session_starts_per_minute" {
+  description = "Cognition-side maximum sandbox session starts per minute for the generated profile/scope pair."
+  type        = number
+  default     = 30
+}
+
+variable "max_idle_duration_seconds" {
+  description = "Maximum idle time before Lambda may suspend the MicroVM."
+  type        = number
+  default     = 900
+}
+
+variable "suspended_duration_seconds" {
+  description = "Duration Lambda may keep a suspended MicroVM available for resume."
+  type        = number
+  default     = 300
+}
+
+variable "default_execution_role_arn" {
+  description = "Optional sandbox execution role ARN to include in generated profile YAML."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "tags" {
+  description = "Additional tags applied to AWS resources."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/aws-lambda-microvm-default-runtime/terraform/versions.tf
+++ b/examples/aws-lambda-microvm-default-runtime/terraform/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.90.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}

--- a/examples/aws-lambda-microvm-sandbox/README.md
+++ b/examples/aws-lambda-microvm-sandbox/README.md
@@ -12,6 +12,14 @@ It includes:
 The Terraform consumes a prebuilt Lambda MicroVM image ARN. It does not build,
 publish, or update MicroVM images.
 
+## Need an Image?
+
+If you do not already have a Lambda MicroVM image, use
+[`examples/aws-lambda-microvm-default-runtime`](../aws-lambda-microvm-default-runtime/)
+first. That example packages Cognition's commented default runtime source,
+creates a builder-owned Lambda MicroVM image, and outputs the image ARN/version
+used by this example.
+
 ## Prerequisites
 
 You need:
@@ -187,6 +195,7 @@ Terraform does not delete or modify your prebuilt MicroVM image.
 
 ## Related Docs
 
-- [AWS Lambda MicroVM Sandbox concept](../../docs/concepts/aws-lambda-microvm-sandbox.md)
-- [AWS Lambda MicroVM Sandbox setup guide](../../docs/guides/aws-lambda-microvm-sandbox.md)
+- [AWS Lambda MicroVM Sandbox concept](../../docs/concepts/sandboxes/aws-lambda-microvm/index.md)
+- [Default runtime image](../../docs/concepts/sandboxes/aws-lambda-microvm/default-runtime-image.md)
+- [AWS Lambda MicroVM Sandbox setup guide](../../docs/concepts/sandboxes/aws-lambda-microvm/setup.md)
 - [API Reference: Sandbox Profiles](../../docs/guides/api-reference.md#sandbox-profiles)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
           - AWS Lambda MicroVM:
               - Overview: concepts/sandboxes/aws-lambda-microvm/index.md
               - Setup: concepts/sandboxes/aws-lambda-microvm/setup.md
+              - Default Runtime Image: concepts/sandboxes/aws-lambda-microvm/default-runtime-image.md
               - Profiles: concepts/sandboxes/aws-lambda-microvm/profiles.md
               - IAM & Networking: concepts/sandboxes/aws-lambda-microvm/iam-and-networking.md
               - Runtime Command Server: concepts/sandboxes/aws-lambda-microvm/runtime-command-server.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,10 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 show_error_codes = true
 explicit_package_bases = true
-exclude = ["^workspaces/"]
+exclude = [
+    "^workspaces/",
+    "^examples/aws-lambda-microvm-default-runtime/runtime/server\\.py$",
+]
 
 # Pragmatic overrides for tests - too many untyped fixtures to fix
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Summary

Adds a public default Lambda MicroVM runtime image example for builders who need a starter image for Cognition's `aws_lambda_microvm` sandbox backend.

## Changes

- Adds commented runtime source files for the AWS image zip: `Dockerfile`, `server.py`, and runtime `README.md`.
- Adds a packaging script that creates `dist/cognition-lambda-microvm-runtime.zip` without committing generated artifacts.
- Adds Terraform that uploads the zip to S3, creates the Lambda MicroVM image build role, creates the image via `awscc_lambda_microvm_image`, and outputs `microvm_image_arn`, `microvm_image_version`, and `sandbox_profiles_yaml`.
- Adds public docs for the default runtime image flow and cross-links from Lambda MicroVM setup/profile/runtime/troubleshooting docs.
- Updates examples navigation and the existing prebuilt-image sandbox example with a “Need an Image?” path.

## Validation

- `./examples/aws-lambda-microvm-default-runtime/scripts/package-runtime.sh`
- `unzip -l examples/aws-lambda-microvm-default-runtime/dist/cognition-lambda-microvm-runtime.zip`
- `python3 -m py_compile examples/aws-lambda-microvm-default-runtime/runtime/server.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --extra docs mkdocs build --strict`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform fmt -check`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform init -backend=false`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform validate`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform fmt -check`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform init -backend=false`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform validate`
- `git diff --check`
- Confirmed no generated zip, Terraform state, `.terraform/`, `.terraform.lock.hcl`, real account IDs, tokens, or secrets are committed.
