### PR TITLE
chore: prepare 0.11.0 rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.11.0-rc.6] — 2026-07-10
+
+### Added
+
+- Added public documentation and a reusable builder-owned default Lambda MicroVM runtime image example, including commented runtime source, packaging script, Terraform image creation template, and sandbox profile output.
+
+---
+
 ## [0.11.0-rc.5] — 2026-07-10
 
 ### Fixed

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.11.0-rc.5"
+VERSION = "0.11.0-rc.6"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- Bump server version metadata to `0.11.0-rc.6`.
- Add the rc6 changelog entry for the default Lambda MicroVM runtime image documentation and builder-owned example.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit -v`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv sync --all-extras --dev` then `UV_CACHE_DIR=/tmp/uv-cache uv run mypy .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --extra docs mkdocs build --strict`
- `python3 -m py_compile examples/aws-lambda-microvm-default-runtime/runtime/server.py`
- `examples/aws-lambda-microvm-default-runtime/scripts/package-runtime.sh`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform fmt -check`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform init -backend=false`
- `terraform -chdir=examples/aws-lambda-microvm-default-runtime/terraform validate`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform fmt -check`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform init -backend=false`
- `terraform -chdir=examples/aws-lambda-microvm-sandbox/terraform validate`
- `git diff --check`

## Notes
- Generated docs, Terraform, Python cache, and runtime zip artifacts were removed after validation.
- Pre-release image workflow should run after merge from the exact release branch commit before tagging `v0.11.0-rc.6`.
