### PR TITLE
Add public display names to A2A Agent Cards

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-18 | Remove Cognition implementation branding from A2A Agent Card names so cards identify the configured agent directly. | Kennel Agent Card identity report | 6 | Completed |
 | 2026-07-10 | Verify Lambda MicroVM teardown before reporting completion and emit token-free lifecycle events/logs for launch, auth token creation, healthchecks, runtime snapshots, and teardown outcomes. | v0.11 rc Lambda MicroVM operator observability follow-up | 3/6/7 | Completed |
 | 2026-07-02 | Fix rc.3 scoped agent execution and Lambda MicroVM quota leaks — session validation/runtime resolution now use effective scope, runtime no longer silently falls back to `default`, completed runs return sessions to `idle`, terminal session cleanup releases sandbox quota, and health counts non-terminal sessions. | Kennel rc.3 production-pilot findings | 3/4/6/7 | Completed |
 | 2026-06-27 | Fix scoped API-created agents being rejected by `POST /sessions` and `PATCH /sessions/{id}` agent validation because session routes checked primary-agent eligibility without request scope. | Kennel rc.2 Lambda MicroVM smoke report | 4/6 | Completed |
@@ -190,6 +191,7 @@ The following fallback patterns exist and are tracked for removal. They produce 
 
 | Task | Layer | Status | Acceptance Criteria | Effort | Dependencies |
 |------|-------|--------|---------------------|--------|--------------|
+| **Optional public agent display name** | Layer 4/6 | Completed | `AgentDefinition`, agent CRUD, and persisted definitions support an optional `display_name`; A2A cards use it for `AgentCard.name` and the synthesized public skill without changing runtime lookup, routing, session binding, or deletion; the public skill uses `id="primary"` when a display name is configured; definitions without it retain existing behavior; focused definition, CRUD, and A2A tests pass. | 0.5 day | Existing per-agent A2A adapter and ConfigRegistry persistence |
 | **Configurable agent recursion_limit and max_tokens** | Layer 4 | Completed | `agent_recursion_limit` configurable via env/Settings/YAML (default: 1000); `llm_max_tokens` wired to model factories (default: 20000) | 0.5 days | None |
 | **MCP server wiring** | Layer 4/5 | Completed | `COGNITION_MCP_SERVERS` env var / YAML key configures remote MCP servers; each entry validated (HTTP/HTTPS only) at startup; tools from MCP servers available to agent in all execution paths | 0.5 days | None |
 | **Bedrock IAM role support** | Layer 5 | Completed | Ambient credentials (instance profile, ECS task role, Lambda, IRSA) work without any key configuration; `COGNITION_BEDROCK_ROLE_ARN` enables cross-account role assumption; `AWS_SESSION_TOKEN` supported for STS temp credentials; partial key pair raises clear error | 0.5 days | None |

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -178,6 +178,7 @@ class AgentDefinition(BaseModel):
 
     Attributes:
         name: Unique agent identifier.
+        display_name: Optional human-readable name for public presentation.
         system_prompt: System prompt that defines agent behavior.
         tools: List of attached tool names.
         skills: List of attached skill names.
@@ -190,6 +191,7 @@ class AgentDefinition(BaseModel):
     """
 
     name: str = Field(..., min_length=1, max_length=100)
+    display_name: str | None = Field(default=None, min_length=1, max_length=200)
     system_prompt: str = Field(..., min_length=1)
     tools: list[str] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
@@ -584,6 +586,7 @@ def load_agent_definition_from_markdown(path: str | Path) -> AgentDefinition:
 
     definition = AgentDefinition(
         name=name,
+        display_name=frontmatter.get("display_name"),
         system_prompt=body,
         description=frontmatter.get("description"),
         mode=frontmatter.get("mode", "all"),

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -856,7 +856,11 @@ class CapabilityResponse(BaseModel):
 class AgentResponse(BaseModel):
     """Agent information for API responses."""
 
-    name: str = Field(..., description="Agent name")
+    name: str = Field(..., description="Stable agent runtime identifier")
+    display_name: str | None = Field(
+        None,
+        description="Optional human-readable name used for public Agent presentation",
+    )
     description: str | None = Field(None, description="Agent description")
     mode: Literal["primary", "subagent", "all"] = Field(..., description="Agent mode")
     hidden: bool = Field(..., description="Whether agent is hidden from listings")
@@ -1231,7 +1235,18 @@ class ProviderTestResponse(BaseModel):
 class AgentCreate(BaseModel):
     """Request to create or replace an agent definition."""
 
-    name: str = Field(..., min_length=1, max_length=100, description="Agent identifier")
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Stable agent runtime identifier",
+    )
+    display_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=200,
+        description="Optional human-readable name used for public Agent presentation",
+    )
     system_prompt: str = Field(default="", description="System prompt text")
     description: str | None = Field(default=None)
     mode: Literal["primary", "subagent", "all"] = Field(default="primary")
@@ -1272,6 +1287,12 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     """Request to partially update an agent definition."""
 
+    display_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=200,
+        description="Optional human-readable name used for public Agent presentation",
+    )
     system_prompt: str | None = None
     description: str | None = None
     mode: Literal["primary", "subagent", "all"] | None = None

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -22,6 +22,7 @@ router = APIRouter(prefix="/agents", tags=["agents"])
 def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
     return AgentResponse(
         name=agent.name,
+        display_name=agent.display_name,
         description=agent.description,
         mode=agent.mode,
         hidden=agent.hidden,
@@ -121,6 +122,7 @@ async def create_agent(
     try:
         definition_data: dict[str, Any] = {
             "name": body.name,
+            "display_name": body.display_name,
             "system_prompt": body.system_prompt,
             "description": body.description,
             "mode": body.mode,
@@ -216,6 +218,8 @@ async def update_agent(
         data, agent_scope = result
 
         updates = body.model_dump(exclude_none=True)
+        if "display_name" in body.model_fields_set:
+            updates["display_name"] = body.display_name
         config_fields = {
             "model",
             "temperature",

--- a/server/app/protocols/a2a/card.py
+++ b/server/app/protocols/a2a/card.py
@@ -23,24 +23,38 @@ def build_agent_card_for_agent(
     """Build an A2A AgentCard for a single Cognition agent.
 
     The card's supportedInterfaces URL points to /a2a/{agent_name}.
-    The card name includes the agent name for client-side identification.
+    The card name uses the public display name when configured and otherwise
+    falls back to the runtime agent name.
 
     The card does NOT expose: system prompt, tool list, skill contents,
     scope values, secrets, or subagent details.
     """
+    public_name = agent.display_name or agent.name
+    has_public_name = agent.display_name is not None
+    card_description = agent.description or (
+        f"Agent: {public_name}"
+        if has_public_name
+        else f"Cognition agent: {public_name}"
+    )
+    skill_description = agent.description or (
+        f"Primary capability for {public_name}"
+        if has_public_name
+        else f"Cognition agent: {public_name}"
+    )
+
     skill = AgentSkill(
-        id=agent.name,
-        name=agent.name,
-        description=agent.description or f"Cognition agent: {agent.name}",
-        tags=["cognition", agent.mode],
+        id="primary" if has_public_name else agent.name,
+        name=public_name,
+        description=skill_description,
+        tags=["primary"] if has_public_name else ["cognition", agent.mode],
         input_modes=["text/plain"],
         output_modes=["text/plain", "application/json"],
         examples=[],
     )
 
     card = AgentCard(
-        name=f"Cognition ({agent.name})",
-        description=agent.description or f"Cognition agent: {agent.name}",
+        name=public_name,
+        description=card_description,
         version=version,
         default_input_modes=["text/plain"],
         default_output_modes=["text/plain", "application/json"],

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -85,6 +85,28 @@ class TestGetAgent:
 
 
 class TestCreateAgent:
+    def test_create_agent_persists_display_name(self):
+        response = client.post(
+            "/agents",
+            json={
+                "name": "ka_create_display_name",
+                "display_name": "Customer Support Concierge",
+                "system_prompt": "Help customers.",
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["name"] == "ka_create_display_name"
+        assert response.json()["display_name"] == "Customer Support Concierge"
+
+        get_response = client.get("/agents/ka_create_display_name")
+        assert get_response.status_code == 200
+        assert get_response.json()["display_name"] == "Customer Support Concierge"
+
+        raw = asyncio.run(get_config_store().get_agent_raw("ka_create_display_name"))
+        assert raw is not None
+        assert raw["display_name"] == "Customer Support Concierge"
+
     def test_create_new_agent(self):
         payload = {
             "name": "test-create-agent",
@@ -227,6 +249,34 @@ class TestCreateAgent:
 
 
 class TestUpdateAgent:
+    def test_patch_agent_updates_and_clears_display_name(self):
+        client.post(
+            "/agents",
+            json={
+                "name": "ka_patch_display_name",
+                "display_name": "Original Name",
+                "system_prompt": "Help customers.",
+            },
+        )
+
+        update_response = client.patch(
+            "/agents/ka_patch_display_name",
+            json={"display_name": "Updated Name"},
+        )
+        assert update_response.status_code == 200
+        assert update_response.json()["display_name"] == "Updated Name"
+
+        clear_response = client.patch(
+            "/agents/ka_patch_display_name",
+            json={"display_name": None},
+        )
+        assert clear_response.status_code == 200
+        assert clear_response.json()["display_name"] is None
+
+        raw = asyncio.run(get_config_store().get_agent_raw("ka_patch_display_name"))
+        assert raw is not None
+        assert raw["display_name"] is None
+
     def test_put_agent_updates_definition(self):
         """PUT should fully replace the agent definition."""
         # Create

--- a/tests/unit/test_a2a_adapter.py
+++ b/tests/unit/test_a2a_adapter.py
@@ -42,12 +42,33 @@ class TestA2AExposedField:
 
 
 class TestBuildAgentCardForAgent:
-    def test_card_has_agent_name_in_title(self):
+    def test_card_uses_agent_name_as_title(self):
         agent = AgentDefinition(
             name="my-agent", system_prompt="test", mode="primary", a2a_exposed=True
         )
         card = build_agent_card_for_agent(agent, "http://localhost:8000", "0.10.0")
-        assert card.name == "Cognition (my-agent)"
+        assert card.name == "my-agent"
+
+    def test_card_uses_display_name_for_public_presentation(self):
+        agent = AgentDefinition(
+            name="ka_0cadedacd0b74a509358b48b5e3fd952",
+            display_name="Customer Support Concierge",
+            system_prompt="test",
+            mode="primary",
+            a2a_exposed=True,
+        )
+
+        card = build_agent_card_for_agent(agent, "http://localhost:8000", "0.10.0")
+
+        assert card.name == "Customer Support Concierge"
+        assert card.description == "Agent: Customer Support Concierge"
+        assert len(card.skills) == 1
+        assert card.skills[0].id == "primary"
+        assert card.skills[0].name == "Customer Support Concierge"
+        assert card.skills[0].description == (
+            "Primary capability for Customer Support Concierge"
+        )
+        assert card.skills[0].tags == ["primary"]
 
     def test_card_has_correct_endpoint(self):
         agent = AgentDefinition(
@@ -150,8 +171,10 @@ class TestA2APerAgentCardRoute:
 
         assert response.status_code == 200
         card = response.json()
-        assert card["name"] == "Cognition (scoped-agent)"
-        assert card["supportedInterfaces"][0]["url"] == ("http://example.test/a2a/scoped-agent")
+        assert card["name"] == "scoped-agent"
+        assert card["supportedInterfaces"][0]["url"] == (
+            "http://example.test/a2a/scoped-agent"
+        )
 
     @pytest.mark.asyncio
     async def test_per_agent_card_respects_request_scope(self):

--- a/tests/unit/test_agent_markdown_config.py
+++ b/tests/unit/test_agent_markdown_config.py
@@ -11,6 +11,7 @@ def test_markdown_config_block_populates_agent_config(tmp_path: Path) -> None:
     path = tmp_path / "investigator.md"
     path.write_text(
         """---
+display_name: Incident Investigator
 description: Investigates incidents
 temperature: 0.2
 config:
@@ -27,6 +28,7 @@ You are an investigator.
 
     definition = load_agent_definition_from_markdown(path)
 
+    assert definition.display_name == "Incident Investigator"
     assert definition.config.temperature == 0.2
     assert definition.config.max_tokens == 16000
     assert definition.config.recursion_limit == 500


### PR DESCRIPTION
## Summary

- add an optional `display_name` to `AgentDefinition` and Agent CRUD models
- persist and round-trip the display name through scoped ConfigRegistry-backed definitions
- use the display name for `AgentCard.name` and the synthesized public skill
- use the stable public skill ID `primary` when a display name is configured
- remove the `Cognition (...)` wrapper from fallback Agent Card names
- preserve the existing runtime `name` for lookup, routing, sessions, updates, and deletion

## Why

`AgentDefinition.name` is Cognition's stable runtime lookup key, but the A2A adapter also projected it into public presentation fields. Control planes such as Kennel need opaque, stable runtime names while presenting a customer-facing Agent identity. Using the display name as the runtime key would make renames and duplicate customer-facing names unsafe.

This change separates presentation from runtime identity without introducing a new resource ID or changing A2A routing and protocol behavior.

## Behavior

When `display_name` is supplied:

- `AgentCard.name` uses the display name
- the synthesized skill uses `id="primary"`
- skill name and fallback descriptions use the public display name
- the runtime lookup name remains unchanged

When omitted, Agent Card presentation falls back to the runtime name. Sending `display_name: null` through PATCH clears the override.

## Validation

- `uv run pytest tests/unit -q`
  - 841 passed
  - 4 skipped
- focused Agent definition, CRUD, persistence, Markdown, and A2A tests included
- Ruff lint passed for all touched Python files
- `git diff --check` passed
