### PR TITLE
Fix public A2A interface URLs for 0.12.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.12.0-rc.3] — 2026-07-18
+
+### Added
+
+- Added optional `display_name` agent configuration for human-readable A2A Agent Card and synthesized skill presentation without changing the stable runtime lookup name.
+- Added optional `a2a_public_interface_url` agent configuration for builder-routed public A2A endpoints.
+
+### Fixed
+
+- Agent Cards now advertise the configured public A2A interface URL exactly when supplied, while preserving the request-derived `/a2a/{agent_name}` fallback for existing definitions.
+- Updated the reported Cognition version to `0.12.0-rc.3` so card and health metadata match the published release candidate.
+
 ## [0.12.0-rc.1] — 2026-07-15
 
 ### Highlights

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-18 | Honor a builder-configured external A2A interface URL in Agent Cards while retaining the request-derived per-agent route as a backward-compatible fallback. | Kennel `0.12.0-rc2` public Agent Card URL report | 2/6 | Completed |
 | 2026-07-18 | Remove Cognition implementation branding from A2A Agent Card names so cards identify the configured agent directly. | Kennel Agent Card identity report | 6 | Completed |
 | 2026-07-10 | Verify Lambda MicroVM teardown before reporting completion and emit token-free lifecycle events/logs for launch, auth token creation, healthchecks, runtime snapshots, and teardown outcomes. | v0.11 rc Lambda MicroVM operator observability follow-up | 3/6/7 | Completed |
 | 2026-07-02 | Fix rc.3 scoped agent execution and Lambda MicroVM quota leaks — session validation/runtime resolution now use effective scope, runtime no longer silently falls back to `default`, completed runs return sessions to `idle`, terminal session cleanup releases sandbox quota, and health counts non-terminal sessions. | Kennel rc.3 production-pilot findings | 3/4/6/7 | Completed |

--- a/docs/concepts/agent-runtime.md
+++ b/docs/concepts/agent-runtime.md
@@ -109,7 +109,8 @@ Every consumer of the runtime (streaming endpoint, tests, evaluators) deals only
 
 ```python
 class AgentDefinition(BaseModel):
-    name: str
+    name: str                       # Stable runtime lookup identifier
+    display_name: str | None = None # Optional public presentation name
     system_prompt: str | PromptConfig | None = None
     tools: list[str] = []           # registry tool names
     skills: list[str] = []          # registry skill names
@@ -123,6 +124,7 @@ class AgentDefinition(BaseModel):
     hidden: bool = False
     native: bool = False            # True for built-in agents
     a2a_exposed: bool = False       # Expose via A2A protocol (default: off)
+    a2a_public_interface_url: str | None = None  # External JSON-RPC endpoint
 ```
 
 ### Agent Modes
@@ -142,13 +144,22 @@ The `a2a_exposed` field controls whether an agent is exposed via strict [A2A 1.0
 - The agent gets a dedicated JSON-RPC endpoint at `POST /a2a/{agent_name}`
 - External A2A clients can discover and invoke the agent
 
+Set `a2a_public_interface_url` when a gateway or builder platform exposes the
+agent at a different public endpoint. Cognition advertises that absolute HTTP(S)
+URL exactly in `supportedInterfaces`. If it is omitted, Cognition derives the
+interface URL from the incoming request and its private
+`/a2a/{agent_name}` route for backward compatibility. The configured URL must
+not contain credentials or a fragment.
+
 Built-in agents (`default`, `readonly`, etc.) have `a2a_exposed=False` by default. Set it to `True` explicitly for agents you want to expose:
 
 ```yaml
 # .cognition/agents/deploy-agent.yaml
 name: deploy-agent
+display_name: Deployment Assistant
 mode: primary
 a2a_exposed: true
+a2a_public_interface_url: https://agents.example.com/deployment/a2a
 system_prompt: |
   You are a deployment agent...
 ```
@@ -158,7 +169,7 @@ Or via the API:
 ```bash
 curl -X POST http://localhost:8000/agents \
   -H "Content-Type: application/json" \
-  -d '{"name": "deploy-agent", "system_prompt": "...", "a2a_exposed": true}'
+  -d '{"name": "deploy-agent", "display_name": "Deployment Assistant", "system_prompt": "...", "a2a_exposed": true, "a2a_public_interface_url": "https://agents.example.com/deployment/a2a"}'
 ```
 
 ### System Prompt Sources

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -625,11 +625,13 @@ List all non-hidden agents available in the registry.
   "agents": [
     {
       "name": "default",
+      "display_name": null,
       "description": "Full-access coding agent with all tools enabled",
       "mode": "primary",
       "hidden": false,
       "native": true,
       "a2a_exposed": false,
+      "a2a_public_interface_url": null,
       "provider": null,
       "model": null,
       "temperature": null,
@@ -695,6 +697,7 @@ Create or replace an agent definition in the ConfigRegistry.
 ```json
 {
   "name": "security-auditor",
+  "display_name": "Security Auditor",
   "system_prompt": "You are a security expert. Audit code for vulnerabilities.",
   "description": "Audits code for security issues",
   "mode": "subagent",
@@ -703,6 +706,7 @@ Create or replace an agent definition in the ConfigRegistry.
   "memory": ["AGENTS.md"],
   "interrupt_on": {},
   "a2a_exposed": false,
+  "a2a_public_interface_url": "https://agents.example.com/security-auditor/a2a",
   "model": "gpt-4o",
   "temperature": 0.1,
   "max_tokens": 4096,
@@ -718,11 +722,13 @@ Create or replace an agent definition in the ConfigRegistry.
 | Field | Type | Description |
 |---|---|---|
 | `name` | string | Agent identifier (1–100 chars) |
+| `display_name` | string | Optional human-readable name used for public Agent presentation without changing runtime lookup |
 | `system_prompt` | string | Agent's system prompt |
 | `description` | string | Human-readable description |
 | `mode` | `"primary"` \| `"subagent"` \| `"all"` | Whether agent can own sessions, be delegated to, or both |
 | `hidden` | boolean | Hide the agent from `GET /agents` list results |
 | `a2a_exposed` | boolean | Expose eligible `primary` or `all` agents through the A2A protocol |
+| `a2a_public_interface_url` | string | Optional absolute HTTP(S) JSON-RPC endpoint advertised exactly in the Agent Card; credentials and fragments are rejected |
 | `tools` | list[string] | Registry tool names to attach to this agent |
 | `skills` | list[string] | Registry skill names to attach to this agent |
 | `memory` | list[string] | Paths to instruction files (e.g. AGENTS.md) |
@@ -1765,16 +1771,16 @@ X-Cognition-Scope-User: alice
 **Response `200 OK`:**
 ```json
 {
-  "name": "Cognition (deploy-agent)",
+  "name": "Deployment Assistant",
   "description": "Handles deployment workflows",
   "supportedInterfaces": [
     {
-      "url": "http://localhost:8000/a2a/deploy-agent",
+      "url": "https://agents.example.com/deployment/a2a",
       "protocolBinding": "JSONRPC",
       "protocolVersion": "1.0"
     }
   ],
-  "version": "0.10.3",
+  "version": "0.12.0-rc.3",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false,
@@ -1782,9 +1788,24 @@ X-Cognition-Scope-User: alice
   },
   "defaultInputModes": ["text/plain"],
   "defaultOutputModes": ["text/plain", "application/json"],
-  "skills": []
+  "skills": [
+    {
+      "id": "primary",
+      "name": "Deployment Assistant",
+      "description": "Handles deployment workflows",
+      "tags": ["primary"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["text/plain", "application/json"]
+    }
+  ]
 }
 ```
+
+When the agent definition includes `a2a_public_interface_url`, Cognition uses
+that value exactly for `supportedInterfaces[].url`. Otherwise it derives the
+URL from the incoming request and `/a2a/{agent_name}` for backward
+compatibility. `display_name` affects only public presentation; internal lookup
+and the fallback route continue to use `name`.
 
 Only agents visible in the exact supplied scope with `a2a_exposed=True` are
 returned. Built-in agents are not exposed by default.

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -14,14 +14,15 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
+from urllib.parse import urlsplit
 
 import structlog
 
 logger = structlog.get_logger(__name__)
 
 from langchain_core.tools import BaseTool
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AfterValidator, BaseModel, Field, field_validator
 
 try:
     import yaml
@@ -29,6 +30,33 @@ try:
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
+
+
+def _validate_a2a_public_interface_url(value: str) -> str:
+    """Validate an absolute public HTTP(S) A2A interface URL without rewriting it."""
+    if not value or any(character.isspace() for character in value):
+        raise ValueError("A2A public interface URL must not be empty or contain whitespace")
+
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError("A2A public interface URL is malformed") from exc
+
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
+        raise ValueError("A2A public interface URL must be an absolute HTTP(S) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("A2A public interface URL must not contain credentials")
+    if parsed.fragment:
+        raise ValueError("A2A public interface URL must not contain a fragment")
+    return value
+
+
+A2APublicInterfaceUrl = Annotated[
+    str,
+    AfterValidator(_validate_a2a_public_interface_url),
+]
 
 
 class ContextPolicy(BaseModel):
@@ -179,6 +207,8 @@ class AgentDefinition(BaseModel):
     Attributes:
         name: Unique agent identifier.
         display_name: Optional human-readable name for public presentation.
+        a2a_public_interface_url: Optional externally routed A2A endpoint advertised
+            in the Agent Card.
         system_prompt: System prompt that defines agent behavior.
         tools: List of attached tool names.
         skills: List of attached skill names.
@@ -210,6 +240,7 @@ class AgentDefinition(BaseModel):
     hidden: bool = Field(default=False)
     native: bool = Field(default=False)
     a2a_exposed: bool = Field(default=False)
+    a2a_public_interface_url: A2APublicInterfaceUrl | None = Field(default=None)
 
     @field_validator("name")
     @classmethod
@@ -587,6 +618,7 @@ def load_agent_definition_from_markdown(path: str | Path) -> AgentDefinition:
     definition = AgentDefinition(
         name=name,
         display_name=frontmatter.get("display_name"),
+        a2a_public_interface_url=frontmatter.get("a2a_public_interface_url"),
         system_prompt=body,
         description=frontmatter.get("description"),
         mode=frontmatter.get("mode", "all"),
@@ -603,6 +635,7 @@ def load_agent_definition_from_markdown(path: str | Path) -> AgentDefinition:
 
 
 __all__ = [
+    "A2APublicInterfaceUrl",
     "AgentConfig",
     "AgentDefinition",
     "AsyncSubagentConfig",

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from pydantic import AnyHttpUrl, BaseModel, Field
 
 from server.app.agent.definition import (
+    A2APublicInterfaceUrl,
     AsyncSubagentConfig,
     ContextPolicy,
     FilesystemPermissionConfig,
@@ -865,7 +866,13 @@ class AgentResponse(BaseModel):
     mode: Literal["primary", "subagent", "all"] = Field(..., description="Agent mode")
     hidden: bool = Field(..., description="Whether agent is hidden from listings")
     native: bool = Field(..., description="Whether agent is built-in")
-    a2a_exposed: bool = Field(default=False, description="Whether agent is exposed via A2A protocol")
+    a2a_exposed: bool = Field(
+        default=False, description="Whether agent is exposed via A2A protocol"
+    )
+    a2a_public_interface_url: A2APublicInterfaceUrl | None = Field(
+        default=None,
+        description="Externally routed A2A endpoint advertised in the Agent Card",
+    )
     provider: str | None = Field(
         None,
         description="Deprecated compatibility field. Use config.provider instead.",
@@ -1252,6 +1259,10 @@ class AgentCreate(BaseModel):
     mode: Literal["primary", "subagent", "all"] = Field(default="primary")
     hidden: bool = Field(default=False)
     a2a_exposed: bool = Field(default=False, description="Expose agent via A2A protocol")
+    a2a_public_interface_url: A2APublicInterfaceUrl | None = Field(
+        default=None,
+        description="Externally routed A2A endpoint advertised in the Agent Card",
+    )
     tools: list[str] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
     memory: list[str] = Field(default_factory=list)
@@ -1298,6 +1309,10 @@ class AgentUpdate(BaseModel):
     mode: Literal["primary", "subagent", "all"] | None = None
     hidden: bool | None = None
     a2a_exposed: bool | None = None
+    a2a_public_interface_url: A2APublicInterfaceUrl | None = Field(
+        default=None,
+        description="Externally routed A2A endpoint advertised in the Agent Card",
+    )
     tools: list[str] | None = None
     skills: list[str] | None = None
     memory: list[str] | None = None

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -28,6 +28,7 @@ def _agent_to_response(agent: AgentDefinition) -> AgentResponse:
         hidden=agent.hidden,
         native=agent.native,
         a2a_exposed=agent.a2a_exposed,
+        a2a_public_interface_url=agent.a2a_public_interface_url,
         provider=agent.config.provider,
         model=agent.config.model,
         temperature=agent.config.temperature,
@@ -128,6 +129,7 @@ async def create_agent(
             "mode": body.mode,
             "hidden": body.hidden,
             "a2a_exposed": body.a2a_exposed,
+            "a2a_public_interface_url": body.a2a_public_interface_url,
             "native": False,
             "tools": body.tools,
             "skills": body.skills,
@@ -220,6 +222,8 @@ async def update_agent(
         updates = body.model_dump(exclude_none=True)
         if "display_name" in body.model_fields_set:
             updates["display_name"] = body.display_name
+        if "a2a_public_interface_url" in body.model_fields_set:
+            updates["a2a_public_interface_url"] = body.a2a_public_interface_url
         config_fields = {
             "model",
             "temperature",

--- a/server/app/protocols/a2a/card.py
+++ b/server/app/protocols/a2a/card.py
@@ -1,8 +1,9 @@
 """Per-agent A2A Agent Card generation from Cognition agent definitions.
 
-Each A2A-exposed agent gets its own AgentCard with a dedicated JSON-RPC
-endpoint at /a2a/{agent_name}. Builders control exposure via the
-a2a_exposed field on AgentDefinition. No agent is exposed by default.
+Each A2A-exposed agent gets its own AgentCard. Builders can advertise an
+externally routed JSON-RPC endpoint with ``a2a_public_interface_url``; otherwise
+Cognition falls back to its dedicated ``/a2a/{agent_name}`` route. Builders
+control exposure via the ``a2a_exposed`` field. No agent is exposed by default.
 """
 
 from __future__ import annotations
@@ -22,7 +23,8 @@ def build_agent_card_for_agent(
 ) -> AgentCard:
     """Build an A2A AgentCard for a single Cognition agent.
 
-    The card's supportedInterfaces URL points to /a2a/{agent_name}.
+    The card's supportedInterfaces URL uses the configured public interface URL
+    when present and otherwise points to /a2a/{agent_name}.
     The card name uses the public display name when configured and otherwise
     falls back to the runtime agent name.
 
@@ -32,15 +34,14 @@ def build_agent_card_for_agent(
     public_name = agent.display_name or agent.name
     has_public_name = agent.display_name is not None
     card_description = agent.description or (
-        f"Agent: {public_name}"
-        if has_public_name
-        else f"Cognition agent: {public_name}"
+        f"Agent: {public_name}" if has_public_name else f"Cognition agent: {public_name}"
     )
     skill_description = agent.description or (
         f"Primary capability for {public_name}"
         if has_public_name
         else f"Cognition agent: {public_name}"
     )
+    interface_url = agent.a2a_public_interface_url or f"{base_url}/a2a/{agent.name}"
 
     skill = AgentSkill(
         id="primary" if has_public_name else agent.name,
@@ -70,7 +71,7 @@ def build_agent_card_for_agent(
         supported_interfaces=[
             AgentInterface(
                 protocol_binding="JSONRPC",
-                url=f"{base_url}/a2a/{agent.name}",
+                url=interface_url,
                 protocol_version="1.0",
             )
         ],
@@ -80,6 +81,6 @@ def build_agent_card_for_agent(
     logger.info(
         "A2A Agent Card built",
         agent_name=agent.name,
-        endpoint=f"/a2a/{agent.name}",
+        interface_url=interface_url,
     )
     return card

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.12.0-rc.1"
+VERSION = "0.12.0-rc.3"
 
 __all__ = ["VERSION"]

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -85,6 +85,50 @@ class TestGetAgent:
 
 
 class TestCreateAgent:
+    def test_create_agent_persists_public_a2a_interface_url(self):
+        public_url = "https://opaque.agents.example.com/a2a"
+        response = client.post(
+            "/agents",
+            json={
+                "name": "ka_create_public_a2a_url",
+                "system_prompt": "Help customers.",
+                "a2a_exposed": True,
+                "a2a_public_interface_url": public_url,
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["a2a_public_interface_url"] == public_url
+
+        get_response = client.get("/agents/ka_create_public_a2a_url")
+        assert get_response.status_code == 200
+        assert get_response.json()["a2a_public_interface_url"] == public_url
+
+        raw = asyncio.run(get_config_store().get_agent_raw("ka_create_public_a2a_url"))
+        assert raw is not None
+        assert raw["a2a_public_interface_url"] == public_url
+
+    @pytest.mark.parametrize(
+        "public_url",
+        [
+            "opaque.agents.example.com/a2a",
+            "ftp://opaque.agents.example.com/a2a",
+            "https://user:secret@opaque.agents.example.com/a2a",
+            "https://opaque.agents.example.com/a2a#fragment",
+        ],
+    )
+    def test_create_agent_rejects_invalid_public_a2a_interface_url(self, public_url: str) -> None:
+        response = client.post(
+            "/agents",
+            json={
+                "name": "ka_invalid_public_a2a_url",
+                "system_prompt": "Help customers.",
+                "a2a_public_interface_url": public_url,
+            },
+        )
+
+        assert response.status_code == 422
+
     def test_create_agent_persists_display_name(self):
         response = client.post(
             "/agents",
@@ -249,6 +293,36 @@ class TestCreateAgent:
 
 
 class TestUpdateAgent:
+    def test_patch_agent_updates_and_clears_public_a2a_interface_url(self):
+        original_url = "https://original.agents.example.com/a2a"
+        updated_url = "https://updated.agents.example.com/a2a"
+        client.post(
+            "/agents",
+            json={
+                "name": "ka_patch_public_a2a_url",
+                "system_prompt": "Help customers.",
+                "a2a_public_interface_url": original_url,
+            },
+        )
+
+        update_response = client.patch(
+            "/agents/ka_patch_public_a2a_url",
+            json={"a2a_public_interface_url": updated_url},
+        )
+        assert update_response.status_code == 200
+        assert update_response.json()["a2a_public_interface_url"] == updated_url
+
+        clear_response = client.patch(
+            "/agents/ka_patch_public_a2a_url",
+            json={"a2a_public_interface_url": None},
+        )
+        assert clear_response.status_code == 200
+        assert clear_response.json()["a2a_public_interface_url"] is None
+
+        raw = asyncio.run(get_config_store().get_agent_raw("ka_patch_public_a2a_url"))
+        assert raw is not None
+        assert raw["a2a_public_interface_url"] is None
+
     def test_patch_agent_updates_and_clears_display_name(self):
         client.post(
             "/agents",

--- a/tests/unit/test_a2a_adapter.py
+++ b/tests/unit/test_a2a_adapter.py
@@ -79,6 +79,22 @@ class TestBuildAgentCardForAgent:
         assert card.supported_interfaces[0].url == "http://localhost:8000/a2a/my-agent"
         assert card.supported_interfaces[0].protocol_binding == "JSONRPC"
 
+    def test_card_uses_configured_public_interface_url_exactly(self):
+        public_url = "https://opaque.agents.example.com/a2a?channel=public"
+        agent = AgentDefinition(
+            name="ka_private_runtime_name",
+            display_name="Customer Support Concierge",
+            system_prompt="test",
+            mode="primary",
+            a2a_exposed=True,
+            a2a_public_interface_url=public_url,
+        )
+
+        card = build_agent_card_for_agent(agent, "http://private:8000", "0.12.0-rc.3")
+
+        assert card.supported_interfaces[0].url == public_url
+        assert "ka_private_runtime_name" not in card.supported_interfaces[0].url
+
     def test_card_has_streaming_capability(self):
         agent = AgentDefinition(name="test", system_prompt="test", mode="primary", a2a_exposed=True)
         card = build_agent_card_for_agent(agent, "http://localhost:8000", "0.10.0")
@@ -216,6 +232,50 @@ class TestA2APerAgentCardRoute:
             )
 
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_per_agent_card_uses_configured_public_interface_url(self):
+        from server.app.protocols.a2a.routes import mount_a2a_routes
+        from server.app.storage.config_registry import MemoryConfigRegistry
+        from server.app.storage.config_store import DefaultConfigStore
+
+        app = FastAPI()
+        settings = MagicMock()
+        settings.scope_keys = []
+        config_store = DefaultConfigStore(MemoryConfigRegistry())
+        public_url = "https://opaque.agents.example.com/a2a"
+        await config_store.upsert_agent(
+            "ka_private_runtime_name",
+            {},
+            {
+                "name": "ka_private_runtime_name",
+                "display_name": "Customer Support Concierge",
+                "system_prompt": "test",
+                "mode": "primary",
+                "a2a_exposed": True,
+                "a2a_public_interface_url": public_url,
+            },
+        )
+        await mount_a2a_routes(
+            app,
+            settings=settings,
+            config_store=config_store,
+            session_agent_manager=MagicMock(),
+            store=MagicMock(),
+            version="0.12.0-rc.3",
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://private:8000",
+        ) as client:
+            response = await client.get("/a2a/ka_private_runtime_name/.well-known/agent-card.json")
+
+        assert response.status_code == 200
+        card = response.json()
+        assert card["name"] == "Customer Support Concierge"
+        assert card["supportedInterfaces"][0]["url"] == public_url
 
 
 class TestA2AExposureFiltering:

--- a/tests/unit/test_agent_markdown_config.py
+++ b/tests/unit/test_agent_markdown_config.py
@@ -13,6 +13,7 @@ def test_markdown_config_block_populates_agent_config(tmp_path: Path) -> None:
         """---
 display_name: Incident Investigator
 description: Investigates incidents
+a2a_public_interface_url: https://opaque.agents.example.com/a2a
 temperature: 0.2
 config:
   max_tokens: 16000
@@ -29,6 +30,7 @@ You are an investigator.
     definition = load_agent_definition_from_markdown(path)
 
     assert definition.display_name == "Incident Investigator"
+    assert definition.a2a_public_interface_url == "https://opaque.agents.example.com/a2a"
     assert definition.config.temperature == 0.2
     assert definition.config.max_tokens == 16000
     assert definition.config.recursion_limit == 500


### PR DESCRIPTION
## Summary

- add optional validated a2a_public_interface_url to agent definitions and CRUD APIs
- advertise the configured endpoint exactly in A2A Agent Cards, retaining request-derived per-agent URLs as fallback
- preserve runtime lookup identity and display-name behavior
- update docs, roadmap, changelog, and reported version for 0.12.0-rc3

## Compatibility

Existing agent definitions remain valid. When the new field is absent, supportedInterfaces continues to use the current /a2a/{agent_name} route derived from the request base URL.

## Verification

- uv run pytest tests/unit -v (849 passed, 4 skipped)
- uv run mypy .
- uv run ruff check .

## Release

After required checks pass, merge into release/v0.12.0 and publish both app and sandbox 0.12.0-rc3 multi-arch images from the merged release commit.