### PR TITLE
Publish A2A authentication discovery for 0.12.0-rc4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ COGNITION_OTEL_ENABLED=false
 COGNITION_OTEL_ENDPOINT=http://localhost:4317
 COGNITION_METRICS_PORT=9090
 
+# A2A protocol and public authentication discovery
+COGNITION_A2A_ENABLED=true
+# Public metadata only. Never include OAuth client secrets or bearer tokens.
+# COGNITION_A2A_SECURITY_SCHEMES={"oauth2":{"oauth2SecurityScheme":{"description":"Machine credentials","flows":{"clientCredentials":{"tokenUrl":"https://auth.example.com/oauth/token","scopes":{"a2a.invoke":"Invoke the agent"}}},"oauth2MetadataUrl":"https://auth.example.com/.well-known/openid-configuration"}}}
+# COGNITION_A2A_SECURITY_REQUIREMENTS=[{"schemes":{"oauth2":{}}}]
+
 # MLflow Tracing (optional)
 COGNITION_MLFLOW_ENABLED=false
 COGNITION_MLFLOW_TRACKING_URI=http://localhost:5000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.12.0-rc.4] — 2026-07-18
+
+### Added
+
+- Added deployment-level `COGNITION_A2A_SECURITY_SCHEMES` and `COGNITION_A2A_SECURITY_REQUIREMENTS` configuration for canonical A2A authentication discovery metadata.
+
+### Fixed
+
+- Generated Agent Cards now publish validated security schemes and requirements for gateway-protected A2A endpoints, fail startup on invalid metadata or undeclared scheme references, and retain unauthenticated defaults when the settings are omitted.
+- Updated the reported Cognition version to `0.12.0-rc.4` for the new release candidate.
+
 ## [0.12.0-rc.3] — 2026-07-18
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-18 | Publish validated deployment-level A2A authentication schemes and requirements in generated Agent Cards without moving authentication enforcement into Cognition. | Kennel `0.12.0-rc3` authentication-discovery blocker | 1/6 | Completed |
 | 2026-07-18 | Honor a builder-configured external A2A interface URL in Agent Cards while retaining the request-derived per-agent route as a backward-compatible fallback. | Kennel `0.12.0-rc2` public Agent Card URL report | 2/6 | Completed |
 | 2026-07-18 | Remove Cognition implementation branding from A2A Agent Card names so cards identify the configured agent directly. | Kennel Agent Card identity report | 6 | Completed |
 | 2026-07-10 | Verify Lambda MicroVM teardown before reporting completion and emit token-free lifecycle events/logs for launch, auth token creation, healthchecks, runtime snapshots, and teardown outcomes. | v0.11 rc Lambda MicroVM operator observability follow-up | 3/6/7 | Completed |

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -232,6 +232,13 @@ are visible; set it only on agents intended for A2A access.
 
 **Global disable**: Set `COGNITION_A2A_ENABLED=false` to prevent the A2A protocol surface from being mounted at all. When disabled, the endpoints do not exist and `GET /capabilities` reports `a2a: false`.
 
+**Authentication discovery**: When trusted ingress protects the advertised A2A
+interface, set `COGNITION_A2A_SECURITY_SCHEMES` and
+`COGNITION_A2A_SECURITY_REQUIREMENTS` to canonical A2A ProtoJSON. Cognition
+publishes the validated values in its Agent Cards but does not enforce them.
+Gateway enforcement must match the card. Because Agent Cards are public, never
+place client secrets, bearer tokens, or private credentials in these values.
+
 ---
 
 ## Rate Limiting

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -1756,6 +1756,12 @@ messages, events, and artifacts exactly by it; it does not own tenant or IAM mod
 
 The A2A protocol surface can be disabled entirely by setting `COGNITION_A2A_ENABLED=false`. When disabled, the `/.well-known/agent-card.json` and `/a2a/{agent_name}` endpoints are not mounted, and `GET /capabilities` reports `a2a: false`.
 
+For endpoints protected by builder-owned ingress, configure public authentication
+discovery with `COGNITION_A2A_SECURITY_SCHEMES` and
+`COGNITION_A2A_SECURITY_REQUIREMENTS`. Both values use canonical A2A ProtoJSON.
+Cognition validates them during startup and publishes them on every generated
+card; it does not enforce the advertised authentication scheme.
+
 ### `GET /.well-known/agent-card.json`
 
 Return one scope-visible A2A `AgentCard`. Use `?assistant_id={agent_name}` when a
@@ -1780,12 +1786,31 @@ X-Cognition-Scope-User: alice
       "protocolVersion": "1.0"
     }
   ],
-  "version": "0.12.0-rc.3",
+  "version": "0.12.0-rc.4",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false,
     "extendedAgentCard": false
   },
+  "securitySchemes": {
+    "oauth2": {
+      "oauth2SecurityScheme": {
+        "description": "Machine credentials",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://auth.example.com/oauth/token",
+            "scopes": {
+              "a2a.invoke": "Invoke the agent"
+            }
+          }
+        },
+        "oauth2MetadataUrl": "https://auth.example.com/.well-known/openid-configuration"
+      }
+    }
+  },
+  "securityRequirements": [
+    {"schemes": {"oauth2": {}}}
+  ],
   "defaultInputModes": ["text/plain"],
   "defaultOutputModes": ["text/plain", "application/json"],
   "skills": [

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -445,10 +445,19 @@ for the end-to-end setup flow and Terraform example.
 | `security.trusted_tool_namespaces` | `COGNITION_TRUSTED_TOOL_NAMESPACES` | `[]` | Allowed Python namespaces for tool imports; empty = allow all |
 | `security.blocked_tools` | `COGNITION_BLOCKED_TOOLS` | `[]` | Deployment-wide tool names no agent can invoke; merged with per-agent `blocked_tools` and enforced by `ToolSecurityMiddleware` |
 | `security.a2a_enabled` | `COGNITION_A2A_ENABLED` | `true` | Enable/disable the A2A protocol adapter (`/.well-known/agent-card.json` + `/a2a/{agent_name}`) |
+| — | `COGNITION_A2A_SECURITY_SCHEMES` | `{}` | Canonical A2A ProtoJSON map of public authentication scheme names to `SecurityScheme` objects |
+| — | `COGNITION_A2A_SECURITY_REQUIREMENTS` | `[]` | Canonical A2A ProtoJSON array of `SecurityRequirement` objects applied to every generated card |
 
 > **Note:** `COGNITION_TOOL_SECURITY` (`warn`/`strict`) was removed. AST scanning has been replaced with Gateway-level authorization. See [Security concepts](../concepts/security.md) for the current trust model.
 
 `COGNITION_BLOCKED_TOOLS` is an execution-deny policy only. It does not remove tools from the model-visible schema. To hide tools for a specific agent, set `config.excluded_tools` on that agent definition or pass `excluded_tools` through the `/agents` API.
+
+The A2A security variables publish authentication discovery metadata; they do
+not make Cognition an OAuth server or enforce authentication. Enforcement
+remains the responsibility of trusted ingress. Cognition validates their
+canonical A2A protobuf JSON shape during startup and rejects requirements that
+reference undeclared schemes. These public values must never contain client
+secrets, access tokens, or other credentials.
 
 ---
 
@@ -634,9 +643,11 @@ scoping:
     - "user"
     - "project"
 
-# A2A is auto-mounted when enabled. No configuration needed.
+# A2A is auto-mounted when enabled. Unauthenticated deployments need no extra config.
 # Expose agents via A2A by setting a2a_exposed: true on their definition.
 # Set COGNITION_A2A_ENABLED=false to disable the A2A protocol surface entirely.
+# Gateway-protected deployments can publish authentication discovery through
+# COGNITION_A2A_SECURITY_SCHEMES and COGNITION_A2A_SECURITY_REQUIREMENTS.
 
 rate_limit:
   per_minute: 120

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -150,6 +150,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Mount A2A protocol adapter (requires COGNITION_A2A_ENABLED=true)
     if settings.a2a_enabled:
+        from server.app.protocols.a2a.security import parse_a2a_card_security
+
+        card_security = parse_a2a_card_security(
+            settings.a2a_security_schemes,
+            settings.a2a_security_requirements,
+        )
         try:
             from server.app.protocols.a2a.routes import mount_a2a_routes
 
@@ -161,6 +167,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 store=storage_backend,
                 version=VERSION,
                 artifact_store=artifact_store,
+                card_security=card_security,
             )
             logger.info("A2A protocol adapter mounted")
         except Exception as e:

--- a/server/app/protocols/a2a/card.py
+++ b/server/app/protocols/a2a/card.py
@@ -12,6 +12,7 @@ import structlog
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
 
 from server.app.agent.definition import AgentDefinition
+from server.app.protocols.a2a.security import A2ACardSecurity
 
 logger = structlog.get_logger(__name__)
 
@@ -20,6 +21,7 @@ def build_agent_card_for_agent(
     agent: AgentDefinition,
     base_url: str,
     version: str,
+    security: A2ACardSecurity | None = None,
 ) -> AgentCard:
     """Build an A2A AgentCard for a single Cognition agent.
 
@@ -42,6 +44,7 @@ def build_agent_card_for_agent(
         else f"Cognition agent: {public_name}"
     )
     interface_url = agent.a2a_public_interface_url or f"{base_url}/a2a/{agent.name}"
+    security = security or A2ACardSecurity(schemes={}, requirements=())
 
     skill = AgentSkill(
         id="primary" if has_public_name else agent.name,
@@ -75,6 +78,8 @@ def build_agent_card_for_agent(
                 protocol_version="1.0",
             )
         ],
+        security_schemes=security.schemes,
+        security_requirements=list(security.requirements),
         skills=[skill],
     )
 

--- a/server/app/protocols/a2a/routes.py
+++ b/server/app/protocols/a2a/routes.py
@@ -68,6 +68,7 @@ from server.app.exceptions import (
 from server.app.models import TaskStatus
 from server.app.protocols.a2a.card import build_agent_card_for_agent
 from server.app.protocols.a2a.executor import CognitionA2AExecutor
+from server.app.protocols.a2a.security import A2ACardSecurity, parse_a2a_card_security
 from server.app.protocols.a2a.task_store import (
     CognitionTaskStore,
     effective_scope_from_context,
@@ -428,6 +429,7 @@ async def mount_a2a_routes(
     version: str,
     artifact_store: ArtifactStore | None = None,
     message_id_idempotency: bool = True,
+    card_security: A2ACardSecurity | None = None,
 ) -> None:
     """Mount A2A protocol routes on the FastAPI app.
 
@@ -440,6 +442,11 @@ async def mount_a2a_routes(
     """
     scope_keys = list(settings.scope_keys)
     scoping_enabled = bool(getattr(settings, "scoping_enabled", False))
+    if card_security is None:
+        card_security = parse_a2a_card_security(
+            getattr(settings, "a2a_security_schemes", {}),
+            getattr(settings, "a2a_security_requirements", []),
+        )
 
     runtime = AgentTaskRuntime(
         store,
@@ -533,7 +540,12 @@ async def mount_a2a_routes(
                 status_code=404,
             )
 
-        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
+        card = build_agent_card_for_agent(
+            agent,
+            _request_base_url(request),
+            version,
+            security=card_security,
+        )
         return card_response(card)
 
     async def per_agent_card_handler(request: Request) -> JSONResponse:
@@ -554,7 +566,12 @@ async def mount_a2a_routes(
                 status_code=404,
             )
 
-        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
+        card = build_agent_card_for_agent(
+            agent,
+            _request_base_url(request),
+            version,
+            security=card_security,
+        )
         return card_response(card)
 
     # --- Catch-all JSON-RPC endpoint ---
@@ -601,7 +618,12 @@ async def mount_a2a_routes(
         if not isinstance(payload, dict):
             return _jsonrpc_error_response(None, -32600, "Invalid request")
 
-        card = build_agent_card_for_agent(agent, _request_base_url(request), version)
+        card = build_agent_card_for_agent(
+            agent,
+            _request_base_url(request),
+            version,
+            security=card_security,
+        )
         handler = get_handler(agent.name, card)
         dispatcher = JsonRpcDispatcher(
             request_handler=handler,

--- a/server/app/protocols/a2a/security.py
+++ b/server/app/protocols/a2a/security.py
@@ -1,0 +1,93 @@
+"""Deployment-level A2A Agent Card security discovery configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from a2a.types import SecurityRequirement, SecurityScheme
+from a2a.utils.proto_utils import validate_proto_required_fields
+from google.protobuf.json_format import ParseDict  # type: ignore[import-untyped]
+
+
+class A2ASecurityConfigurationError(ValueError):
+    """Raised when public A2A security discovery metadata is invalid."""
+
+
+@dataclass(frozen=True)
+class A2ACardSecurity:
+    """Validated security metadata shared by generated Agent Cards."""
+
+    schemes: dict[str, SecurityScheme]
+    requirements: tuple[SecurityRequirement, ...]
+
+
+def parse_a2a_card_security(
+    schemes_data: dict[str, dict[str, Any]],
+    requirements_data: list[dict[str, Any]],
+) -> A2ACardSecurity:
+    """Parse and cross-validate canonical A2A ProtoJSON security metadata.
+
+    Args:
+        schemes_data: Map of public scheme names to ``SecurityScheme`` ProtoJSON.
+        requirements_data: List of ``SecurityRequirement`` ProtoJSON objects.
+
+    Returns:
+        Typed protobuf security metadata suitable for an ``AgentCard``.
+
+    Raises:
+        A2ASecurityConfigurationError: If the ProtoJSON is invalid or a requirement
+            references an undeclared scheme.
+    """
+    schemes: dict[str, SecurityScheme] = {}
+    for name, payload in schemes_data.items():
+        if not name:
+            raise A2ASecurityConfigurationError(
+                "COGNITION_A2A_SECURITY_SCHEMES contains an empty scheme name"
+            )
+        try:
+            scheme = ParseDict(
+                payload,
+                SecurityScheme(),
+                ignore_unknown_fields=False,
+            )
+            if scheme.WhichOneof("scheme") is None:
+                raise ValueError("exactly one security scheme variant is required")
+            validate_proto_required_fields(scheme)
+        except Exception as exc:
+            raise A2ASecurityConfigurationError(
+                f"COGNITION_A2A_SECURITY_SCHEMES[{name!r}] is invalid: {exc}"
+            ) from exc
+        schemes[name] = scheme
+
+    requirements: list[SecurityRequirement] = []
+    for index, payload in enumerate(requirements_data):
+        try:
+            requirement = ParseDict(
+                payload,
+                SecurityRequirement(),
+                ignore_unknown_fields=False,
+            )
+            validate_proto_required_fields(requirement)
+        except Exception as exc:
+            raise A2ASecurityConfigurationError(
+                f"COGNITION_A2A_SECURITY_REQUIREMENTS[{index}] is invalid: {exc}"
+            ) from exc
+
+        undeclared = sorted(set(requirement.schemes) - set(schemes))
+        if undeclared:
+            names = ", ".join(undeclared)
+            raise A2ASecurityConfigurationError(
+                "COGNITION_A2A_SECURITY_REQUIREMENTS"
+                f"[{index}] references undeclared schemes: {names}"
+            )
+        requirements.append(requirement)
+
+    return A2ACardSecurity(schemes=schemes, requirements=tuple(requirements))
+
+
+__all__ = [
+    "A2ACardSecurity",
+    "A2ASecurityConfigurationError",
+    "parse_a2a_card_security",
+]

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -234,6 +234,21 @@ class Settings(BaseSettings):
             "Individual agents still require a2a_exposed=true to be visible."
         ),
     )
+    a2a_security_schemes: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        alias="COGNITION_A2A_SECURITY_SCHEMES",
+        description=(
+            "Canonical A2A ProtoJSON map of public Agent Card authentication schemes. "
+            "This is discovery metadata only and must never contain credentials."
+        ),
+    )
+    a2a_security_requirements: list[dict[str, Any]] = Field(
+        default_factory=list,
+        alias="COGNITION_A2A_SECURITY_REQUIREMENTS",
+        description=(
+            "Canonical A2A ProtoJSON security requirements applied to generated Agent Cards."
+        ),
+    )
 
     # SSE (Server-Sent Events) settings
     sse_heartbeat_interval_seconds: float = Field(

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.12.0-rc.3"
+VERSION = "0.12.0-rc.4"
 
 __all__ = ["VERSION"]

--- a/tests/unit/test_a2a_security.py
+++ b/tests/unit/test_a2a_security.py
@@ -1,0 +1,156 @@
+"""Tests for deployment-level A2A Agent Card security discovery."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
+
+from server.app.agent.definition import AgentDefinition
+from server.app.protocols.a2a.card import build_agent_card_for_agent
+from server.app.protocols.a2a.security import (
+    A2ASecurityConfigurationError,
+    parse_a2a_card_security,
+)
+from server.app.storage.config_registry import MemoryConfigRegistry
+from server.app.storage.config_store import DefaultConfigStore
+
+OAUTH2_SCHEMES: dict[str, dict[str, Any]] = {
+    "oauth2": {
+        "oauth2SecurityScheme": {
+            "description": "KennelAMS machine credentials",
+            "flows": {
+                "clientCredentials": {
+                    "tokenUrl": "https://auth.example.com/oauth/token",
+                    "scopes": {
+                        "a2a.invoke": "Invoke the agent",
+                        "a2a.task.read": "Read owned tasks",
+                    },
+                }
+            },
+            "oauth2MetadataUrl": (
+                "https://auth.example.com/.well-known/openid-configuration"
+            ),
+        }
+    }
+}
+OAUTH2_REQUIREMENTS: list[dict[str, Any]] = [{"schemes": {"oauth2": {}}}]
+
+
+def test_parse_security_and_publish_canonical_agent_card_fields() -> None:
+    security = parse_a2a_card_security(OAUTH2_SCHEMES, OAUTH2_REQUIREMENTS)
+    agent = AgentDefinition(
+        name="private-runtime-name",
+        display_name="Customer Support Concierge",
+        system_prompt="Help customers.",
+        a2a_exposed=True,
+    )
+
+    card = build_agent_card_for_agent(
+        agent,
+        "https://agents.example.com",
+        "0.12.0-rc.4",
+        security=security,
+    )
+    payload = MessageToDict(card, preserving_proto_field_name=False)
+
+    assert payload["securitySchemes"] == OAUTH2_SCHEMES
+    assert payload["securityRequirements"] == OAUTH2_REQUIREMENTS
+
+
+def test_empty_security_defaults_leave_card_unauthenticated() -> None:
+    security = parse_a2a_card_security({}, [])
+    agent = AgentDefinition(name="public-agent", system_prompt="Help customers.")
+
+    card = build_agent_card_for_agent(
+        agent,
+        "https://agents.example.com",
+        "0.12.0-rc.4",
+        security=security,
+    )
+    payload = MessageToDict(card, preserving_proto_field_name=False)
+
+    assert "securitySchemes" not in payload
+    assert "securityRequirements" not in payload
+
+
+def test_rejects_requirement_referencing_undeclared_scheme() -> None:
+    with pytest.raises(A2ASecurityConfigurationError, match="undeclared schemes: oauth2"):
+        parse_a2a_card_security({}, OAUTH2_REQUIREMENTS)
+
+
+def test_rejects_unknown_protojson_fields() -> None:
+    schemes: dict[str, dict[str, Any]] = {
+        "oauth2": {"unknownSecurityScheme": {}}
+    }
+
+    with pytest.raises(A2ASecurityConfigurationError, match="oauth2.*invalid"):
+        parse_a2a_card_security(schemes, [])
+
+
+def test_rejects_scheme_without_variant() -> None:
+    with pytest.raises(A2ASecurityConfigurationError, match="exactly one"):
+        parse_a2a_card_security({"oauth2": {}}, [])
+
+
+def test_rejects_oauth_flow_without_required_token_url() -> None:
+    schemes: dict[str, dict[str, Any]] = {
+        "oauth2": {
+            "oauth2SecurityScheme": {
+                "flows": {"clientCredentials": {"scopes": {}}}
+            }
+        }
+    }
+
+    with pytest.raises(A2ASecurityConfigurationError, match="oauth2.*invalid"):
+        parse_a2a_card_security(schemes, [])
+
+
+@pytest.mark.asyncio
+async def test_mounted_card_uses_deployment_security_settings() -> None:
+    from server.app.protocols.a2a.routes import mount_a2a_routes
+
+    app = FastAPI()
+    settings = MagicMock()
+    settings.scope_keys = []
+    settings.scoping_enabled = False
+    settings.workspace_path = "/tmp"
+    settings.a2a_security_schemes = OAUTH2_SCHEMES
+    settings.a2a_security_requirements = OAUTH2_REQUIREMENTS
+    config_store = DefaultConfigStore(MemoryConfigRegistry())
+    await config_store.upsert_agent(
+        "support-agent",
+        {},
+        {
+            "name": "support-agent",
+            "system_prompt": "Help customers.",
+            "mode": "primary",
+            "a2a_exposed": True,
+        },
+    )
+    await mount_a2a_routes(
+        app,
+        settings=settings,
+        config_store=config_store,
+        session_agent_manager=MagicMock(),
+        store=MagicMock(),
+        version="0.12.0-rc.4",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="https://agents.example.com",
+    ) as client:
+        response = await client.get(
+            "/a2a/support-agent/.well-known/agent-card.json"
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["securitySchemes"] == OAUTH2_SCHEMES
+    assert payload["securityRequirements"] == OAUTH2_REQUIREMENTS

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic import SecretStr
@@ -51,6 +53,40 @@ class TestSettingsDefaults:
         settings = TestSettings()
         assert settings.otel_endpoint is None
         assert settings.metrics_port == 9090
+
+    def test_default_a2a_security_discovery_is_empty(self):
+        settings = TestSettings()
+        assert settings.a2a_security_schemes == {}
+        assert settings.a2a_security_requirements == []
+
+
+class TestA2ASecuritySettings:
+    """Test JSON environment parsing for public Agent Card security metadata."""
+
+    def test_parses_a2a_security_environment_json(self, monkeypatch: pytest.MonkeyPatch):
+        schemes = {
+            "oauth2": {
+                "oauth2SecurityScheme": {
+                    "flows": {
+                        "clientCredentials": {
+                            "tokenUrl": "https://auth.example.com/oauth/token",
+                            "scopes": {"a2a.invoke": "Invoke the agent"},
+                        }
+                    }
+                }
+            }
+        }
+        requirements: list[dict[str, Any]] = [{"schemes": {"oauth2": {}}}]
+        monkeypatch.setenv("COGNITION_A2A_SECURITY_SCHEMES", json.dumps(schemes))
+        monkeypatch.setenv(
+            "COGNITION_A2A_SECURITY_REQUIREMENTS",
+            json.dumps(requirements),
+        )
+
+        settings = TestSettings()
+
+        assert settings.a2a_security_schemes == schemes
+        assert settings.a2a_security_requirements == requirements
 
 
 class TestSettingsSecrets:


### PR DESCRIPTION
## Summary

- add deployment-level COGNITION_A2A_SECURITY_SCHEMES and COGNITION_A2A_SECURITY_REQUIREMENTS settings
- parse canonical A2A ProtoJSON into typed protobuf security objects at startup
- reject invalid shapes, incomplete required fields, and requirements referencing undeclared schemes
- publish validated metadata on every generated Agent Card while leaving enforcement at trusted ingress
- preserve empty unauthenticated defaults and prepare 0.12.0-rc4

## Root cause

Cognition generated A2A 1.0 cards without any deployment-level authentication discovery input, so gateway-protected endpoints could not advertise the OAuth or other schemes clients must use.

## Validation

- uv run pytest tests/unit -q (858 passed, 4 skipped)
- uv run mypy .
- uv run ruff check .

## Release

After required checks pass, merge into release/v0.12.0 and publish app and sandbox 0.12.0-rc4 multi-arch images from the merged release commit.