### PR TITLE
chore: prepare 0.12.0 rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.0-rc.5] — 2026-07-19
+
 ### Added
 
 - Added ordered inbound A2A 1.0 `text`, `data`, `raw`, and `url` Part normalization. Inline bytes and URL references become inert, task-linked artifacts under the request's exact scope; URL Parts are never fetched implicitly.

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -1804,7 +1804,7 @@ X-Cognition-Scope-User: alice
       "protocolVersion": "1.0"
     }
   ],
-  "version": "0.12.0-rc.4",
+  "version": "0.12.0-rc.5",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false,

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.12.0-rc.4"
+VERSION = "0.12.0-rc.5"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary

- set the runtime-reported version to `0.12.0-rc.5`
- promote the merged A2A work from Unreleased into the rc5 changelog
- update the Agent Card API example to rc5

## Validation

- `uv run pytest tests/unit/test_rest_api.py tests/unit/test_a2a_adapter.py tests/unit/test_a2a_security.py -q`
- `git diff --check`

This metadata update prevents the published rc5 image and generated Agent Cards from reporting rc4.