### PR TITLE
fix(runtime): terminate stalled agent executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Enforced `agent.config.timeout_seconds` as a shared execution deadline. Stalled provider streams are aborted and native or A2A callers now receive a terminal `EXECUTION_TIMEOUT` failure instead of an indefinitely open response.
+
 ## [0.12.0-rc.5] — 2026-07-19
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-20 | Enforce the configured per-agent execution deadline across shared native and A2A streaming so stalled provider streams terminate with a durable failure. | Kennel `0.12.0-rc5` live A2A streaming report | 4/6 | Completed |
 | 2026-07-19 | Prevent unit-test settings mocks from being coerced into real `MagicMock`-named workspace directories; use concrete temporary/in-memory paths and fail tests that attempt mocked filesystem writes. | Test-suite filesystem leak | 1/2 | Completed |
 | 2026-07-18 | Publish validated deployment-level A2A authentication schemes and requirements in generated Agent Cards without moving authentication enforcement into Cognition. | Kennel `0.12.0-rc3` authentication-discovery blocker | 1/6 | Completed |
 | 2026-07-18 | Honor a builder-configured external A2A interface URL in Agent Cards while retaining the request-derived per-agent route as a backward-compatible fallback. | Kennel `0.12.0-rc2` public Agent Card URL report | 2/6 | Completed |

--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -753,7 +753,7 @@ Create or replace an agent definition in the ConfigRegistry.
 | `context_policy` | object | Context and summarization policy configuration |
 | `excluded_tools` | list[string] | Tool names removed from the model-visible tool list for this agent |
 | `blocked_tools` | list[string] | Tool names denied at execution time for this agent in addition to global `COGNITION_BLOCKED_TOOLS` |
-| `timeout_seconds` | float | Per-agent model request timeout |
+| `timeout_seconds` | float | Per-agent execution deadline. A stalled provider or agent run is aborted and reported as failed when the deadline expires. |
 | `middleware` | list | Middleware names or middleware config dicts |
 | `subagents` | list[object] | In-process subagent definitions |
 | `async_subagents` | list[object] | Experimental remote Agent Protocol async subagent definitions |

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -17,9 +17,9 @@ import hashlib
 import json
 import time
 from collections import deque
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 import structlog
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -63,6 +63,8 @@ from server.app.storage.config_store import ConfigStore
 from server.app.storage.factory import create_storage_backend
 
 logger = structlog.get_logger(__name__)
+
+_EventT = TypeVar("_EventT")
 
 
 class AgentDefinitionUnavailableError(Exception):
@@ -216,6 +218,21 @@ class StreamAccumulator:
     @property
     def in_tool_call(self) -> bool:
         return self._current_tool_call is not None
+
+
+async def _with_execution_timeout(
+    events: AsyncIterator[_EventT],
+    timeout_seconds: float | None,
+) -> AsyncIterator[_EventT]:
+    """Yield runtime events while enforcing the configured turn deadline."""
+    if timeout_seconds is None:
+        async for event in events:
+            yield event
+        return
+
+    async with asyncio.timeout(timeout_seconds):
+        async for event in events:
+            yield event
 
 
 def _has_explicit_agent_field(agent_def: Any, field_name: str) -> bool:
@@ -544,14 +561,22 @@ class DeepAgentStreamingService:
             messages = self._build_messages(content, None)
 
             acc = StreamAccumulator(input_tokens=count_text_tokens(content))
+            execution_timeout_seconds = (
+                agent_cfg.agent_def.config.timeout_seconds
+                if agent_cfg.agent_def is not None
+                else None
+            )
 
             runtime_exception: Exception | None = None
 
             try:
                 try:
-                    async for event in runtime.astream_events(
-                        {"messages": messages},
-                        thread_id=thread_id,
+                    async for event in _with_execution_timeout(
+                        runtime.astream_events(
+                            {"messages": messages},
+                            thread_id=thread_id,
+                        ),
+                        execution_timeout_seconds,
                     ):
                         if isinstance(event, TokenEvent):
                             acc.record_token(event.content)
@@ -592,6 +617,22 @@ class DeepAgentStreamingService:
 
                     # DoneEvent from the runtime is absorbed here; we emit our own below.
 
+                except TimeoutError:
+                    await runtime.abort(thread_id)
+                    logger.warning(
+                        "Agent execution deadline exceeded",
+                        session_id=session_id,
+                        thread_id=thread_id,
+                        timeout_seconds=execution_timeout_seconds,
+                    )
+                    yield ErrorEvent(
+                        message=(
+                            "Agent execution exceeded the configured "
+                            f"{execution_timeout_seconds:g} second deadline"
+                        ),
+                        code="EXECUTION_TIMEOUT",
+                    )
+                    return
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:

--- a/tests/unit/test_a2a_jsonrpc_runtime.py
+++ b/tests/unit/test_a2a_jsonrpc_runtime.py
@@ -13,6 +13,7 @@ from server.app.agent.runtime import (
     ArtifactEvent,
     DirectMessageEvent,
     DoneEvent,
+    ErrorEvent,
     InterruptEvent,
     TokenEvent,
 )
@@ -47,6 +48,12 @@ class _FakeAgentService:
                 tool_call_id="approval-1",
                 tool_name="publish",
                 args={},
+            )
+            return
+        if message_id.startswith("execution-timeout"):
+            yield ErrorEvent(
+                message="Agent execution exceeded the configured deadline",
+                code="EXECUTION_TIMEOUT",
             )
             return
         if message_id.startswith("tck-artifact-data"):
@@ -327,6 +334,41 @@ async def test_send_streaming_uses_1_0_wrappers_and_terminal_subscribe_is_reject
         )
 
         assert subscribe.json()["error"]["code"] == -32004
+
+
+async def test_streaming_execution_timeout_emits_failed_terminal_status(
+    setup_storage_backend: StorageBackend,
+    tmp_path,
+) -> None:
+    client = await _build_client(setup_storage_backend, tmp_path)
+    stream_request = _send_request("execution-timeout-message")
+    stream_request["method"] = "SendStreamingMessage"
+    events: list[dict] = []
+
+    async with client:
+        async with client.stream(
+            "POST",
+            "/a2a/researcher",
+            json=stream_request,
+            headers={"Accept": "text/event-stream"},
+        ) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[6:]))
+
+    terminal = [
+        event["result"]["statusUpdate"]
+        for event in events
+        if "statusUpdate" in event.get("result", {})
+    ]
+    assert terminal[-1]["status"]["state"] == "TASK_STATE_FAILED"
+    task_id = terminal[-1]["taskId"]
+    task = await setup_storage_backend.get_task(task_id, {"account": "acme"})
+    assert task is not None
+    assert task.status.value == "failed"
+    run = await setup_storage_backend.get_run(task.last_run_id or task.current_run_id or "")
+    assert run is not None
+    assert run.error_code == "EXECUTION_TIMEOUT"
 
 
 async def test_jsonrpc_trailing_slash_and_wrong_content_type_are_protocol_responses(

--- a/tests/unit/test_streaming_bugs.py
+++ b/tests/unit/test_streaming_bugs.py
@@ -20,6 +20,7 @@ Bug 3 — model in usage event reports gpt-4o regardless of provider:
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Literal
@@ -29,6 +30,7 @@ import pytest
 
 from server.app.agent.runtime import (
     DoneEvent,
+    ErrorEvent,
     TokenEvent,
     UsageEvent,
 )
@@ -155,6 +157,13 @@ async def _runtime_raises(exc: Exception) -> AsyncGenerator[Any, None]:
     if False:
         yield None
     raise exc
+
+
+async def _runtime_never_finishes() -> AsyncGenerator[Any, None]:
+    """Model a provider stream that opens but never terminates."""
+    if False:
+        yield None
+    await asyncio.Event().wait()
 
 
 # ---------------------------------------------------------------------------
@@ -383,3 +392,55 @@ class TestRuntimeErrorsSurface:
         error_events = [e for e in collected if getattr(e, "code", None) == "STREAMING_ERROR"]
         assert len(error_events) == 1
         assert "graph blew up" in error_events[0].message
+
+
+class TestExecutionTimeout:
+    """Configured agent deadlines must terminate stalled provider streams."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_aborts_runtime_and_emits_stable_error(self):
+        from server.app.agent.definition import AgentConfig, AgentDefinition
+        from server.app.llm.deep_agent_service import (
+            DeepAgentStreamingService,
+            ResolvedAgentConfig,
+        )
+
+        session = _make_session()
+        mock_runtime = MagicMock()
+        mock_runtime.astream_events = MagicMock(return_value=_runtime_never_finishes())
+        mock_runtime.abort = AsyncMock(return_value=True)
+        service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
+
+        agent_definition = AgentDefinition(
+            name="timeout-agent",
+            system_prompt="Remain bounded",
+            config=AgentConfig(timeout_seconds=0.01),
+        )
+        resolved = ResolvedAgentConfig(agent_def=agent_definition)
+        p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch.object(
+                service,
+                "_resolve_agent_config",
+                new=AsyncMock(return_value=(resolved, [])),
+            ),
+        ):
+            collected = await _collect(service, session)
+
+        timeout_events = [
+            event
+            for event in collected
+            if isinstance(event, ErrorEvent) and event.code == "EXECUTION_TIMEOUT"
+        ]
+        assert len(timeout_events) == 1
+        assert "0.01 second deadline" in timeout_events[0].message
+        mock_runtime.abort.assert_awaited_once_with(session.thread_id)
+        assert not any(isinstance(event, DoneEvent) for event in collected)


### PR DESCRIPTION
## Summary

- enforce `agent.config.timeout_seconds` around the shared Deep Agents execution stream
- abort a stalled runtime and emit the stable `EXECUTION_TIMEOUT` error when its deadline expires
- allow the A2A executor to persist and emit a terminal `TASK_STATE_FAILED` update, closing the SSE response
- document the field as an execution deadline and record the rc5 Kennel finding in the roadmap/changelog

This is provider-neutral and applies to both native and A2A callers through the shared streaming service. Agents without `timeout_seconds` retain their current behavior.

## Regression coverage

- a deliberately non-terminating runtime is aborted at the configured deadline
- exactly one `EXECUTION_TIMEOUT` error is emitted and no completion event follows
- A2A streaming emits a failed terminal status, closes, and persists the run error code

## Validation

- `uv run pytest tests/unit -q` — 868 passed, 4 skipped
- `uv run ruff check .`
- `uv run mypy .` — 244 files
- `uv run mkdocs build --strict`
- `git diff --check`
