### PR TITLE
fix(a2a): support bidirectional Part projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Projected validated Deep Agents `structured_response` state as an outbound A2A data artifact and added bidirectional wire coverage for text, data, raw, and URL Parts.
+
 ## [0.12.0-rc.5] — 2026-07-19
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-20 | Project validated Deep Agents structured responses into outbound A2A data artifacts and verify text, data, raw, and URL Parts bidirectionally on JSON-RPC and SSE wire paths. | A2A outbound Part coverage gap | 4/6 | Completed |
 | 2026-07-19 | Prevent unit-test settings mocks from being coerced into real `MagicMock`-named workspace directories; use concrete temporary/in-memory paths and fail tests that attempt mocked filesystem writes. | Test-suite filesystem leak | 1/2 | Completed |
 | 2026-07-18 | Publish validated deployment-level A2A authentication schemes and requirements in generated Agent Cards without moving authentication enforcement into Cognition. | Kennel `0.12.0-rc3` authentication-discovery blocker | 1/6 | Completed |
 | 2026-07-18 | Honor a builder-configured external A2A interface URL in Agent Cards while retaining the request-derived per-agent route as a backward-compatible fallback. | Kennel `0.12.0-rc2` public Agent Card URL report | 2/6 | Completed |

--- a/docs/concepts/a2a/message-parts.md
+++ b/docs/concepts/a2a/message-parts.md
@@ -85,3 +85,12 @@ Cognition returns an A2A content/parameter error before starting a run when:
 
 Unknown media types are retained as metadata for raw and URL artifacts. They are
 not interpreted or executed by the adapter.
+
+## Outbound Parts
+
+Cognition serializes protocol-neutral runtime artifacts as the matching A2A
+Part variant: text, structured data, inline raw bytes, or a URL reference.
+Deep Agents structured output configured with `response_format` is published as
+an `application/json` data artifact. Cognition does not parse ordinary text that
+happens to look like JSON; builders must configure a response schema or emit an
+explicit data artifact when consumers require machine-readable output.

--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -19,7 +19,7 @@ Architecture:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, runtime_checkable
@@ -409,6 +409,26 @@ def _extract_todos_from_update(update: Any) -> list[dict[str, Any]] | None:
         todos = state_update.get("todos")
         if isinstance(todos, list):
             return [_normalize_todo_item(todo) for todo in todos]
+    return None
+
+
+def _extract_structured_response(update: Any) -> dict[str, Any] | None:
+    """Extract a JSON-object structured response from a root graph update."""
+    if not isinstance(update, Mapping):
+        return None
+
+    candidates: list[Any] = [update]
+    candidates.extend(value for value in update.values() if isinstance(value, Mapping))
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping) or "structured_response" not in candidate:
+            continue
+        response = candidate["structured_response"]
+        if hasattr(response, "model_dump"):
+            response = response.model_dump(mode="json")
+        elif is_dataclass(response) and not isinstance(response, type):
+            response = asdict(response)
+        if isinstance(response, Mapping):
+            return {str(key): value for key, value in response.items()}
     return None
 
 
@@ -839,6 +859,7 @@ class DeepAgentRuntime:
             previous_todos: list[dict[str, Any]] = []
             emitted_initial_plan = False
             interrupt_emitted = False
+            structured_response_emitted = False
 
             async for chunk in self._agent.astream(
                 agent_input,
@@ -957,6 +978,18 @@ class DeepAgentRuntime:
                             else None,
                             summary_id=str(file_path) if file_path is not None else None,
                         )
+
+                    if not ns and not structured_response_emitted:
+                        structured_response = _extract_structured_response(data)
+                        if structured_response is not None:
+                            structured_response_emitted = True
+                            yield ArtifactEvent(
+                                artifact_id="structured-response",
+                                name="structured-response",
+                                kind="data",
+                                value=structured_response,
+                                media_type="application/json",
+                            )
 
                     is_subagent = any(s.startswith("tools:") for s in ns)
 

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -575,6 +575,7 @@ class DeepAgentStreamingService:
                             event,
                             (
                                 DelegationEvent,
+                                ArtifactEvent,
                                 StatusEvent,
                                 StepCompleteEvent,
                                 InterruptEvent,

--- a/tests/unit/test_a2a_jsonrpc_runtime.py
+++ b/tests/unit/test_a2a_jsonrpc_runtime.py
@@ -7,6 +7,7 @@ import json
 from typing import cast
 
 import httpx
+import pytest
 from fastapi import FastAPI
 
 from server.app.agent.runtime import (
@@ -404,6 +405,58 @@ async def test_message_only_and_non_text_artifact_variants_are_supported(
         )
         url_part = url.json()["result"]["task"]["artifacts"][0]["parts"][0]
         assert url_part["url"] == "https://example.com/output.txt"
+
+
+@pytest.mark.parametrize(
+    ("message_id", "variant", "expected"),
+    [
+        ("stream-output-text", "text", "A2A works"),
+        ("tck-artifact-data-stream", "data", {"key": "value", "count": 42}),
+        ("tck-artifact-file-stream", "raw", "ZmlsZSBvdXRwdXQ="),
+        (
+            "tck-artifact-file-url-stream",
+            "url",
+            "https://example.com/output.txt",
+        ),
+    ],
+)
+async def test_all_outbound_part_variants_stream_on_the_a2a_wire(
+    setup_storage_backend: StorageBackend,
+    tmp_path,
+    message_id: str,
+    variant: str,
+    expected: object,
+) -> None:
+    client = await _build_client(setup_storage_backend, tmp_path)
+    request = _send_request(message_id)
+    request["method"] = "SendStreamingMessage"
+    events: list[dict] = []
+
+    async with client:
+        async with client.stream(
+            "POST",
+            "/a2a/researcher",
+            json=request,
+            headers={"Accept": "text/event-stream"},
+        ) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[6:]))
+
+    artifact_updates = [
+        event["result"]["artifactUpdate"]
+        for event in events
+        if "artifactUpdate" in event.get("result", {})
+    ]
+    assert len(artifact_updates) == 1
+    part = artifact_updates[0]["artifact"]["parts"][0]
+    assert part[variant] == expected
+    assert artifact_updates[0]["lastChunk"] is True
+    assert any(
+        event["result"].get("statusUpdate", {}).get("status", {}).get("state")
+        == "TASK_STATE_COMPLETED"
+        for event in events
+    )
 
 
 async def test_all_inbound_part_variants_are_ordered_scoped_and_inert(

--- a/tests/unit/test_runtime_streaming.py
+++ b/tests/unit/test_runtime_streaming.py
@@ -28,6 +28,7 @@ from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_core.messages.tool import ToolCallChunk
 
 from server.app.agent.runtime import (
+    ArtifactEvent,
     DeepAgentRuntime,
     DelegationEvent,
     DoneEvent,
@@ -38,6 +39,7 @@ from server.app.agent.runtime import (
     ToolResultEvent,
     ToolSafetyEvent,
 )
+from tests.fixtures.schemas import AgentResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -159,6 +161,42 @@ class TestTokenStreaming:
         runtime = _make_runtime(_ai_token("hi"))
         events = await _collect(runtime)
         assert isinstance(events[-1], DoneEvent)
+
+
+class TestStructuredOutputStreaming:
+    """Validated root-agent output becomes one protocol-neutral data artifact."""
+
+    @pytest.mark.asyncio
+    async def test_pydantic_structured_response_yields_data_artifact(self):
+        response = AgentResult(summary="Looks good")
+        runtime = _make_runtime(
+            _make_chunk(
+                "updates",
+                {"model": {"structured_response": response}},
+            )
+        )
+
+        events = await _collect(runtime)
+
+        artifacts = [event for event in events if isinstance(event, ArtifactEvent)]
+        assert len(artifacts) == 1
+        assert artifacts[0].kind == "data"
+        assert artifacts[0].media_type == "application/json"
+        assert artifacts[0].value == response.model_dump(mode="json")
+
+    @pytest.mark.asyncio
+    async def test_subagent_structured_response_is_not_published_as_root_output(self):
+        runtime = _make_runtime(
+            _make_chunk(
+                "updates",
+                {"model": {"structured_response": {"private": True}}},
+                ns=("tools:subagent-call",),
+            )
+        )
+
+        events = await _collect(runtime)
+
+        assert not any(isinstance(event, ArtifactEvent) for event in events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_streaming_bugs.py
+++ b/tests/unit/test_streaming_bugs.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from server.app.agent.runtime import (
+    ArtifactEvent,
     DoneEvent,
     TokenEvent,
     UsageEvent,
@@ -228,6 +229,32 @@ class TestExactlyOneDoneEvent:
         assert isinstance(collected[-1], DoneEvent), (
             f"Last event should be DoneEvent, got {type(collected[-1]).__name__}"
         )
+
+    @pytest.mark.asyncio
+    async def test_structured_artifact_passes_through_shared_service(self):
+        """Structured runtime output must reach native and protocol adapters."""
+        from server.app.llm.deep_agent_service import DeepAgentStreamingService
+
+        session = _make_session()
+        artifact = ArtifactEvent(
+            artifact_id="structured-response",
+            name="structured-response",
+            kind="data",
+            value={"answer": 42},
+            media_type="application/json",
+        )
+        mock_runtime = _make_mock_runtime(artifact, DoneEvent())
+        service = DeepAgentStreamingService(_make_settings())
+        service.storage_backend = MagicMock()
+        service.storage_backend.get_session = AsyncMock(return_value=session)
+        service.storage_backend.get_checkpointer = AsyncMock(return_value=MagicMock())
+        service.storage_backend.get_store = AsyncMock(return_value=MagicMock())
+
+        p1, p2, p3, p4 = _stream_patches(mock_runtime, session)
+        with p1, p2, p3, p4:
+            collected = await _collect(service, session)
+
+        assert artifact in collected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- project validated root-agent `structured_response` updates into protocol-neutral `application/json` data artifacts
- pass those artifacts through the shared Deep Agents streaming service so A2A serializes them as `DataPart`
- avoid publishing structured state from subagents as the parent agent's output
- retain explicit artifact handling for text, raw bytes, and URL references
- document that arbitrary JSON-looking text is not parsed opportunistically

## Bidirectional Part coverage

Caller → Cognition:
- text and data enter model context in wire order
- raw and URL inputs persist as inert, scoped artifacts
- URL inputs are never fetched implicitly

Cognition → caller:
- text, data, raw, and URL artifacts are verified through real `SendStreamingMessage` SSE ProtoJSON responses
- every stream includes a terminal `TASK_STATE_COMPLETED` update and closes
- structured Pydantic output is verified as an outbound data artifact

## Validation

- `uv run pytest tests/unit -q` — 873 passed, 4 skipped
- `uv run ruff check .`
- `uv run mypy .` — 244 files
- `uv run mkdocs build --strict`
- official pinned A2A 1.0 JSON-RPC TCK — 92 passed, 173 skipped
- `git diff --check`
