### PR TITLE
feat(a2a): harden durable streaming

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 |------|-------------|-------|-------|--------|
 | 2026-07-20 | Project validated Deep Agents structured responses into outbound A2A data artifacts and verify text, data, raw, and URL Parts bidirectionally on JSON-RPC and SSE wire paths. | A2A outbound Part coverage gap | 4/6 | Completed |
 | 2026-07-20 | Enforce the configured per-agent execution deadline across shared native and A2A streaming so stalled provider streams terminate with a durable failure. | Kennel `0.12.0-rc5` live A2A streaming report | 4/6 | Completed |
+| 2026-07-20 | Reject conflicting A2A message-id retries by comparing a canonical request fingerprint instead of silently reusing a task created for different input. | A2A idempotency conflict | 2/4/6 | Completed |
 | 2026-07-19 | Prevent unit-test settings mocks from being coerced into real `MagicMock`-named workspace directories; use concrete temporary/in-memory paths and fail tests that attempt mocked filesystem writes. | Test-suite filesystem leak | 1/2 | Completed |
 | 2026-07-18 | Publish validated deployment-level A2A authentication schemes and requirements in generated Agent Cards without moving authentication enforcement into Cognition. | Kennel `0.12.0-rc3` authentication-discovery blocker | 1/6 | Completed |
 | 2026-07-18 | Honor a builder-configured external A2A interface URL in Agent Cards while retaining the request-derived per-agent route as a backward-compatible fallback. | Kennel `0.12.0-rc2` public Agent Card URL report | 2/6 | Completed |
@@ -121,6 +122,7 @@ The following fallback patterns exist and are tracked for removal. They produce 
 
 | Description | Target Metric | Before | After | Layer | Status |
 |-------------|---------------|--------|-------|-------|--------|
+| Coalesce durable A2A token output and add bounded request/output handling | Durable writes per streamed response | One write per model token | Bounded by configured byte/time chunk thresholds | 2/4/6/7 | Completed |
 | Strict mypy type checking for all production code (`server/`, `client/`) | Production mypy errors | ~341 errors | 0 errors | 1–6 | Completed |
 | Ruff lint cleanup for `feature/config-registry` — unused imports, unsorted import blocks, unused `type: ignore` comments (12 auto-fixed; 10 mypy suppressions removed as stubs are now available) | Lint/mypy errors | 12 ruff + 10 mypy | 0 | 1–6 | Completed |
 

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -77,6 +77,26 @@ Implemented in `server/app/observability/__init__.py`. All metrics are defined a
 | `cognition_llm_call_duration_seconds` | Histogram | `provider`, `model` | LLM API call latency |
 | `cognition_tool_calls_total` | Counter | `tool_name`, `status` | Tool invocations (`success`/`error`) |
 | `cognition_active_sessions` | Gauge | — | Open non-terminal sessions |
+| `cognition_a2a_requests_total` | Counter | `operation`, `outcome` | A2A operation outcomes |
+| `cognition_runtime_task_transitions_total` | Counter | `transport`, `status` | Durable task transitions |
+| `cognition_runtime_active_tasks` | Gauge | `transport` | Active in-process executions |
+| `cognition_a2a_active_subscribers` | Gauge | — | Active A2A subscribers |
+| `cognition_runtime_time_to_first_output_seconds` | Histogram | `transport` | Time to first output |
+| `cognition_runtime_task_duration_seconds` | Histogram | `transport`, `outcome` | Execution duration |
+| `cognition_a2a_stream_chunk_bytes` | Histogram | — | Coalesced artifact-update size |
+| `cognition_a2a_stream_flush_duration_seconds` | Histogram | — | Persist-and-enqueue latency |
+| `cognition_a2a_subscriptions_total` | Counter | `outcome` | Subscription lifecycle outcomes |
+| `cognition_a2a_idempotency_total` | Counter | `outcome` | Retry reuse and conflicts |
+| `cognition_a2a_limit_rejections_total` | Counter | `direction`, `limit` | Resource-limit rejections |
+| `cognition_runtime_task_cleanup_total` | Counter | `transport`, `outcome` | Retention cleanup results |
+| `cognition_runtime_task_cleanup_duration_seconds` | Histogram | `transport` | Cleanup pass duration |
+
+A2A adapter metrics intentionally exclude agent names, task/message IDs, and raw scope
+values. Runtime metrics use the bounded `transport` label (currently `a2a`) so
+the same metric families can cover native API and future protocol adapters.
+Recommended alerts cover sustained limit rejections, idempotency conflicts,
+cleanup errors, increasing time-to-first-event, and nonzero active tasks without
+corresponding terminal transitions.
 
 When `prometheus_client` is not installed, all metrics fall back to `DummyMetric` — a no-op object that accepts any call without error.
 

--- a/docs/guides/a2a.md
+++ b/docs/guides/a2a.md
@@ -151,6 +151,34 @@ updates. Use `SubscribeToTask` to reconnect to an existing non-terminal task.
 See [Tasks and Streaming](../concepts/a2a/tasks-and-streaming.md) for durable
 identity, continuation, cancellation, and replay behavior.
 
+### Durability and resource controls
+
+Cognition coalesces model tokens into bounded artifact updates. Each update is
+persisted before it is emitted, so a disconnected subscriber can replay ordered
+updates through `SubscribeToTask`; disconnecting does not cancel execution.
+Tune the deployment without changing Agent Cards:
+
+| Environment variable | Default | Purpose |
+|---|---:|---|
+| `COGNITION_A2A_MAX_PARTS` | `64` | Maximum Parts in one inbound message |
+| `COGNITION_A2A_MAX_MESSAGE_BYTES` | `16777216` | Aggregate decoded inbound bytes |
+| `COGNITION_A2A_MAX_TEXT_PART_BYTES` | `2097152` | Maximum UTF-8 bytes in one text Part |
+| `COGNITION_A2A_MAX_DATA_PART_BYTES` | `2097152` | Maximum canonical JSON bytes in one data Part |
+| `COGNITION_A2A_MAX_RAW_PART_BYTES` | `10485760` | Maximum decoded bytes in one raw Part |
+| `COGNITION_A2A_MAX_OUTPUT_ARTIFACTS` | `100` | Maximum distinct artifacts per execution |
+| `COGNITION_A2A_MAX_OUTPUT_BYTES` | `16777216` | Aggregate output limit per execution |
+| `COGNITION_A2A_STREAM_CHUNK_BYTES` | `4096` | Target size for durable text chunks |
+| `COGNITION_A2A_STREAM_FLUSH_INTERVAL_SECONDS` | `0.25` | Maximum active-stream coalescing interval |
+| `COGNITION_A2A_TERMINAL_TASK_TTL_SECONDS` | `0` | Terminal task retention; zero disables deletion |
+| `COGNITION_A2A_CLEANUP_INTERVAL_SECONDS` | `3600` | Minimum cleanup interval per active agent/scope |
+| `COGNITION_A2A_CLEANUP_BATCH_SIZE` | `100` | Maximum tasks removed per cleanup pass |
+| `COGNITION_A2A_CLEANUP_GRACE_SECONDS` | `300` | Additional terminal-state safety window |
+
+Cleanup runs opportunistically for exact agent/scope namespaces receiving A2A
+traffic. It never deletes active tasks or unrelated data in a shared context.
+After a retained task is deleted, its former message-id idempotency key may be
+used for a new task.
+
 ## 7. Verify isolation
 
 Before deployment, repeat discovery and task/artifact reads with a different
@@ -166,6 +194,7 @@ continuation, listing, subscription, and cancellation.
 | Card advertises a private URL | Set `a2a.public_interface_url` to the externally routed JSON-RPC endpoint. |
 | Media type is rejected | Confirm valid MIME syntax and that the card or selected public skill advertises the format. |
 | Raw Part is rejected | Check `COGNITION_A2A_MAX_RAW_PART_BYTES` and base64 validity. |
+| Retry returns invalid parameters | A `messageId` was reused with execution-relevant content that differs from the original request. |
 | URL content is not available | URL Parts are references; provide an explicit authorized retrieval tool if remote fetching is required. |
 | Authentication metadata is missing | Configure both security environment values and restart Cognition so startup validation runs. |
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -475,6 +475,13 @@ the host's tenant, membership, role, or entitlement model.
 
 ---
 
+## A2A Runtime Hardening
+
+The deployment-level A2A durability, streaming, retention, and resource-limit
+settings are documented in [Configure and Invoke an A2A Agent](a2a.md#durability-and-resource-controls).
+They use the `COGNITION_A2A_*` namespace and do not alter agent-level Agent Card
+configuration under `AgentDefinition.a2a`.
+
 ## SSE Streaming
 
 | YAML key | Environment variable | Default | Description |

--- a/server/app/agent/task_runtime.py
+++ b/server/app/agent/task_runtime.py
@@ -538,7 +538,12 @@ class AgentTaskRuntime:
             "artifact.updated",
             payload={
                 "artifact_id": artifact_id,
+                "name": name,
                 "kind": kind,
+                "value": encoded_value,
+                "media_type": media_type,
+                "filename": filename,
+                "description": description,
                 "append": append,
                 "last_chunk": last_chunk,
             },

--- a/server/app/observability/__init__.py
+++ b/server/app/observability/__init__.py
@@ -16,12 +16,13 @@ import structlog
 
 # Optional imports with fallbacks
 try:
-    from prometheus_client import Counter, Histogram, start_http_server
+    from prometheus_client import Counter, Gauge, Histogram, start_http_server
 
     PROMETHEUS_AVAILABLE = True
 except ImportError:
     PROMETHEUS_AVAILABLE = False
     Counter = None  # type: ignore[assignment,misc]
+    Gauge = None  # type: ignore[assignment,misc]
     Histogram = None  # type: ignore[assignment,misc]
     start_http_server = None  # type: ignore[assignment]
 
@@ -118,6 +119,68 @@ if PROMETHEUS_AVAILABLE:
         "Session lifecycle events",
         ["event_type"],  # created, resumed, closed, expired
     )
+    A2A_REQUESTS_TOTAL = Counter(
+        "cognition_a2a_requests_total",
+        "A2A operations by outcome",
+        ["operation", "outcome"],
+    )
+    RUNTIME_TASK_TRANSITIONS_TOTAL = Counter(
+        "cognition_runtime_task_transitions_total",
+        "Durable task lifecycle transitions",
+        ["transport", "status"],
+    )
+    RUNTIME_ACTIVE_TASKS = Gauge(
+        "cognition_runtime_active_tasks",
+        "Task executions active in this process",
+        ["transport"],
+    )
+    A2A_ACTIVE_SUBSCRIBERS = Gauge(
+        "cognition_a2a_active_subscribers",
+        "A2A subscribers active in this process",
+    )
+    RUNTIME_TIME_TO_FIRST_OUTPUT = Histogram(
+        "cognition_runtime_time_to_first_output_seconds",
+        "Time from task execution start to first output",
+        ["transport"],
+    )
+    RUNTIME_TASK_DURATION = Histogram(
+        "cognition_runtime_task_duration_seconds",
+        "Task execution duration",
+        ["transport", "outcome"],
+    )
+    A2A_STREAM_CHUNK_BYTES = Histogram(
+        "cognition_a2a_stream_chunk_bytes",
+        "Encoded bytes per emitted A2A artifact chunk",
+    )
+    A2A_STREAM_FLUSH_DURATION = Histogram(
+        "cognition_a2a_stream_flush_duration_seconds",
+        "Time required to persist and emit one A2A stream chunk",
+    )
+    A2A_SUBSCRIPTIONS_TOTAL = Counter(
+        "cognition_a2a_subscriptions_total",
+        "A2A subscription lifecycle events",
+        ["outcome"],
+    )
+    A2A_IDEMPOTENCY_TOTAL = Counter(
+        "cognition_a2a_idempotency_total",
+        "A2A idempotency outcomes",
+        ["outcome"],
+    )
+    A2A_LIMIT_REJECTIONS_TOTAL = Counter(
+        "cognition_a2a_limit_rejections_total",
+        "A2A requests or outputs rejected by resource limits",
+        ["direction", "limit"],
+    )
+    RUNTIME_TASK_CLEANUP_TOTAL = Counter(
+        "cognition_runtime_task_cleanup_total",
+        "Durable task retention cleanup outcomes",
+        ["transport", "outcome"],
+    )
+    RUNTIME_TASK_CLEANUP_DURATION = Histogram(
+        "cognition_runtime_task_cleanup_duration_seconds",
+        "Durable task retention cleanup duration",
+        ["transport"],
+    )
 else:
     # Dummy metrics that do nothing
     class DummyMetric:
@@ -126,6 +189,9 @@ else:
             return self
 
         def inc(self, *args: Any, **kwargs: Any) -> None:
+            """No-op."""
+
+        def dec(self, *args: Any, **kwargs: Any) -> None:
             """No-op."""
 
         def observe(self, *args: Any, **kwargs: Any) -> None:
@@ -141,6 +207,19 @@ else:
     RUNTIME_EVENT_COUNT = DummyMetric()  # type: ignore[assignment]
     RUN_TRANSITION_COUNT = DummyMetric()  # type: ignore[assignment]
     SESSION_COUNT = DummyMetric()  # type: ignore[assignment]
+    A2A_REQUESTS_TOTAL = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_TASK_TRANSITIONS_TOTAL = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_ACTIVE_TASKS = DummyMetric()  # type: ignore[assignment]
+    A2A_ACTIVE_SUBSCRIBERS = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_TIME_TO_FIRST_OUTPUT = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_TASK_DURATION = DummyMetric()  # type: ignore[assignment]
+    A2A_STREAM_CHUNK_BYTES = DummyMetric()  # type: ignore[assignment]
+    A2A_STREAM_FLUSH_DURATION = DummyMetric()  # type: ignore[assignment]
+    A2A_SUBSCRIPTIONS_TOTAL = DummyMetric()  # type: ignore[assignment]
+    A2A_IDEMPOTENCY_TOTAL = DummyMetric()  # type: ignore[assignment]
+    A2A_LIMIT_REJECTIONS_TOTAL = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_TASK_CLEANUP_TOTAL = DummyMetric()  # type: ignore[assignment]
+    RUNTIME_TASK_CLEANUP_DURATION = DummyMetric()  # type: ignore[assignment]
 
 
 def setup_tracing(

--- a/server/app/protocols/a2a/executor.py
+++ b/server/app/protocols/a2a/executor.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from a2a.helpers.proto_helpers import (
@@ -38,6 +42,17 @@ from server.app.agent.task_runtime import (
 )
 from server.app.exceptions import RuntimeTaskConflictError, RuntimeTaskNotFoundError
 from server.app.models import RunStatus, TaskStatus
+from server.app.observability import (
+    A2A_STREAM_CHUNK_BYTES,
+    A2A_STREAM_FLUSH_DURATION,
+    RUNTIME_ACTIVE_TASKS,
+    RUNTIME_TASK_DURATION,
+    RUNTIME_TASK_TRANSITIONS_TOTAL,
+    RUNTIME_TIME_TO_FIRST_OUTPUT,
+)
+from server.app.observability import (
+    span as trace_span,
+)
 from server.app.protocols.a2a.inbound import InvalidA2APartError, normalize_a2a_parts
 from server.app.protocols.a2a.task_store import (
     CognitionTaskStore,
@@ -50,6 +65,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 _ARTIFACT_NAME = "response"
+_FLUSH_TICK = object()
 _TASK_STATUS_TO_A2A: dict[TaskStatus, int] = {
     TaskStatus.SUBMITTED: TaskState.TASK_STATE_SUBMITTED,
     TaskStatus.WORKING: TaskState.TASK_STATE_WORKING,
@@ -74,6 +90,14 @@ class CognitionA2AExecutor(AgentExecutor):
         agent_name: str,
         message_id_idempotency: bool = True,
         max_raw_part_bytes: int = 10 * 1024 * 1024,
+        max_parts: int = 64,
+        max_message_bytes: int = 16 * 1024 * 1024,
+        max_text_part_bytes: int = 2 * 1024 * 1024,
+        max_data_part_bytes: int = 2 * 1024 * 1024,
+        max_output_artifacts: int = 100,
+        max_output_bytes: int = 16 * 1024 * 1024,
+        stream_chunk_bytes: int = 4096,
+        stream_flush_interval_seconds: float = 0.25,
     ) -> None:
         self._runtime = runtime
         self._task_store = task_store
@@ -81,6 +105,14 @@ class CognitionA2AExecutor(AgentExecutor):
         self._agent_name = agent_name
         self._message_id_idempotency = message_id_idempotency
         self._max_raw_part_bytes = max_raw_part_bytes
+        self._max_parts = max_parts
+        self._max_message_bytes = max_message_bytes
+        self._max_text_part_bytes = max_text_part_bytes
+        self._max_data_part_bytes = max_data_part_bytes
+        self._max_output_artifacts = max_output_artifacts
+        self._max_output_bytes = max_output_bytes
+        self._stream_chunk_bytes = stream_chunk_bytes
+        self._stream_flush_interval = stream_flush_interval_seconds
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         """Create/continue a task, stream execution, and persist before emitting."""
@@ -89,18 +121,35 @@ class CognitionA2AExecutor(AgentExecutor):
         scope = effective_scope_from_context(context.call_context)
         message_id = context.message.message_id if context.message else None
         try:
-            normalized = normalize_a2a_parts(
-                context.message.parts if context.message else (),
-                task_id=context.task_id,
-                message_id=message_id,
-                max_raw_part_bytes=self._max_raw_part_bytes,
-            )
+            with trace_span(
+                "cognition.a2a.normalize",
+                {
+                    "a2a.task_id": context.task_id,
+                    "a2a.part_count": len(context.message.parts) if context.message else 0,
+                    "cognition.scope_keys": ",".join(sorted(scope)),
+                },
+            ):
+                normalized = normalize_a2a_parts(
+                    context.message.parts if context.message else (),
+                    task_id=context.task_id,
+                    message_id=message_id,
+                    max_raw_part_bytes=self._max_raw_part_bytes,
+                    max_parts=self._max_parts,
+                    max_message_bytes=self._max_message_bytes,
+                    max_text_part_bytes=self._max_text_part_bytes,
+                    max_data_part_bytes=self._max_data_part_bytes,
+                )
         except InvalidA2APartError as exc:
+            from server.app.observability import A2A_LIMIT_REJECTIONS_TOTAL
+
+            A2A_LIMIT_REJECTIONS_TOTAL.labels(direction="input", limit="message").inc()
             raise InvalidParamsError(message=str(exc)) from exc
         user_text = normalized.content or "(empty message)"
         persisted_message_id = message_id if self._message_id_idempotency else None
         idempotency_key = message_id or context.task_id if self._message_id_idempotency else None
         execution: TaskExecution | None = None
+        active_metric = False
+        execution_started = time.monotonic()
 
         try:
             existing = await self._runtime.get(GetTask(context.task_id, self._agent_name, scope))
@@ -117,6 +166,9 @@ class CognitionA2AExecutor(AgentExecutor):
                         metadata={
                             "source": "a2a-jsonrpc",
                             "a2a_message_id": message_id,
+                            "a2a_request_fingerprint": context.call_context.state.get(
+                                "a2a_request_fingerprint"
+                            ),
                         },
                     )
                 )
@@ -134,6 +186,9 @@ class CognitionA2AExecutor(AgentExecutor):
                         metadata={
                             "source": "a2a-jsonrpc",
                             "a2a_message_id": message_id,
+                            "a2a_request_fingerprint": context.call_context.state.get(
+                                "a2a_request_fingerprint"
+                            ),
                         },
                     )
                 )
@@ -147,6 +202,9 @@ class CognitionA2AExecutor(AgentExecutor):
                 await event_queue.enqueue_event(await self._task_store.project(execution.task))
                 return
 
+            RUNTIME_ACTIVE_TASKS.labels(transport="a2a").inc()
+            active_metric = True
+
             await self._runtime.persist_input_artifacts(execution, normalized.artifacts)
 
             service = self._agent_manager.get_service(execution.session.id)
@@ -157,10 +215,56 @@ class CognitionA2AExecutor(AgentExecutor):
                 )
 
             accumulated_text: list[str] = []
+            chunk_buffer: list[str] = []
             task_announced = False
             has_artifact = False
+            streamed_chunk = False
+            output_bytes = 0
+            output_artifact_ids: set[str] = set()
+            started_at = time.monotonic()
+            last_flush_at = started_at
+            first_output_recorded = False
+
+            async def flush_text_chunk(*, last_chunk: bool) -> None:
+                nonlocal streamed_chunk, last_flush_at, first_output_recorded
+                text = "".join(chunk_buffer)
+                if not text and not (last_chunk and streamed_chunk):
+                    return
+                chunk_buffer.clear()
+                flush_started = time.monotonic()
+                artifact_id = f"task-{execution.task.id}-response"
+                await self._runtime.persist_artifact_output(
+                    execution,
+                    artifact_id=artifact_id,
+                    name=_ARTIFACT_NAME,
+                    kind="text",
+                    value=text,
+                    media_type="text/plain",
+                    append=streamed_chunk,
+                    last_chunk=last_chunk,
+                )
+                await event_queue.enqueue_event(
+                    new_text_artifact_update_event(
+                        task_id=execution.task.id,
+                        context_id=execution.task.context_id,
+                        name=_ARTIFACT_NAME,
+                        text=text,
+                        artifact_id=artifact_id,
+                        append=streamed_chunk,
+                        last_chunk=last_chunk,
+                    )
+                )
+                A2A_STREAM_CHUNK_BYTES.observe(len(text.encode("utf-8")))
+                A2A_STREAM_FLUSH_DURATION.observe(time.monotonic() - flush_started)
+                if not first_output_recorded:
+                    RUNTIME_TIME_TO_FIRST_OUTPUT.labels(transport="a2a").observe(
+                        time.monotonic() - started_at
+                    )
+                    first_output_recorded = True
+                streamed_chunk = True
+                last_flush_at = time.monotonic()
             system_prompt = execution.session.config.system_prompt
-            async for event in service.stream_response(
+            source = service.stream_response(
                 session_id=execution.session.id,
                 thread_id=execution.session.thread_id,
                 project_path=execution.session.workspace_path,
@@ -169,7 +273,12 @@ class CognitionA2AExecutor(AgentExecutor):
                 manager=self._agent_manager,
                 scope=scope,
                 run_id=None,
-            ):
+            )
+            async for event in _with_flush_ticks(source, self._stream_flush_interval):
+                if event is _FLUSH_TICK:
+                    await flush_text_chunk(last_chunk=False)
+                    has_artifact = has_artifact or streamed_chunk
+                    continue
                 current = await self._runtime.get(
                     GetTask(execution.task.id, self._agent_name, scope)
                 )
@@ -211,6 +320,17 @@ class CognitionA2AExecutor(AgentExecutor):
                     task_announced = True
 
                 if isinstance(event, ArtifactEvent):
+                    artifact_bytes = _artifact_size(event.kind, event.value)
+                    output_bytes += artifact_bytes
+                    output_artifact_ids.add(event.artifact_id)
+                    if output_bytes > self._max_output_bytes:
+                        await self._fail_output_limit(execution, event_queue, "OUTPUT_BYTES_EXCEEDED")
+                        return
+                    if len(output_artifact_ids) > self._max_output_artifacts:
+                        await self._fail_output_limit(
+                            execution, event_queue, "OUTPUT_ARTIFACTS_EXCEEDED"
+                        )
+                        return
                     await self._runtime.persist_artifact_output(
                         execution,
                         artifact_id=event.artifact_id,
@@ -229,12 +349,19 @@ class CognitionA2AExecutor(AgentExecutor):
 
                 if isinstance(event, TokenEvent):
                     accumulated_text.append(event.content)
-                    await self._runtime.projection.append_event(
-                        execution.run,
-                        "message.assistant.delta",
-                        payload={"length": len(event.content)},
-                        visibility="internal",
-                    )
+                    chunk_buffer.append(event.content)
+                    output_bytes += len(event.content.encode("utf-8"))
+                    if output_bytes > self._max_output_bytes:
+                        await self._fail_output_limit(execution, event_queue, "OUTPUT_BYTES_EXCEEDED")
+                        return
+                    buffered_bytes = len("".join(chunk_buffer).encode("utf-8"))
+                    elapsed = time.monotonic() - last_flush_at
+                    if (
+                        buffered_bytes >= self._stream_chunk_bytes
+                        or elapsed >= self._stream_flush_interval
+                    ):
+                        await flush_text_chunk(last_chunk=False)
+                        has_artifact = True
                     continue
 
                 if isinstance(event, InterruptEvent) or (
@@ -294,21 +421,23 @@ class CognitionA2AExecutor(AgentExecutor):
                 if isinstance(event, DoneEvent) or (
                     isinstance(event, RunStateEvent) and event.to_status == "done"
                 ):
+                    await flush_text_chunk(last_chunk=True)
                     await self._complete(
                         execution,
                         event_queue,
                         accumulated_text,
-                        has_artifact=has_artifact,
+                        has_artifact=has_artifact or streamed_chunk,
                     )
                     return
 
             if not task_announced:
                 await event_queue.enqueue_event(await self._task_store.project(execution.task))
+            await flush_text_chunk(last_chunk=True)
             await self._complete(
                 execution,
                 event_queue,
                 accumulated_text,
-                has_artifact=has_artifact,
+                has_artifact=has_artifact or streamed_chunk,
             )
         except RuntimeTaskNotFoundError as exc:
             raise TaskNotFoundError from exc
@@ -337,6 +466,44 @@ class CognitionA2AExecutor(AgentExecutor):
                 )
                 return
             raise
+        finally:
+            if active_metric:
+                RUNTIME_ACTIVE_TASKS.labels(transport="a2a").dec()
+                final_task = await self._runtime.get(
+                    GetTask(context.task_id, self._agent_name, scope)
+                )
+                outcome = final_task.status.value if final_task is not None else "unknown"
+                RUNTIME_TASK_DURATION.labels(transport="a2a", outcome=outcome).observe(
+                    time.monotonic() - execution_started
+                )
+                RUNTIME_TASK_TRANSITIONS_TOTAL.labels(
+                    transport="a2a", status=outcome
+                ).inc()
+
+    async def _fail_output_limit(
+        self,
+        execution: TaskExecution,
+        event_queue: EventQueue,
+        error_code: str,
+    ) -> None:
+        """Persist a stable terminal failure for bounded A2A output."""
+        from server.app.observability import A2A_LIMIT_REJECTIONS_TOTAL
+
+        A2A_LIMIT_REJECTIONS_TOTAL.labels(direction="output", limit=error_code).inc()
+        await self._runtime.transition(
+            execution.task,
+            execution.run,
+            RunStatus.FAILED,
+            reason="A2A output exceeded the configured resource limit",
+            error_code=error_code,
+        )
+        await event_queue.enqueue_event(
+            _status_event(
+                execution,
+                TaskState.TASK_STATE_FAILED,
+                "A2A output exceeded the configured resource limit",
+            )
+        )
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
         """Cancel exactly the task identified by the A2A request context."""
@@ -461,3 +628,36 @@ def _artifact_event(
         last_chunk=event.last_chunk,
         artifact_id=event.artifact_id,
     )
+
+
+def _artifact_size(kind: str, value: Any) -> int:
+    """Return a stable byte estimate for output-limit enforcement."""
+    if kind == "raw" and isinstance(value, bytes):
+        return len(value)
+    if kind == "data":
+        return len(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    return len(str(value).encode("utf-8"))
+
+
+async def _with_flush_ticks(
+    source: AsyncIterator[Any], interval: float
+) -> AsyncIterator[Any]:
+    """Yield source events plus periodic ticks without cancelling the producer."""
+    iterator = aiter(source)
+    pending: asyncio.Future[Any] = asyncio.ensure_future(anext(iterator))
+    try:
+        while True:
+            done, _ = await asyncio.wait({pending}, timeout=interval)
+            if not done:
+                yield _FLUSH_TICK
+                continue
+            try:
+                event = pending.result()
+            except StopAsyncIteration:
+                return
+            yield event
+            pending = asyncio.ensure_future(anext(iterator))
+    finally:
+        if not pending.done():
+            pending.cancel()
+            await asyncio.gather(pending, return_exceptions=True)

--- a/server/app/protocols/a2a/idempotency.py
+++ b/server/app/protocols/a2a/idempotency.py
@@ -1,0 +1,48 @@
+"""Canonical A2A request identity used for safe retry handling."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from a2a.types import SendMessageRequest
+from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
+
+
+def request_fingerprint(
+    params: SendMessageRequest,
+    *,
+    agent_name: str,
+    effective_scope: dict[str, str],
+    task_id: str,
+    context_id: str,
+) -> str:
+    """Hash the complete execution-relevant request using canonical ProtoJSON."""
+    payload: dict[str, Any] = {
+        "agent_name": agent_name,
+        "effective_scope": effective_scope,
+        "task_id": task_id,
+        "context_id": context_id,
+        "message": MessageToDict(params.message, preserving_proto_field_name=True),
+        "configuration": (
+            MessageToDict(params.configuration, preserving_proto_field_name=True)
+            if params.HasField("configuration")
+            else None
+        ),
+        "metadata": (
+            MessageToDict(params.metadata, preserving_proto_field_name=True)
+            if params.HasField("metadata")
+            else None
+        ),
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = ["request_fingerprint"]

--- a/server/app/protocols/a2a/inbound.py
+++ b/server/app/protocols/a2a/inbound.py
@@ -32,6 +32,10 @@ def normalize_a2a_parts(
     task_id: str,
     message_id: str | None,
     max_raw_part_bytes: int,
+    max_parts: int = 64,
+    max_message_bytes: int = 16 * 1024 * 1024,
+    max_text_part_bytes: int = 2 * 1024 * 1024,
+    max_data_part_bytes: int = 2 * 1024 * 1024,
 ) -> NormalizedA2AMessage:
     """Normalize all A2A 1.0 Part variants while preserving wire order.
 
@@ -42,18 +46,39 @@ def normalize_a2a_parts(
     artifacts: list[TaskInputArtifact] = []
     stable_message_id = message_id or "anonymous"
 
-    for index, part in enumerate(parts):
+    materialized = tuple(parts)
+    if len(materialized) > max_parts:
+        raise InvalidA2APartError(f"A2A message exceeds the {max_parts}-Part limit")
+    total_bytes = 0
+
+    for index, part in enumerate(materialized):
         kind = part.WhichOneof("content")
         if kind is None:
             raise InvalidA2APartError(f"A2A message Part {index} has no content")
 
         if kind == "text":
+            size = len(part.text.encode("utf-8"))
+            if size > max_text_part_bytes:
+                raise InvalidA2APartError(
+                    f"A2A text Part {index} exceeds the {max_text_part_bytes}-byte limit"
+                )
+            total_bytes += size
             blocks.append(part.text)
             continue
         if kind == "data":
             value = MessageToDict(part.data)
+            compact_data = json.dumps(
+                value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+            encoded_data = json.dumps(value, ensure_ascii=False, sort_keys=True)
+            size = len(compact_data.encode("utf-8"))
+            if size > max_data_part_bytes:
+                raise InvalidA2APartError(
+                    f"A2A data Part {index} exceeds the {max_data_part_bytes}-byte limit"
+                )
+            total_bytes += size
             blocks.append(
-                f"[A2A data Part {index}]\n{json.dumps(value, ensure_ascii=False, sort_keys=True)}"
+                f"[A2A data Part {index}]\n{encoded_data}"
             )
             continue
 
@@ -68,9 +93,16 @@ def normalize_a2a_parts(
                 )
             content = base64.b64encode(part.raw).decode("ascii")
             content_encoding = "base64"
+            total_bytes += len(part.raw)
         else:
             content = part.url
             content_encoding = "uri"
+            total_bytes += len(part.url.encode("utf-8"))
+
+        if total_bytes > max_message_bytes:
+            raise InvalidA2APartError(
+                f"A2A message exceeds the {max_message_bytes}-byte aggregate limit"
+            )
 
         artifacts.append(
             TaskInputArtifact(
@@ -95,6 +127,11 @@ def normalize_a2a_parts(
             sort_keys=True,
         )
         blocks.append(f"[A2A {kind} Part {index}]\n{details}")
+
+    if total_bytes > max_message_bytes:
+        raise InvalidA2APartError(
+            f"A2A message exceeds the {max_message_bytes}-byte aggregate limit"
+        )
 
     return NormalizedA2AMessage(content="\n\n".join(blocks), artifacts=tuple(artifacts))
 

--- a/server/app/protocols/a2a/retention.py
+++ b/server/app/protocols/a2a/retention.py
@@ -1,0 +1,145 @@
+"""Scope-aware opportunistic retention for durable A2A task data."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import structlog
+
+from server.app.agent.task_runtime import AgentTaskRuntime, ListTasks
+from server.app.models import RuntimeTask, TaskStatus
+from server.app.observability import (
+    RUNTIME_TASK_CLEANUP_DURATION,
+    RUNTIME_TASK_CLEANUP_TOTAL,
+    span,
+)
+
+if TYPE_CHECKING:
+    from server.app.storage.artifact_store import ArtifactStore
+    from server.app.storage.backend import StorageBackend
+
+logger = structlog.get_logger(__name__)
+
+
+class A2ARetentionManager:
+    """Run bounded cleanup for scopes that are actively using A2A."""
+
+    def __init__(
+        self,
+        runtime: AgentTaskRuntime,
+        store: StorageBackend,
+        artifact_store: ArtifactStore | None,
+        *,
+        ttl_seconds: int,
+        interval_seconds: float,
+        batch_size: int,
+        grace_seconds: int,
+    ) -> None:
+        self._runtime = runtime
+        self._store = store
+        self._artifact_store = artifact_store
+        self._ttl_seconds = ttl_seconds
+        self._interval_seconds = interval_seconds
+        self._batch_size = batch_size
+        self._grace_seconds = grace_seconds
+        self._last_run: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
+        self._lock = asyncio.Lock()
+
+    async def maybe_cleanup(self, agent_name: str, scope: dict[str, str]) -> int:
+        """Clean one exact agent/scope namespace when its interval has elapsed."""
+        if self._ttl_seconds <= 0:
+            return 0
+        key = (agent_name, tuple(sorted(scope.items())))
+        now = time.monotonic()
+        if now - self._last_run.get(key, 0.0) < self._interval_seconds:
+            return 0
+        async with self._lock:
+            now = time.monotonic()
+            if now - self._last_run.get(key, 0.0) < self._interval_seconds:
+                return 0
+            started = time.monotonic()
+            try:
+                with span(
+                    "cognition.a2a.cleanup",
+                    {"cognition.scope_keys": ",".join(sorted(scope))},
+                ):
+                    deleted = await self._cleanup(agent_name, scope)
+            except Exception:
+                RUNTIME_TASK_CLEANUP_TOTAL.labels(transport="a2a", outcome="error").inc()
+                logger.exception("A2A retention cleanup failed", agent_name=agent_name)
+                return 0
+            finally:
+                self._last_run[key] = time.monotonic()
+                RUNTIME_TASK_CLEANUP_DURATION.labels(transport="a2a").observe(
+                    time.monotonic() - started
+                )
+            RUNTIME_TASK_CLEANUP_TOTAL.labels(transport="a2a", outcome="deleted").inc(
+                deleted
+            )
+            return deleted
+
+    async def _cleanup(self, agent_name: str, scope: dict[str, str]) -> int:
+        cutoff = datetime.now(UTC) - timedelta(
+            seconds=self._ttl_seconds + self._grace_seconds
+        )
+        deleted = 0
+        candidates: list[RuntimeTask] = []
+        terminal = {
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELED,
+            TaskStatus.REJECTED,
+        }
+        cursor: str | None = None
+        while len(candidates) < self._batch_size:
+            page = await self._runtime.list(
+                ListTasks(
+                    agent_name=agent_name,
+                    effective_scope=scope,
+                    statuses=terminal,
+                    limit=min(100, self._batch_size),
+                    cursor=cursor,
+                )
+            )
+            if not page.tasks:
+                break
+            for task in page.tasks:
+                updated_at = datetime.fromisoformat(task.updated_at)
+                if updated_at.tzinfo is None:
+                    updated_at = updated_at.replace(tzinfo=UTC)
+                if updated_at > cutoff:
+                    continue
+                candidates.append(task)
+                if len(candidates) >= self._batch_size:
+                    break
+            cursor = page.next_cursor
+            if cursor is None:
+                break
+
+        # Collect before deleting so cursor pagination never refers to a row
+        # removed earlier in the same cleanup pass.
+        for task in candidates:
+            runs = [
+                run
+                for run in await self._store.list_runs(task.session_id)
+                if run.task_id == task.id
+            ]
+            if self._artifact_store is not None:
+                for run in runs:
+                    artifacts = await self._artifact_store.list_artifacts(
+                        scope=task.effective_scope,
+                        run_id=run.id,
+                    )
+                    for artifact in artifacts:
+                        await self._artifact_store.delete_artifact(
+                            artifact.id, task.effective_scope
+                        )
+            if await self._store.delete_task_data(task.id, task.effective_scope):
+                deleted += 1
+        return deleted
+
+
+__all__ = ["A2ARetentionManager"]

--- a/server/app/protocols/a2a/routes.py
+++ b/server/app/protocols/a2a/routes.py
@@ -23,6 +23,12 @@ from email.utils import format_datetime
 from typing import TYPE_CHECKING, Any
 
 import structlog
+from a2a.helpers.proto_helpers import (
+    new_data_artifact_update_event,
+    new_raw_artifact_update_event,
+    new_text_artifact_update_event,
+    new_url_artifact_update_event,
+)
 from a2a.server.agent_execution import RequestContext, SimpleRequestContextBuilder
 from a2a.server.context import ServerCallContext
 from a2a.server.events import Event
@@ -42,6 +48,7 @@ from a2a.types import (
 )
 from a2a.utils.errors import (
     ContentTypeNotSupportedError,
+    InvalidParamsError,
     TaskNotCancelableError,
     TaskNotFoundError,
     UnsupportedOperationError,
@@ -66,8 +73,15 @@ from server.app.exceptions import (
     RuntimeTaskNotFoundError,
 )
 from server.app.models import TaskStatus
+from server.app.observability import (
+    A2A_ACTIVE_SUBSCRIBERS,
+    A2A_REQUESTS_TOTAL,
+    A2A_SUBSCRIPTIONS_TOTAL,
+)
 from server.app.protocols.a2a.card import build_agent_card_for_agent
 from server.app.protocols.a2a.executor import CognitionA2AExecutor
+from server.app.protocols.a2a.idempotency import request_fingerprint
+from server.app.protocols.a2a.retention import A2ARetentionManager
 from server.app.protocols.a2a.security import A2ACardSecurity, parse_a2a_card_security
 from server.app.protocols.a2a.task_store import (
     CognitionTaskStore,
@@ -239,6 +253,7 @@ class _ScopedRequestHandler(DefaultRequestHandler):
         params: SendMessageRequest,
         context: ServerCallContext,
     ) -> Any:
+        await self._bind_request_fingerprint(params, context)
         existing = await self._idempotent_task_response(params, context)
         return existing if existing is not None else await super().on_message_send(params, context)
 
@@ -248,6 +263,7 @@ class _ScopedRequestHandler(DefaultRequestHandler):
         params: SendMessageRequest,
         context: ServerCallContext,
     ) -> AsyncGenerator[Event, None]:
+        await self._bind_request_fingerprint(params, context)
         existing = await self._idempotent_task_response(params, context)
         if existing is not None:
             yield existing
@@ -288,10 +304,20 @@ class _ScopedRequestHandler(DefaultRequestHandler):
         yield current
 
         signature = _task_signature(current)
+        A2A_ACTIVE_SUBSCRIBERS.inc()
+        A2A_SUBSCRIPTIONS_TOTAL.labels(outcome="started").inc()
         try:
-            async for _event in self._runtime.subscribe(
+            async for runtime_event in self._runtime.subscribe(
                 SubscribeTask(params.id, self._agent_name, scope)
             ):
+                artifact_update = _artifact_update_from_runtime_event(
+                    current.id,
+                    current.context_id,
+                    runtime_event.payload,
+                ) if runtime_event.event_type == "artifact.updated" else None
+                if artifact_update is not None:
+                    yield artifact_update
+                    continue
                 projected = await self._cognition_task_store.get(params.id, context)
                 if projected is None:
                     raise TaskNotFoundError
@@ -301,6 +327,9 @@ class _ScopedRequestHandler(DefaultRequestHandler):
                     yield projected
         except RuntimeTaskNotFoundError as exc:
             raise TaskNotFoundError from exc
+        finally:
+            A2A_ACTIVE_SUBSCRIBERS.dec()
+            A2A_SUBSCRIPTIONS_TOTAL.labels(outcome="ended").inc()
 
     async def _idempotent_task_response(
         self,
@@ -325,9 +354,44 @@ class _ScopedRequestHandler(DefaultRequestHandler):
             # A distinct message naming an input-required task is a
             # continuation, not a duplicate submission.
             return None
+        fingerprint = context.state.get("a2a_request_fingerprint")
+        stored_fingerprint = task.metadata.get("a2a_request_fingerprint")
+        if stored_fingerprint is not None and fingerprint != stored_fingerprint:
+            from server.app.observability import A2A_IDEMPOTENCY_TOTAL
+
+            A2A_IDEMPOTENCY_TOTAL.labels(outcome="conflict").inc()
+            raise InvalidParamsError(
+                message="A2A message_id was already used for a different request"
+            )
+        from server.app.observability import A2A_IDEMPOTENCY_TOTAL
+
+        A2A_IDEMPOTENCY_TOTAL.labels(outcome="reused").inc()
         if task.metadata.get("interaction_mode") == "message":
             return await self._cognition_task_store.project_message(task)
         return await self._cognition_task_store.project(task)
+
+    async def _bind_request_fingerprint(
+        self,
+        params: SendMessageRequest,
+        context: ServerCallContext,
+    ) -> None:
+        """Attach the canonical fingerprint before idempotency short-circuiting."""
+        task_id = self._idempotent_context_builder.task_id_for(params, context)
+        if task_id is None:
+            return
+        existing = await self._cognition_task_store.get(task_id, context)
+        context_id = (
+            existing.context_id
+            if existing is not None
+            else str(uuid.uuid5(uuid.NAMESPACE_URL, f"cognition:a2a-context:{task_id}"))
+        )
+        context.state["a2a_request_fingerprint"] = request_fingerprint(
+            params,
+            agent_name=self._agent_name,
+            effective_scope=effective_scope_from_context(context),
+            task_id=task_id,
+            context_id=context_id,
+        )
 
 
 def _is_terminal_task(task: Task) -> bool:
@@ -342,6 +406,69 @@ def _is_terminal_task(task: Task) -> bool:
 def _task_signature(task: Task) -> bytes:
     """Return a deterministic projection signature for subscription changes."""
     return bytes(task.SerializeToString(deterministic=True))
+
+
+def _artifact_update_from_runtime_event(
+    task_id: str,
+    context_id: str,
+    payload: dict[str, Any],
+) -> Event | None:
+    """Rehydrate a persisted artifact update for reconnecting subscribers."""
+    kind = payload.get("kind")
+    name = str(payload.get("name") or "response")
+    artifact_id = str(payload.get("artifact_id") or "response")
+    media_type = payload.get("media_type")
+    media_type = str(media_type) if media_type is not None else None
+    append = bool(payload.get("append"))
+    last_chunk = bool(payload.get("last_chunk"))
+    if kind == "text":
+        return new_text_artifact_update_event(
+            task_id=task_id,
+            context_id=context_id,
+            name=name,
+            text=str(payload.get("value") or ""),
+            artifact_id=artifact_id,
+            append=append,
+            last_chunk=last_chunk,
+        )
+    if kind == "data" and isinstance(payload.get("value"), dict):
+        return new_data_artifact_update_event(
+            task_id=task_id,
+            context_id=context_id,
+            name=name,
+            data=payload["value"],
+            artifact_id=artifact_id,
+            media_type=media_type,
+            append=append,
+            last_chunk=last_chunk,
+        )
+    if kind == "raw" and isinstance(payload.get("value"), str):
+        import base64
+
+        return new_raw_artifact_update_event(
+            raw=base64.b64decode(payload["value"]),
+            filename=payload.get("filename"),
+            task_id=task_id,
+            context_id=context_id,
+            name=name,
+            artifact_id=artifact_id,
+            media_type=media_type,
+            append=append,
+            last_chunk=last_chunk,
+        )
+    if kind == "url":
+        return new_url_artifact_update_event(
+            url=str(payload.get("value") or ""),
+            filename=payload.get("filename"),
+            task_id=task_id,
+            context_id=context_id,
+            name=name,
+            artifact_id=artifact_id,
+            media_type=media_type,
+            append=append,
+            last_chunk=last_chunk,
+        )
+    return None
 
 
 def _jsonrpc_error_response(
@@ -454,6 +581,15 @@ async def mount_a2a_routes(
         artifact_store=artifact_store,
     )
     handlers: dict[str, _ScopedRequestHandler] = {}
+    retention = A2ARetentionManager(
+        runtime,
+        store,
+        artifact_store,
+        ttl_seconds=getattr(settings, "a2a_terminal_task_ttl_seconds", 0),
+        interval_seconds=getattr(settings, "a2a_cleanup_interval_seconds", 3600.0),
+        batch_size=getattr(settings, "a2a_cleanup_batch_size", 100),
+        grace_seconds=getattr(settings, "a2a_cleanup_grace_seconds", 300),
+    )
     cards_last_modified = format_datetime(datetime.now(UTC), usegmt=True)
 
     def get_handler(agent_name: str, card: Any) -> _ScopedRequestHandler:
@@ -475,6 +611,22 @@ async def mount_a2a_routes(
                     settings,
                     "a2a_max_raw_part_bytes",
                     10 * 1024 * 1024,
+                ),
+                max_parts=getattr(settings, "a2a_max_parts", 64),
+                max_message_bytes=getattr(settings, "a2a_max_message_bytes", 16 * 1024 * 1024),
+                max_text_part_bytes=getattr(
+                    settings, "a2a_max_text_part_bytes", 2 * 1024 * 1024
+                ),
+                max_data_part_bytes=getattr(
+                    settings, "a2a_max_data_part_bytes", 2 * 1024 * 1024
+                ),
+                max_output_artifacts=getattr(settings, "a2a_max_output_artifacts", 100),
+                max_output_bytes=getattr(
+                    settings, "a2a_max_output_bytes", 16 * 1024 * 1024
+                ),
+                stream_chunk_bytes=getattr(settings, "a2a_stream_chunk_bytes", 4096),
+                stream_flush_interval_seconds=getattr(
+                    settings, "a2a_stream_flush_interval_seconds", 0.25
                 ),
             )
             context_builder = _IdempotentRequestContextBuilder(
@@ -600,6 +752,8 @@ async def mount_a2a_routes(
                 status_code=404,
             )
 
+        await retention.maybe_cleanup(agent.name, scope or {})
+
         if request.headers.get("content-type", "").split(";", 1)[0].strip().lower() != (
             "application/json"
         ):
@@ -622,6 +776,16 @@ async def mount_a2a_routes(
             return _jsonrpc_error_response(None, -32700, "Parse error")
         if not isinstance(payload, dict):
             return _jsonrpc_error_response(None, -32600, "Invalid request")
+        operation = payload.get("method")
+        known_operations = {
+            "SendMessage",
+            "SendStreamingMessage",
+            "GetTask",
+            "ListTasks",
+            "CancelTask",
+            "SubscribeToTask",
+        }
+        operation_label = operation if operation in known_operations else "unknown"
 
         card = build_agent_card_for_agent(
             agent,
@@ -641,6 +805,7 @@ async def mount_a2a_routes(
             _discard_unknown_proto_fields(payload),
         )
         sdk_response = await dispatcher.handle_requests(sdk_request)
+        A2A_REQUESTS_TOTAL.labels(operation=operation_label, outcome="handled").inc()
         sdk_response.headers.setdefault("a2a-version", CURRENT_A2A_VERSION)
         return sdk_response
 

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -255,6 +255,64 @@ class Settings(BaseSettings):
         alias="COGNITION_A2A_MAX_RAW_PART_BYTES",
         description="Maximum decoded size accepted for one inbound A2A raw Part.",
     )
+    a2a_max_parts: int = Field(default=64, ge=1, alias="COGNITION_A2A_MAX_PARTS")
+    a2a_max_message_bytes: int = Field(
+        default=16 * 1024 * 1024,
+        ge=1,
+        alias="COGNITION_A2A_MAX_MESSAGE_BYTES",
+    )
+    a2a_max_text_part_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=1,
+        alias="COGNITION_A2A_MAX_TEXT_PART_BYTES",
+    )
+    a2a_max_data_part_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=1,
+        alias="COGNITION_A2A_MAX_DATA_PART_BYTES",
+    )
+    a2a_max_output_artifacts: int = Field(
+        default=100,
+        ge=1,
+        alias="COGNITION_A2A_MAX_OUTPUT_ARTIFACTS",
+    )
+    a2a_max_output_bytes: int = Field(
+        default=16 * 1024 * 1024,
+        ge=1,
+        alias="COGNITION_A2A_MAX_OUTPUT_BYTES",
+    )
+    a2a_stream_chunk_bytes: int = Field(
+        default=4096,
+        ge=1,
+        alias="COGNITION_A2A_STREAM_CHUNK_BYTES",
+    )
+    a2a_stream_flush_interval_seconds: float = Field(
+        default=0.25,
+        gt=0,
+        alias="COGNITION_A2A_STREAM_FLUSH_INTERVAL_SECONDS",
+    )
+    a2a_terminal_task_ttl_seconds: int = Field(
+        default=0,
+        ge=0,
+        alias="COGNITION_A2A_TERMINAL_TASK_TTL_SECONDS",
+        description="Terminal A2A task retention. Zero disables automatic deletion.",
+    )
+    a2a_cleanup_interval_seconds: float = Field(
+        default=3600.0,
+        gt=0,
+        alias="COGNITION_A2A_CLEANUP_INTERVAL_SECONDS",
+    )
+    a2a_cleanup_batch_size: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        alias="COGNITION_A2A_CLEANUP_BATCH_SIZE",
+    )
+    a2a_cleanup_grace_seconds: int = Field(
+        default=300,
+        ge=0,
+        alias="COGNITION_A2A_CLEANUP_GRACE_SECONDS",
+    )
 
     # SSE (Server-Sent Events) settings
     sse_heartbeat_interval_seconds: float = Field(

--- a/server/app/storage/backend.py
+++ b/server/app/storage/backend.py
@@ -321,6 +321,12 @@ class RuntimeStore(Protocol):
         """Conditionally update a task, returning None on mismatch/not-found."""
         ...
 
+    async def delete_task_data(
+        self, task_id: str, effective_scope: dict[str, str]
+    ) -> bool:
+        """Delete a terminal task and its task-owned runtime projections."""
+        ...
+
     async def create_run(
         self,
         run_id: str,
@@ -567,6 +573,12 @@ class StorageBackend(Protocol):
         metadata: dict[str, Any] | None = None,
     ) -> RuntimeTask | None:
         """Conditionally update a task, returning None on mismatch/not-found."""
+        ...
+
+    async def delete_task_data(
+        self, task_id: str, effective_scope: dict[str, str]
+    ) -> bool:
+        """Delete a terminal task and its task-owned runtime projections."""
         ...
 
     async def create_run(

--- a/server/app/storage/memory.py
+++ b/server/app/storage/memory.py
@@ -416,6 +416,27 @@ class MemoryStorageBackend:
         task.updated_at = now_utc_iso()
         return task
 
+    async def delete_task_data(
+        self, task_id: str, effective_scope: dict[str, str]
+    ) -> bool:
+        """Delete only terminal, exact-scope data owned by one task."""
+        task = await self.get_task(task_id, effective_scope)
+        if task is None or not TaskStatus.is_terminal(task.status):
+            return False
+        run_ids = {run.id for run in self._runs.values() if run.task_id == task_id}
+        for event_id in [key for key, event in self._events.items() if event.task_id == task_id]:
+            del self._events[event_id]
+        for message_id in [
+            key
+            for key, message in self._messages.items()
+            if (message.metadata or {}).get("task_id") == task_id
+        ]:
+            del self._messages[message_id]
+        for run_id in run_ids:
+            self._runs.pop(run_id, None)
+        del self._tasks[task_id]
+        return True
+
     async def create_run(
         self,
         run_id: str,

--- a/server/app/storage/postgres.py
+++ b/server/app/storage/postgres.py
@@ -828,6 +828,27 @@ class PostgresStorageBackend:
             return None
         return await self.get_task(task_id, effective_scope)
 
+    async def delete_task_data(
+        self, task_id: str, effective_scope: dict[str, str]
+    ) -> bool:
+        """Delete only terminal, exact-scope data owned by one task."""
+        current = await self.get_task(task_id, effective_scope)
+        if current is None or not TaskStatus.is_terminal(current.status):
+            return False
+        async with self._pool.acquire() as conn, conn.transaction():
+            await conn.execute("DELETE FROM session_events WHERE task_id = $1", task_id)
+            await conn.execute(
+                "DELETE FROM messages WHERE metadata->>'task_id' = $1",
+                task_id,
+            )
+            await conn.execute("DELETE FROM session_runs WHERE task_id = $1", task_id)
+            result = await conn.execute(
+                "DELETE FROM runtime_tasks WHERE id = $1 AND scope_key = $2",
+                task_id,
+                effective_scope_key(effective_scope),
+            )
+        return result == "DELETE 1"
+
     async def create_run(
         self,
         run_id: str,

--- a/server/app/storage/sqlite.py
+++ b/server/app/storage/sqlite.py
@@ -735,6 +735,27 @@ class SqliteStorageBackend:
             return None
         return await self.get_task(task_id, effective_scope)
 
+    async def delete_task_data(
+        self, task_id: str, effective_scope: dict[str, str]
+    ) -> bool:
+        """Delete only terminal, exact-scope data owned by one task."""
+        current = await self.get_task(task_id, effective_scope)
+        if current is None or not TaskStatus.is_terminal(current.status):
+            return False
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("DELETE FROM session_events WHERE task_id = ?", (task_id,))
+            await db.execute(
+                "DELETE FROM messages WHERE json_extract(metadata, '$.task_id') = ?",
+                (task_id,),
+            )
+            await db.execute("DELETE FROM session_runs WHERE task_id = ?", (task_id,))
+            cursor = await db.execute(
+                "DELETE FROM runtime_tasks WHERE id = ? AND scope_key = ?",
+                (task_id, effective_scope_key(effective_scope)),
+            )
+            await db.commit()
+        return cursor.rowcount == 1
+
     async def create_run(
         self,
         run_id: str,

--- a/tests/unit/test_a2a_jsonrpc_runtime.py
+++ b/tests/unit/test_a2a_jsonrpc_runtime.py
@@ -89,6 +89,11 @@ class _FakeAgentService:
             )
             yield DoneEvent()
             return
+        if message_id.startswith("chunked-output"):
+            for token in ("one ", "two ", "three ", "four ", "five"):
+                yield TokenEvent(content=token)
+            yield DoneEvent()
+            return
         yield TokenEvent(content="A2A works")
         yield DoneEvent()
 
@@ -113,6 +118,7 @@ async def _build_client(
     manager: _FakeSessionAgentManager | None = None,
     artifact_store: MemoryArtifactStore | None = None,
     max_raw_part_bytes: int = 10 * 1024 * 1024,
+    stream_chunk_bytes: int = 4096,
 ) -> httpx.AsyncClient:
     app = FastAPI()
     config_store = DefaultConfigStore(MemoryConfigRegistry())
@@ -133,6 +139,7 @@ async def _build_client(
         scoping_enabled = True
         workspace_path = tmp_path
         a2a_max_raw_part_bytes = max_raw_part_bytes
+        a2a_stream_chunk_bytes = stream_chunk_bytes
 
     await mount_a2a_routes(
         app,
@@ -235,6 +242,62 @@ async def test_send_get_list_and_idempotency_use_durable_runtime(
             },
         )
         assert [item["id"] for item in listed.json()["result"]["tasks"]] == [task["id"]]
+
+
+async def test_reusing_message_id_with_different_input_is_rejected(
+    setup_storage_backend: StorageBackend,
+    tmp_path,
+) -> None:
+    client = await _build_client(setup_storage_backend, tmp_path)
+    first = _send_request("fingerprinted-message")
+    conflicting = _send_request("fingerprinted-message")
+    conflicting["params"]["message"]["parts"] = [{"text": "Different input"}]
+
+    async with client:
+        accepted = await client.post("/a2a/researcher", json=first)
+        rejected = await client.post("/a2a/researcher", json=conflicting)
+
+    assert accepted.json()["result"]["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert rejected.json()["error"]["code"] == -32602
+    assert "different request" in rejected.json()["error"]["message"]
+
+
+async def test_streaming_tokens_are_coalesced_into_durable_artifact_updates(
+    setup_storage_backend: StorageBackend,
+    tmp_path,
+) -> None:
+    client = await _build_client(
+        setup_storage_backend,
+        tmp_path,
+        stream_chunk_bytes=10,
+    )
+    request = _send_request("chunked-output-1")
+    request["method"] = "SendStreamingMessage"
+    wire_events: list[dict] = []
+
+    async with client:
+        async with client.stream("POST", "/a2a/researcher", json=request) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    wire_events.append(json.loads(line[6:]))
+
+    updates = [
+        event["result"]["artifactUpdate"]
+        for event in wire_events
+        if "artifactUpdate" in event.get("result", {})
+    ]
+    task = next(event["result"]["task"] for event in wire_events if "task" in event["result"])
+    text = "".join(
+        update["artifact"]["parts"][0].get("text", "") for update in updates
+    )
+    durable = await setup_storage_backend.list_events(
+        task["contextId"], event_type="artifact.updated", task_id=task["id"]
+    )
+
+    assert text == "one two three four five"
+    assert 1 < len(updates) < 5
+    assert len(durable) == len(updates)
+    assert updates[-1]["lastChunk"] is True
 
 
 async def test_scope_mismatch_is_not_found_and_v03_method_is_rejected(

--- a/tests/unit/test_runtime_task_store.py
+++ b/tests/unit/test_runtime_task_store.py
@@ -156,3 +156,45 @@ async def test_run_and_events_retain_task_correlation(task_store: StorageBackend
     assert event.task_id == "task-1"
     events = await task_store.list_events("context-1", task_id="task-1")
     assert [item.id for item in events] == ["event-1"]
+
+
+@pytest.mark.asyncio
+async def test_delete_task_data_is_terminal_exact_scope_and_task_local(
+    task_store: StorageBackend,
+) -> None:
+    scope = {"project": "kennel"}
+    await _session(task_store, "context-1", scope)
+    for task_id in ("expired", "retained"):
+        await task_store.create_task(
+            task_id=task_id,
+            context_id="context-1",
+            session_id="context-1",
+            agent_name="analyst",
+            effective_scope=scope,
+        )
+        await task_store.create_run(
+            run_id=f"run-{task_id}",
+            session_id="context-1",
+            thread_id="thread-1",
+            status=RunStatus.ACTIVE,
+            effective_scope=scope,
+            task_id=task_id,
+        )
+        await task_store.append_event(
+            event_id=f"event-{task_id}",
+            session_id="context-1",
+            run_id=f"run-{task_id}",
+            event_type="run.started",
+            effective_scope=scope,
+            task_id=task_id,
+        )
+
+    assert not await task_store.delete_task_data("expired", scope)
+    await task_store.update_task("expired", scope, status=TaskStatus.WORKING)
+    await task_store.update_task("expired", scope, status=TaskStatus.COMPLETED)
+    assert not await task_store.delete_task_data("expired", {"project": "other"})
+    assert await task_store.delete_task_data("expired", scope)
+    assert await task_store.get_task("expired", scope) is None
+    assert await task_store.get_run("run-expired") is None
+    assert await task_store.list_events("context-1", task_id="expired") == []
+    assert await task_store.get_task("retained", scope) is not None

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -59,6 +59,10 @@ class TestSettingsDefaults:
         assert settings.a2a_security_schemes == {}
         assert settings.a2a_security_requirements == []
         assert settings.a2a_max_raw_part_bytes == 10 * 1024 * 1024
+        assert settings.a2a_max_parts == 64
+        assert settings.a2a_max_message_bytes == 16 * 1024 * 1024
+        assert settings.a2a_stream_chunk_bytes == 4096
+        assert settings.a2a_terminal_task_ttl_seconds == 0
 
 
 class TestA2ASecuritySettings:


### PR DESCRIPTION
## Summary

- coalesce streamed A2A tokens into durable artifact updates with bounded byte/time flushing
- reject conflicting message-id retries using canonical request fingerprints
- add inbound/output limits, exact-scope terminal-task retention, and task-owned cleanup
- add low-cardinality A2A metrics, tracing, builder documentation, and coverage

## Why

The A2A adapter persisted one event per model token while exposing only a final artifact. Retries with a reused message ID could also silently return a task created from different input. This change makes streaming durable and replayable, bounds storage and request pressure, and gives operators useful telemetry.

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest tests/unit -q` (877 passed, 4 skipped)

The repository-wide test command reaches environment-dependent E2E tests that require a separately running Cognition server.
