### PR TITLE
fix(a2a): preserve complete Part semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the A2A-specific `response_format` projection: a deployed Pydantic model no longer determines whether a generic A2A response becomes a DataPart.
+- Preserved every A2A DataPart JSON value and all inbound Part and Message context through canonical task persistence, model rendering, and durable artifact replay.
+
 ## [0.12.0-rc.6] — 2026-07-21
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,9 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-07-21 | Persist a canonical ordered representation of every inbound A2A Part plus Message metadata, extensions, and references; derive model rendering without losing `mediaType`, filename, metadata, or content type. | A2A Part/message fidelity audit | 2/4/6 | Completed |
+| 2026-07-21 | Remove the A2A-specific `response_format` to DataPart projection so generic A2A output does not depend on a builder-installed Python schema. | Decision Room bring-your-own-agent interoperability | 4/6 | Completed |
+| 2026-07-21 | Preserve every valid A2A `DataPart` JSON value (object, array, string, number, boolean, and null) through inbound normalization, durable artifacts, and streaming replay. | A2A Part §4.1.6 DataPart conformance | 2/4/6 | Completed |
 | 2026-07-20 | Project validated Deep Agents structured responses into outbound A2A data artifacts and verify text, data, raw, and URL Parts bidirectionally on JSON-RPC and SSE wire paths. | A2A outbound Part coverage gap | 4/6 | Completed |
 | 2026-07-20 | Enforce the configured per-agent execution deadline across shared native and A2A streaming so stalled provider streams terminate with a durable failure. | Kennel `0.12.0-rc5` live A2A streaming report | 4/6 | Completed |
 | 2026-07-20 | Reject conflicting A2A message-id retries by comparing a canonical request fingerprint instead of silently reusing a task created for different input. | A2A idempotency conflict | 2/4/6 | Completed |

--- a/docs/concepts/a2a/message-parts.md
+++ b/docs/concepts/a2a/message-parts.md
@@ -9,14 +9,24 @@ caller cannot supply or override scope through Part metadata.
 
 | A2A Part content | Cognition representation | Model-visible form |
 |---|---|---|
-| `text` | User-message text | Text, preserving Part order |
-| `data` | Structured JSON value | A delimited JSON block, preserving structure |
+| `text` | Canonical input Part plus user-message text | Text with an annotation block when Part fields accompany it |
+| `data` | Canonical input Part containing any JSON value | A delimited JSON block, preserving value and Part fields |
 | `raw` | Scoped, task-linked input artifact | An artifact reference with filename and media type |
 | `url` | Scoped, task-linked URL artifact | A URL-artifact reference with filename and media type |
 
 Mixed messages preserve Part order in the normalized user message. A message may
 contain any combination of the four variants. Cognition rejects a Part whose A2A
 content oneof is unset instead of silently dropping it.
+
+Every Part is also persisted in a canonical task-local representation containing
+its content kind and value, `mediaType`, `filename`, and `metadata`. Message
+metadata, extension URIs, and reference task IDs are persisted alongside the
+ordered Part IDs. The model-visible rendering is derived from this representation;
+it is not the durable source of truth.
+
+The `data` variant accepts every JSON value permitted by A2A: object, array,
+string, number, boolean, and null. Cognition does not narrow DataParts to JSON
+objects.
 
 `raw` contains inline bytes on the A2A wire. Cognition persists those bytes as a
 base64-encoded artifact representation so they remain JSON-safe and can be
@@ -83,14 +93,14 @@ Cognition returns an A2A content/parameter error before starting a run when:
 - raw content is malformed or exceeds configured request limits; or
 - required Part fields are invalid under the A2A schema.
 
-Unknown media types are retained as metadata for raw and URL artifacts. They are
-not interpreted or executed by the adapter.
+Unknown media types and Part metadata are retained for every content variant.
+They are not interpreted as authorization or executed by the adapter.
 
 ## Outbound Parts
 
 Cognition serializes protocol-neutral runtime artifacts as the matching A2A
 Part variant: text, structured data, inline raw bytes, or a URL reference.
-Deep Agents structured output configured with `response_format` is published as
-an `application/json` data artifact. Cognition does not parse ordinary text that
-happens to look like JSON; builders must configure a response schema or emit an
-explicit data artifact when consumers require machine-readable output.
+Cognition does not infer a data Part from ordinary text that happens to look
+like JSON. A runtime `data` artifact is projected as an A2A DataPart without
+requiring a preconfigured application schema; consumers validate any
+application-specific contract.

--- a/docs/guides/a2a.md
+++ b/docs/guides/a2a.md
@@ -128,7 +128,11 @@ curl -X POST http://localhost:8000/a2a/document-agent \
       "messageId": "message-1",
       "role": "ROLE_USER",
       "parts": [
-        {"text": "Summarize this document.", "mediaType": "text/plain"},
+        {
+          "text": "Summarize this document.",
+          "mediaType": "text/plain",
+          "metadata": {"responseMediaType": "application/json"}
+        },
         {"data": {"priority": 3}, "mediaType": "application/json"},
         {"url": "https://files.example.com/contract.pdf", "filename": "contract.pdf", "mediaType": "application/pdf"}
       ]
@@ -140,7 +144,8 @@ JSON
 
 See [Message Parts and Artifacts](../concepts/a2a/message-parts.md) before
 accepting files or remote references. URL Parts are stored as references and are
-not downloaded automatically.
+not downloaded automatically. Part and Message metadata are preserved as
+untrusted application context; they never override Cognition scope or policy.
 
 ## 6. Stream a response
 

--- a/server/app/agent/runtime.py
+++ b/server/app/agent/runtime.py
@@ -19,7 +19,7 @@ Architecture:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, runtime_checkable
@@ -409,26 +409,6 @@ def _extract_todos_from_update(update: Any) -> list[dict[str, Any]] | None:
         todos = state_update.get("todos")
         if isinstance(todos, list):
             return [_normalize_todo_item(todo) for todo in todos]
-    return None
-
-
-def _extract_structured_response(update: Any) -> dict[str, Any] | None:
-    """Extract a JSON-object structured response from a root graph update."""
-    if not isinstance(update, Mapping):
-        return None
-
-    candidates: list[Any] = [update]
-    candidates.extend(value for value in update.values() if isinstance(value, Mapping))
-    for candidate in candidates:
-        if not isinstance(candidate, Mapping) or "structured_response" not in candidate:
-            continue
-        response = candidate["structured_response"]
-        if hasattr(response, "model_dump"):
-            response = response.model_dump(mode="json")
-        elif is_dataclass(response) and not isinstance(response, type):
-            response = asdict(response)
-        if isinstance(response, Mapping):
-            return {str(key): value for key, value in response.items()}
     return None
 
 
@@ -859,8 +839,6 @@ class DeepAgentRuntime:
             previous_todos: list[dict[str, Any]] = []
             emitted_initial_plan = False
             interrupt_emitted = False
-            structured_response_emitted = False
-
             async for chunk in self._agent.astream(
                 agent_input,
                 config=config,
@@ -978,18 +956,6 @@ class DeepAgentRuntime:
                             else None,
                             summary_id=str(file_path) if file_path is not None else None,
                         )
-
-                    if not ns and not structured_response_emitted:
-                        structured_response = _extract_structured_response(data)
-                        if structured_response is not None:
-                            structured_response_emitted = True
-                            yield ArtifactEvent(
-                                artifact_id="structured-response",
-                                name="structured-response",
-                                kind="data",
-                                value=structured_response,
-                                media_type="application/json",
-                            )
 
                     is_subagent = any(s.startswith("tools:") for s in ns)
 

--- a/server/app/agent/task_runtime.py
+++ b/server/app/agent/task_runtime.py
@@ -117,12 +117,13 @@ class TaskExecution:
 
 
 @dataclass(frozen=True)
-class TaskInputArtifact:
-    """Protocol-neutral, inert input attachment for one task execution."""
+class TaskInputPart:
+    """Protocol-neutral, lossless input part for one task execution."""
 
     id: str
+    index: int
     kind: str
-    content: str
+    value: Any
     content_encoding: str
     media_type: str | None
     filename: str | None
@@ -569,61 +570,79 @@ class AgentTaskRuntime:
             )
         return updated
 
-    async def persist_input_artifacts(
+    async def persist_input_parts(
         self,
         execution: TaskExecution,
-        artifacts: Sequence[TaskInputArtifact],
+        parts: Sequence[TaskInputPart],
+        *,
+        message_id: str,
+        message_metadata: dict[str, Any] | None = None,
+        message_extensions: Sequence[str] = (),
+        reference_task_ids: Sequence[str] = (),
     ) -> RuntimeTask:
-        """Persist inert, task-linked inputs under the execution's exact scope."""
-        if not artifacts:
-            return execution.task
-
+        """Persist lossless input Parts under the execution's exact scope."""
         current = await self._require_task(
             execution.task.id,
             execution.task.agent_name,
             execution.task.effective_scope,
         )
-        new_descriptors = [
+        new_descriptors: list[dict[str, Any]] = [
             {
-                "artifact_id": artifact.id,
-                "kind": artifact.kind,
-                "content_encoding": artifact.content_encoding,
-                "filename": artifact.filename,
-                "media_type": artifact.media_type,
-                "metadata": artifact.metadata,
+                "part_id": part.id,
+                "index": part.index,
+                "kind": part.kind,
+                "value": part.value,
+                "content_encoding": part.content_encoding,
+                "filename": part.filename,
+                "media_type": part.media_type,
+                "metadata": part.metadata,
             }
-            for artifact in artifacts
+            for part in parts
         ]
-        descriptors = [dict(item) for item in current.metadata.get("input_artifacts", [])]
-        new_ids = {item["artifact_id"] for item in new_descriptors}
-        descriptors = [item for item in descriptors if item.get("artifact_id") not in new_ids]
+        descriptors = [dict(item) for item in current.metadata.get("input_parts", [])]
+        new_ids = {item["part_id"] for item in new_descriptors}
+        descriptors = [item for item in descriptors if item.get("part_id") not in new_ids]
         descriptors.extend(new_descriptors)
+        input_messages = [dict(item) for item in current.metadata.get("input_messages", [])]
+        message_descriptor = {
+            "message_id": message_id,
+            "part_ids": [part.id for part in parts],
+            "metadata": dict(message_metadata or {}),
+            "extensions": [str(value) for value in message_extensions],
+            "reference_task_ids": [str(value) for value in reference_task_ids],
+        }
+        input_messages = [item for item in input_messages if item.get("message_id") != message_id]
+        input_messages.append(message_descriptor)
         updated = await self._store.update_task(
             current.id,
             current.effective_scope,
             expected_statuses={current.status},
-            metadata={**current.metadata, "input_artifacts": descriptors},
+            metadata={
+                **current.metadata,
+                "input_parts": descriptors,
+                "input_messages": input_messages,
+            },
         )
         if updated is None:
             raise RuntimeTaskConflictError(
-                f"Task '{current.id}' changed while input artifacts were persisted",
+                f"Task '{current.id}' changed while input Parts were persisted",
                 task_id=current.id,
             )
 
         if self._artifact_store is not None:
             from server.app.storage.config_models import ArtifactDefinition
 
-            for artifact in artifacts:
-                default_type = (
-                    "application/octet-stream" if artifact.kind == "raw" else "text/uri-list"
-                )
+            for part in parts:
+                if part.kind not in {"raw", "url"}:
+                    continue
+                default_type = "application/octet-stream" if part.kind == "raw" else "text/uri-list"
                 await self._artifact_store.upsert_artifact(
                     ArtifactDefinition(
-                        id=artifact.id,
-                        name=artifact.id,
+                        id=part.id,
+                        name=part.id,
                         artifact_type="artifact",
-                        content=artifact.content,
-                        content_type=artifact.media_type or default_type,
+                        content=str(part.value),
+                        content_type=part.media_type or default_type,
                         run_id=execution.run.id,
                         visibility="run",
                         scope=execution.task.effective_scope,
@@ -632,8 +651,8 @@ class AgentTaskRuntime:
                 )
         await self.projection.append_event(
             execution.run,
-            "artifact.input.persisted",
-            payload={"count": len(artifacts)},
+            "part.input.persisted",
+            payload={"count": len(parts)},
             visibility="internal",
         )
         return updated

--- a/server/app/protocols/a2a/executor.py
+++ b/server/app/protocols/a2a/executor.py
@@ -21,6 +21,7 @@ from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.types import Role, TaskArtifactUpdateEvent, TaskState, TaskStatusUpdateEvent
 from a2a.utils.errors import InvalidParamsError, TaskNotFoundError
+from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
 
 from server.app.agent.runtime import (
     ArtifactEvent,
@@ -138,6 +139,17 @@ class CognitionA2AExecutor(AgentExecutor):
                     max_message_bytes=self._max_message_bytes,
                     max_text_part_bytes=self._max_text_part_bytes,
                     max_data_part_bytes=self._max_data_part_bytes,
+                    message_metadata=(
+                        MessageToDict(context.message.metadata)
+                        if context.message and context.message.HasField("metadata")
+                        else None
+                    ),
+                    message_extensions=(
+                        tuple(context.message.extensions) if context.message else ()
+                    ),
+                    reference_task_ids=(
+                        tuple(context.message.reference_task_ids) if context.message else ()
+                    ),
                 )
         except InvalidA2APartError as exc:
             from server.app.observability import A2A_LIMIT_REJECTIONS_TOTAL
@@ -205,7 +217,14 @@ class CognitionA2AExecutor(AgentExecutor):
             RUNTIME_ACTIVE_TASKS.labels(transport="a2a").inc()
             active_metric = True
 
-            await self._runtime.persist_input_artifacts(execution, normalized.artifacts)
+            await self._runtime.persist_input_parts(
+                execution,
+                normalized.parts,
+                message_id=normalized.message_id,
+                message_metadata=normalized.metadata,
+                message_extensions=normalized.extensions,
+                reference_task_ids=normalized.reference_task_ids,
+            )
 
             service = self._agent_manager.get_service(execution.session.id)
             if service is None:
@@ -263,6 +282,7 @@ class CognitionA2AExecutor(AgentExecutor):
                     first_output_recorded = True
                 streamed_chunk = True
                 last_flush_at = time.monotonic()
+
             system_prompt = execution.session.config.system_prompt
             source = service.stream_response(
                 session_id=execution.session.id,
@@ -324,7 +344,9 @@ class CognitionA2AExecutor(AgentExecutor):
                     output_bytes += artifact_bytes
                     output_artifact_ids.add(event.artifact_id)
                     if output_bytes > self._max_output_bytes:
-                        await self._fail_output_limit(execution, event_queue, "OUTPUT_BYTES_EXCEEDED")
+                        await self._fail_output_limit(
+                            execution, event_queue, "OUTPUT_BYTES_EXCEEDED"
+                        )
                         return
                     if len(output_artifact_ids) > self._max_output_artifacts:
                         await self._fail_output_limit(
@@ -352,7 +374,9 @@ class CognitionA2AExecutor(AgentExecutor):
                     chunk_buffer.append(event.content)
                     output_bytes += len(event.content.encode("utf-8"))
                     if output_bytes > self._max_output_bytes:
-                        await self._fail_output_limit(execution, event_queue, "OUTPUT_BYTES_EXCEEDED")
+                        await self._fail_output_limit(
+                            execution, event_queue, "OUTPUT_BYTES_EXCEEDED"
+                        )
                         return
                     buffered_bytes = len("".join(chunk_buffer).encode("utf-8"))
                     elapsed = time.monotonic() - last_flush_at
@@ -476,9 +500,7 @@ class CognitionA2AExecutor(AgentExecutor):
                 RUNTIME_TASK_DURATION.labels(transport="a2a", outcome=outcome).observe(
                     time.monotonic() - execution_started
                 )
-                RUNTIME_TASK_TRANSITIONS_TOTAL.labels(
-                    transport="a2a", status=outcome
-                ).inc()
+                RUNTIME_TASK_TRANSITIONS_TOTAL.labels(transport="a2a", status=outcome).inc()
 
     async def _fail_output_limit(
         self,
@@ -639,9 +661,7 @@ def _artifact_size(kind: str, value: Any) -> int:
     return len(str(value).encode("utf-8"))
 
 
-async def _with_flush_ticks(
-    source: AsyncIterator[Any], interval: float
-) -> AsyncIterator[Any]:
+async def _with_flush_ticks(source: AsyncIterator[Any], interval: float) -> AsyncIterator[Any]:
     """Yield source events plus periodic ticks without cancelling the producer."""
     iterator = aiter(source)
     pending: asyncio.Future[Any] = asyncio.ensure_future(anext(iterator))

--- a/server/app/protocols/a2a/inbound.py
+++ b/server/app/protocols/a2a/inbound.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import base64
 import json
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from a2a.types import Part
 from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
 
-from server.app.agent.task_runtime import TaskInputArtifact
+from server.app.agent.task_runtime import TaskInputPart
 
 
 class InvalidA2APartError(ValueError):
@@ -20,10 +20,35 @@ class InvalidA2APartError(ValueError):
 
 @dataclass(frozen=True)
 class NormalizedA2AMessage:
-    """Model-visible text plus scoped artifacts derived from A2A Parts."""
+    """Model-visible rendering plus lossless canonical A2A Parts."""
 
     content: str
-    artifacts: tuple[TaskInputArtifact, ...]
+    parts: tuple[TaskInputPart, ...]
+    message_id: str
+    metadata: dict[str, object]
+    extensions: tuple[str, ...]
+    reference_task_ids: tuple[str, ...]
+
+    @property
+    def artifacts(self) -> tuple[TaskInputPart, ...]:
+        """Return file-like Parts addressable through the artifact API."""
+        return tuple(part for part in self.parts if part.kind in {"raw", "url"})
+
+
+@dataclass(frozen=True)
+class _CanonicalMessageContext:
+    metadata: dict[str, object]
+    extensions: tuple[str, ...]
+    reference_task_ids: tuple[str, ...]
+    model_block: str | None
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class _NormalizedPart:
+    part: TaskInputPart
+    model_block: str
+    byte_size: int
 
 
 def normalize_a2a_parts(
@@ -36,109 +61,249 @@ def normalize_a2a_parts(
     max_message_bytes: int = 16 * 1024 * 1024,
     max_text_part_bytes: int = 2 * 1024 * 1024,
     max_data_part_bytes: int = 2 * 1024 * 1024,
+    message_metadata: dict[str, object] | None = None,
+    message_extensions: Sequence[str] = (),
+    reference_task_ids: Sequence[str] = (),
 ) -> NormalizedA2AMessage:
     """Normalize all A2A 1.0 Part variants while preserving wire order.
 
     Raw bytes and URLs become inert artifact references. This function performs
     no persistence, execution, file parsing, or network access.
     """
-    blocks: list[str] = []
-    artifacts: list[TaskInputArtifact] = []
-    stable_message_id = message_id or "anonymous"
-
     materialized = tuple(parts)
     if len(materialized) > max_parts:
         raise InvalidA2APartError(f"A2A message exceeds the {max_parts}-Part limit")
-    total_bytes = 0
+
+    stable_message_id = message_id or "anonymous"
+    context = _canonicalize_message_context(
+        metadata=message_metadata,
+        extensions=message_extensions,
+        reference_task_ids=reference_task_ids,
+    )
+    blocks = [context.model_block] if context.model_block is not None else []
+    normalized_parts: list[TaskInputPart] = []
+    total_bytes = context.byte_size
+    _enforce_aggregate_limit(total_bytes, max_message_bytes)
 
     for index, part in enumerate(materialized):
-        kind = part.WhichOneof("content")
-        if kind is None:
-            raise InvalidA2APartError(f"A2A message Part {index} has no content")
+        normalized = _normalize_part(
+            part,
+            index=index,
+            part_id=_part_id(task_id, stable_message_id, index),
+            max_raw_part_bytes=max_raw_part_bytes,
+            max_text_part_bytes=max_text_part_bytes,
+            max_data_part_bytes=max_data_part_bytes,
+        )
+        total_bytes += normalized.byte_size
+        _enforce_aggregate_limit(total_bytes, max_message_bytes)
+        normalized_parts.append(normalized.part)
+        blocks.append(normalized.model_block)
 
-        if kind == "text":
-            size = len(part.text.encode("utf-8"))
-            if size > max_text_part_bytes:
-                raise InvalidA2APartError(
-                    f"A2A text Part {index} exceeds the {max_text_part_bytes}-byte limit"
-                )
-            total_bytes += size
-            blocks.append(part.text)
-            continue
-        if kind == "data":
-            value = MessageToDict(part.data)
-            compact_data = json.dumps(
-                value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-            )
-            encoded_data = json.dumps(value, ensure_ascii=False, sort_keys=True)
-            size = len(compact_data.encode("utf-8"))
-            if size > max_data_part_bytes:
-                raise InvalidA2APartError(
-                    f"A2A data Part {index} exceeds the {max_data_part_bytes}-byte limit"
-                )
-            total_bytes += size
-            blocks.append(
-                f"[A2A data Part {index}]\n{encoded_data}"
-            )
-            continue
+    return NormalizedA2AMessage(
+        content="\n\n".join(blocks),
+        parts=tuple(normalized_parts),
+        message_id=stable_message_id,
+        metadata=context.metadata,
+        extensions=context.extensions,
+        reference_task_ids=context.reference_task_ids,
+    )
 
-        artifact_id = _artifact_id(task_id, stable_message_id, index)
-        media_type = part.media_type or None
-        filename = part.filename or None
-        metadata = MessageToDict(part.metadata) if part.HasField("metadata") else {}
-        if kind == "raw":
-            if len(part.raw) > max_raw_part_bytes:
-                raise InvalidA2APartError(
-                    f"A2A raw Part {index} exceeds the {max_raw_part_bytes}-byte limit"
-                )
-            content = base64.b64encode(part.raw).decode("ascii")
-            content_encoding = "base64"
-            total_bytes += len(part.raw)
-        else:
-            content = part.url
-            content_encoding = "uri"
-            total_bytes += len(part.url.encode("utf-8"))
 
-        if total_bytes > max_message_bytes:
-            raise InvalidA2APartError(
-                f"A2A message exceeds the {max_message_bytes}-byte aggregate limit"
-            )
+def _canonicalize_message_context(
+    *,
+    metadata: dict[str, object] | None,
+    extensions: Sequence[str],
+    reference_task_ids: Sequence[str],
+) -> _CanonicalMessageContext:
+    canonical_metadata = dict(metadata or {})
+    canonical_extensions = tuple(str(value) for value in extensions)
+    canonical_reference_ids = tuple(str(value) for value in reference_task_ids)
+    if not (canonical_metadata or canonical_extensions or canonical_reference_ids):
+        return _CanonicalMessageContext({}, (), (), None, 0)
 
-        artifacts.append(
-            TaskInputArtifact(
-                id=artifact_id,
-                kind=kind,
-                content=content,
-                content_encoding=content_encoding,
+    serialized = json.dumps(
+        {
+            "extensions": canonical_extensions,
+            "metadata": canonical_metadata,
+            "reference_task_ids": canonical_reference_ids,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return _CanonicalMessageContext(
+        metadata=canonical_metadata,
+        extensions=canonical_extensions,
+        reference_task_ids=canonical_reference_ids,
+        model_block=f"[A2A message context]\n{serialized}",
+        byte_size=len(serialized.encode("utf-8")),
+    )
+
+
+def _normalize_part(
+    part: Part,
+    *,
+    index: int,
+    part_id: str,
+    max_raw_part_bytes: int,
+    max_text_part_bytes: int,
+    max_data_part_bytes: int,
+) -> _NormalizedPart:
+    kind = part.WhichOneof("content")
+    if kind is None:
+        raise InvalidA2APartError(f"A2A message Part {index} has no content")
+
+    media_type = part.media_type or None
+    filename = part.filename or None
+    metadata = MessageToDict(part.metadata) if part.HasField("metadata") else {}
+
+    if kind == "text":
+        value: object = part.text
+        content_encoding = "utf-8"
+        byte_size = len(part.text.encode("utf-8"))
+        _enforce_part_limit("text", index, byte_size, max_text_part_bytes)
+        model_block = (
+            _annotated_text_part(
+                index=index,
+                text=part.text,
                 media_type=media_type,
                 filename=filename,
                 metadata=metadata,
             )
+            if metadata or media_type or filename
+            else part.text
         )
-        details = json.dumps(
-            {
-                "artifact": f"/artifacts/{artifact_id}",
-                "content_encoding": content_encoding,
-                "filename": filename,
-                "media_type": media_type,
-                "part_kind": kind,
-            },
-            ensure_ascii=False,
-            sort_keys=True,
+    elif kind == "data":
+        value = MessageToDict(part.data)
+        content_encoding = "json"
+        compact = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        byte_size = len(compact.encode("utf-8"))
+        _enforce_part_limit("data", index, byte_size, max_data_part_bytes)
+        model_block = _data_part_block(
+            index=index,
+            value=value,
+            media_type=media_type,
+            filename=filename,
+            metadata=metadata,
         )
-        blocks.append(f"[A2A {kind} Part {index}]\n{details}")
+    elif kind == "raw":
+        value = base64.b64encode(part.raw).decode("ascii")
+        content_encoding = "base64"
+        byte_size = len(part.raw)
+        _enforce_part_limit("raw", index, byte_size, max_raw_part_bytes)
+        model_block = None
+    elif kind == "url":
+        value = part.url
+        content_encoding = "uri"
+        byte_size = len(part.url.encode("utf-8"))
+        model_block = None
+    else:
+        raise InvalidA2APartError(f"A2A message Part {index} has unsupported content")
 
-    if total_bytes > max_message_bytes:
-        raise InvalidA2APartError(
-            f"A2A message exceeds the {max_message_bytes}-byte aggregate limit"
-        )
+    canonical_part = TaskInputPart(
+        id=part_id,
+        index=index,
+        kind=kind,
+        value=value,
+        content_encoding=content_encoding,
+        media_type=media_type,
+        filename=filename,
+        metadata=metadata,
+    )
+    return _NormalizedPart(
+        part=canonical_part,
+        model_block=model_block or _artifact_reference_block(canonical_part),
+        byte_size=byte_size + _part_envelope_size(media_type, filename, metadata),
+    )
 
-    return NormalizedA2AMessage(content="\n\n".join(blocks), artifacts=tuple(artifacts))
+
+def _data_part_block(
+    *,
+    index: int,
+    value: object,
+    media_type: str | None,
+    filename: str | None,
+    metadata: dict[str, object],
+) -> str:
+    rendered = json.dumps(
+        {
+            "filename": filename,
+            "media_type": media_type,
+            "metadata": metadata,
+            "value": value,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return f"[A2A data Part {index}]\n{rendered}"
 
 
-def _artifact_id(task_id: str, message_id: str, index: int) -> str:
+def _artifact_reference_block(part: TaskInputPart) -> str:
+    details = json.dumps(
+        {
+            "artifact": f"/artifacts/{part.id}",
+            "content_encoding": part.content_encoding,
+            "filename": part.filename,
+            "media_type": part.media_type,
+            "metadata": part.metadata,
+            "part_kind": part.kind,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return f"[A2A {part.kind} Part {part.index}]\n{details}"
+
+
+def _part_envelope_size(
+    media_type: str | None,
+    filename: str | None,
+    metadata: dict[str, object],
+) -> int:
+    serialized = json.dumps(
+        {
+            "filename": filename,
+            "media_type": media_type,
+            "metadata": metadata,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return len(serialized.encode("utf-8"))
+
+
+def _enforce_part_limit(kind: str, index: int, size: int, limit: int) -> None:
+    if size > limit:
+        raise InvalidA2APartError(f"A2A {kind} Part {index} exceeds the {limit}-byte limit")
+
+
+def _enforce_aggregate_limit(size: int, limit: int) -> None:
+    if size > limit:
+        raise InvalidA2APartError(f"A2A message exceeds the {limit}-byte aggregate limit")
+
+
+def _part_id(task_id: str, message_id: str, index: int) -> str:
     identity = f"cognition:a2a-input:{task_id}:{message_id}:{index}"
     return f"a2a-input-{uuid.uuid5(uuid.NAMESPACE_URL, identity).hex}"
+
+
+def _annotated_text_part(
+    *,
+    index: int,
+    text: str,
+    media_type: str | None,
+    filename: str | None,
+    metadata: dict[str, object],
+) -> str:
+    details = json.dumps(
+        {
+            "filename": filename,
+            "media_type": media_type,
+            "metadata": metadata,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return f"[A2A text Part {index}]\n{details}\n\n{text}"
 
 
 __all__ = [

--- a/server/app/protocols/a2a/routes.py
+++ b/server/app/protocols/a2a/routes.py
@@ -445,12 +445,12 @@ def _artifact_update_from_runtime_event(
             append=append,
             last_chunk=last_chunk,
         )
-    if kind == "data" and isinstance(payload.get("value"), dict):
+    if kind == "data":
         return new_data_artifact_update_event(
             task_id=task_id,
             context_id=context_id,
             name=name,
-            data=payload["value"],
+            data=payload.get("value"),
             artifact_id=artifact_id,
             media_type=media_type,
             append=append,

--- a/tests/unit/test_a2a_inbound.py
+++ b/tests/unit/test_a2a_inbound.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from a2a.helpers.proto_helpers import new_data_part
 from a2a.types import Part
 from google.protobuf.json_format import ParseDict  # type: ignore[import-untyped]
 
@@ -47,9 +48,9 @@ def test_normalizes_all_part_variants_in_wire_order_without_fetching() -> None:
     assert normalized.content.index("A2A raw Part 2") < normalized.content.index("A2A url Part 3")
     assert json.dumps({"priority": 3.0}, sort_keys=True) in normalized.content
     assert [artifact.kind for artifact in normalized.artifacts] == ["raw", "url"]
-    assert normalized.artifacts[0].content == "aGVsbG8="
+    assert normalized.artifacts[0].value == "aGVsbG8="
     assert normalized.artifacts[0].content_encoding == "base64"
-    assert normalized.artifacts[1].content == "https://example.com/report.pdf"
+    assert normalized.artifacts[1].value == "https://example.com/report.pdf"
     assert normalized.artifacts[1].content_encoding == "uri"
     assert all(f"/artifacts/{item.id}" in normalized.content for item in normalized.artifacts)
 
@@ -68,6 +69,66 @@ def test_artifact_ids_are_idempotent_per_message_and_unique_across_messages() ->
 
     assert first.artifacts[0].id == retry.artifacts[0].id
     assert first.artifacts[0].id != continuation.artifacts[0].id
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"nested": [True, None]},
+        ["proposal", 2],
+        "command",
+        7,
+        True,
+        None,
+    ],
+)
+def test_normalizes_every_valid_a2a_data_value(value: object) -> None:
+    """A2A DataPart values are any JSON value, not only objects."""
+    normalized = normalize_a2a_parts(
+        [new_data_part(value, media_type="application/json")],
+        task_id="task-1",
+        message_id="message-1",
+        max_raw_part_bytes=1024,
+    )
+
+    assert json.loads(normalized.content.split("\n", 1)[1])["value"] == value
+    assert normalized.artifacts == ()
+
+
+def test_preserves_part_and_message_context_in_model_rendering() -> None:
+    normalized = normalize_a2a_parts(
+        [
+            _part(
+                {
+                    "text": "Return a command",
+                    "mediaType": "text/plain",
+                    "metadata": {
+                        "schema": {"type": "object"},
+                        "contractVersion": "1.0",
+                    },
+                }
+            )
+        ],
+        task_id="task-1",
+        message_id="message-1",
+        max_raw_part_bytes=1024,
+        message_metadata={"roomId": "room-1"},
+        message_extensions=("https://example.com/decision-room/v1",),
+        reference_task_ids=("task-parent",),
+    )
+
+    assert normalized.metadata == {"roomId": "room-1"}
+    assert normalized.extensions == ("https://example.com/decision-room/v1",)
+    assert normalized.reference_task_ids == ("task-parent",)
+    assert normalized.parts[0].media_type == "text/plain"
+    assert normalized.parts[0].metadata == {
+        "contractVersion": "1.0",
+        "schema": {"type": "object"},
+    }
+    assert "A2A message context" in normalized.content
+    assert "decision-room/v1" in normalized.content
+    assert "contractVersion" in normalized.content
+    assert "Return a command" in normalized.content
 
 
 def test_rejects_unset_content_and_oversized_raw_parts() -> None:

--- a/tests/unit/test_a2a_jsonrpc_runtime.py
+++ b/tests/unit/test_a2a_jsonrpc_runtime.py
@@ -9,6 +9,7 @@ from typing import cast
 import httpx
 import pytest
 from fastapi import FastAPI
+from google.protobuf.json_format import MessageToDict  # type: ignore[import-untyped]
 
 from server.app.agent.runtime import (
     ArtifactEvent,
@@ -19,7 +20,7 @@ from server.app.agent.runtime import (
     TokenEvent,
 )
 from server.app.llm.deep_agent_service import SessionAgentManager
-from server.app.protocols.a2a.routes import mount_a2a_routes
+from server.app.protocols.a2a.routes import _artifact_update_from_runtime_event, mount_a2a_routes
 from server.app.settings import Settings
 from server.app.storage.artifact_store import MemoryArtifactStore
 from server.app.storage.backend import StorageBackend
@@ -57,12 +58,28 @@ class _FakeAgentService:
                 code="EXECUTION_TIMEOUT",
             )
             return
-        if message_id.startswith("tck-artifact-data"):
+        data_values: dict[str, object] = {
+            "object": {"key": "value", "count": 42},
+            "array": ["proposal", 2],
+            "string": "proposal",
+            "number": 7,
+            "boolean": True,
+            "null": None,
+        }
+        data_variant = next(
+            (
+                name
+                for name in data_values
+                if message_id.startswith(f"tck-artifact-data-{name}")
+            ),
+            None,
+        )
+        if data_variant is not None:
             yield ArtifactEvent(
                 artifact_id="data-output",
                 name="response",
                 kind="data",
-                value={"key": "value", "count": 42},
+                value=data_values[data_variant],
                 media_type="application/json",
             )
             yield DoneEvent()
@@ -532,7 +549,7 @@ async def test_message_only_and_non_text_artifact_variants_are_supported(
 
         data = await client.post(
             "/a2a/researcher",
-            json=_send_request("tck-artifact-data-1"),
+            json=_send_request("tck-artifact-data-object-1"),
         )
         assert data.json()["result"]["task"]["artifacts"][0]["parts"][0]["data"] == {
             "key": "value",
@@ -556,10 +573,54 @@ async def test_message_only_and_non_text_artifact_variants_are_supported(
 
 
 @pytest.mark.parametrize(
+    ("variant", "expected"),
+    [
+        ("object", {"key": "value", "count": 42}),
+        ("array", ["proposal", 2]),
+        ("string", "proposal"),
+        ("number", 7),
+        ("boolean", True),
+        ("null", None),
+    ],
+)
+async def test_task_projection_preserves_every_data_json_value(
+    setup_storage_backend: StorageBackend,
+    tmp_path,
+    variant: str,
+    expected: object,
+) -> None:
+    """Completed task retrieval must preserve the complete DataPart value union."""
+    client = await _build_client(setup_storage_backend, tmp_path)
+    async with client:
+        sent = await client.post(
+            "/a2a/researcher",
+            json=_send_request(f"tck-artifact-data-{variant}-task"),
+        )
+        task = sent.json()["result"]["task"]
+        fetched = await client.post(
+            "/a2a/researcher",
+            json={
+                "jsonrpc": "2.0",
+                "id": f"get-{variant}",
+                "method": "GetTask",
+                "params": {"id": task["id"]},
+            },
+        )
+
+    assert task["artifacts"][0]["parts"][0]["data"] == expected
+    assert fetched.json()["result"]["artifacts"][0]["parts"][0]["data"] == expected
+
+
+@pytest.mark.parametrize(
     ("message_id", "variant", "expected"),
     [
         ("stream-output-text", "text", "A2A works"),
-        ("tck-artifact-data-stream", "data", {"key": "value", "count": 42}),
+        ("tck-artifact-data-object-stream", "data", {"key": "value", "count": 42}),
+        ("tck-artifact-data-array-stream", "data", ["proposal", 2]),
+        ("tck-artifact-data-string-stream", "data", "proposal"),
+        ("tck-artifact-data-number-stream", "data", 7),
+        ("tck-artifact-data-boolean-stream", "data", True),
+        ("tck-artifact-data-null-stream", "data", None),
         ("tck-artifact-file-stream", "raw", "ZmlsZSBvdXRwdXQ="),
         (
             "tck-artifact-file-url-stream",
@@ -607,6 +668,37 @@ async def test_all_outbound_part_variants_stream_on_the_a2a_wire(
     )
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"proposal": "one"},
+        ["proposal", 2],
+        "proposal",
+        7,
+        True,
+        None,
+    ],
+)
+def test_data_artifact_replay_preserves_every_json_value(value: object) -> None:
+    """Reconnect replay must preserve the full A2A DataPart value union."""
+    event = _artifact_update_from_runtime_event(
+        "task-1",
+        "context-1",
+        {
+            "artifact_id": "data-1",
+            "name": "response",
+            "kind": "data",
+            "value": value,
+            "media_type": "application/json",
+            "last_chunk": True,
+        },
+    )
+
+    assert event is not None
+    assert event.artifact.parts[0].WhichOneof("content") == "data"
+    assert MessageToDict(event.artifact.parts[0].data) == value
+
+
 async def test_all_inbound_part_variants_are_ordered_scoped_and_inert(
     setup_storage_backend: StorageBackend,
     tmp_path,
@@ -620,9 +712,24 @@ async def test_all_inbound_part_variants_are_ordered_scoped_and_inert(
         artifact_store,
     )
     request = _send_request("all-input-parts")
+    request["params"]["message"].update(
+        {
+            "extensions": ["https://example.com/decision-room/v1"],
+            "metadata": {"roomId": "room-1"},
+            "referenceTaskIds": ["task-parent"],
+        }
+    )
     request["params"]["message"]["parts"] = [
-        {"text": "Analyze", "mediaType": "text/plain"},
-        {"data": {"priority": 3}, "mediaType": "application/json"},
+        {
+            "text": "Analyze",
+            "mediaType": "text/plain",
+            "metadata": {"schema": {"type": "object"}},
+        },
+        {
+            "data": {"priority": 3},
+            "mediaType": "application/json",
+            "metadata": {"contractVersion": "1.0"},
+        },
         {
             "raw": "aGVsbG8=",
             "filename": "../../note.txt",
@@ -646,6 +753,36 @@ async def test_all_inbound_part_variants_are_ordered_scoped_and_inert(
     assert content.index("Analyze") < content.index("A2A data Part 1")
     assert content.index("A2A data Part 1") < content.index("A2A raw Part 2")
     assert content.index("A2A raw Part 2") < content.index("A2A url Part 3")
+    assert "decision-room/v1" in content
+    assert '"roomId": "room-1"' in content
+    assert '"schema": {"type": "object"}' in content
+
+    task_id = response.json()["result"]["task"]["id"]
+    stored_task = await setup_storage_backend.get_task(
+        task_id,
+        {"account": "acme"},
+        "researcher",
+    )
+    assert stored_task is not None
+    assert [part["kind"] for part in stored_task.metadata["input_parts"]] == [
+        "text",
+        "data",
+        "raw",
+        "url",
+    ]
+    assert stored_task.metadata["input_parts"][0]["metadata"] == {
+        "schema": {"type": "object"}
+    }
+    assert stored_task.metadata["input_parts"][1]["value"] == {"priority": 3.0}
+    assert stored_task.metadata["input_messages"] == [
+        {
+            "message_id": "all-input-parts",
+            "part_ids": [part["part_id"] for part in stored_task.metadata["input_parts"]],
+            "metadata": {"roomId": "room-1"},
+            "extensions": ["https://example.com/decision-room/v1"],
+            "reference_task_ids": ["task-parent"],
+        }
+    ]
 
     artifacts = await artifact_store.list_artifacts(scope={"account": "acme"})
     artifacts = [item for item in artifacts if item.id.startswith("a2a-input-")]

--- a/tests/unit/test_runtime_streaming.py
+++ b/tests/unit/test_runtime_streaming.py
@@ -28,7 +28,6 @@ from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_core.messages.tool import ToolCallChunk
 
 from server.app.agent.runtime import (
-    ArtifactEvent,
     DeepAgentRuntime,
     DelegationEvent,
     DoneEvent,
@@ -39,7 +38,6 @@ from server.app.agent.runtime import (
     ToolResultEvent,
     ToolSafetyEvent,
 )
-from tests.fixtures.schemas import AgentResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -161,42 +159,6 @@ class TestTokenStreaming:
         runtime = _make_runtime(_ai_token("hi"))
         events = await _collect(runtime)
         assert isinstance(events[-1], DoneEvent)
-
-
-class TestStructuredOutputStreaming:
-    """Validated root-agent output becomes one protocol-neutral data artifact."""
-
-    @pytest.mark.asyncio
-    async def test_pydantic_structured_response_yields_data_artifact(self):
-        response = AgentResult(summary="Looks good")
-        runtime = _make_runtime(
-            _make_chunk(
-                "updates",
-                {"model": {"structured_response": response}},
-            )
-        )
-
-        events = await _collect(runtime)
-
-        artifacts = [event for event in events if isinstance(event, ArtifactEvent)]
-        assert len(artifacts) == 1
-        assert artifacts[0].kind == "data"
-        assert artifacts[0].media_type == "application/json"
-        assert artifacts[0].value == response.model_dump(mode="json")
-
-    @pytest.mark.asyncio
-    async def test_subagent_structured_response_is_not_published_as_root_output(self):
-        runtime = _make_runtime(
-            _make_chunk(
-                "updates",
-                {"model": {"structured_response": {"private": True}}},
-                ns=("tools:subagent-call",),
-            )
-        )
-
-        events = await _collect(runtime)
-
-        assert not any(isinstance(event, ArtifactEvent) for event in events)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- preserve every inbound A2A Part in canonical wire order, including `mediaType`, filename, metadata, Message metadata, extensions, and referenced task IDs
- support the complete A2A `DataPart` JSON value union through send responses, durable task projection, and streaming replay
- remove the A2A-specific `response_format` projection so generic A2A structured output does not depend on a builder-installed Python schema
- document Part handling, trust boundaries, and builder-facing behavior

## Root cause

Cognition treated inbound Parts primarily as rendered model text or file-like artifacts and narrowed outbound data artifacts to JSON objects. It also coupled A2A DataPart generation to Deep Agents `response_format`, which is deployment-specific rather than an A2A protocol mechanic. This lost valid Part context and prevented arrays, scalars, booleans, and null from surviving all output paths.

## Behavior

- `text`, `data`, `raw`, and `url` are handled explicitly and preserve their common Part fields.
- `data` accepts objects, arrays, strings, numbers, booleans, and null.
- raw bytes and URLs remain inert, task-linked, and exact-scope isolated.
- Message extensions and metadata remain untrusted caller context; they cannot override scope, routing, or policy.
- task outputs remain A2A Artifacts; ordinary JSON-looking text is not reinterpreted as a DataPart.
- the core Deep Agents `response_format` setting remains available, but no longer controls A2A Part selection.

## Validation

- `pytest tests/unit`: 902 passed, 4 skipped
- focused A2A/runtime suite: 75 passed
- official pinned A2A v1 JSON-RPC TCK: 100% compatibility, 92 passed, 173 transport/capability skips
- `ruff check .`
- `mypy .`

Compose-backed E2E scenarios were not run locally because the external test server/runtime was not started; CI remains the integration gate.
