### PR TITLE
chore: prepare v0.12.0-rc7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.0-rc.7] — 2026-07-22
+
 ### Fixed
 
 - Removed the A2A-specific `response_format` projection: a deployed Pydantic model no longer determines whether a generic A2A response becomes a DataPart.

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.12.0-rc.6"
+VERSION = "0.12.0-rc.7"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary

- report Cognition version `0.12.0-rc.7`
- move the merged A2A Part conformance fixes into the rc7 changelog section

## Validation

- `PYTHONPATH="$PWD" uv run python -c 'from server.version import VERSION; assert VERSION == "0.12.0-rc.7"'`\n- `PYTHONPATH="$PWD" uv run pytest tests/unit/test_settings.py -q` (15 passed, 2 skipped)