### PR TITLE
Prepare v0.13.0 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0-rc.1] — 2026-07-27
+
 ### Highlights
 
 - Reworked Cognition into a stricter multi-tenant Agent CRUD runtime: deployments start without built-in platform Agents, builders explicitly provision every Agent, and runtime data access is enforced at exact effective-scope boundaries.

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.12.0"
+VERSION = "0.13.0-rc.1"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary

Prepare the v0.13.0 release candidate metadata.

- Bumps server/version.py to 0.13.0-rc.1.
- Promotes the detailed v0.13.0 changelog from Unreleased into 0.13.0-rc.1.

## Validation

- uv run pytest tests/unit -v
- uv run ruff check .
- uv run mypy .
- uv run mkdocs build --strict
- git diff --check

## Release Scope

This PR does not create a final v0.13.0 tag or GitHub release. After merge, dispatch the Pre-Release Images workflow with version=0.13.0 and prerelease_tag=rc1 to create the rc1 app and sandbox images.
