### PR TITLE
Stabilize v0.13 A2A projection release gate

### DIFF
--- a/tests/unit/test_a2a_jsonrpc_runtime.py
+++ b/tests/unit/test_a2a_jsonrpc_runtime.py
@@ -603,7 +603,7 @@ async def test_task_projection_preserves_every_data_json_value(
     async with client:
         sent = await client.post(
             "/a2a/researcher",
-            json=_send_request(f"tck-artifact-data-{variant}-task"),
+            json=_send_request(f"tck-artifact-data-{variant}-task-{tmp_path.name}"),
         )
         task = sent.json()["result"]["task"]
         fetched = await client.post(


### PR DESCRIPTION
## Summary
- make the A2A DataPart projection parametrized test use unique message IDs per pytest temp invocation
- avoids deterministic task-id reuse in full-suite/pre-release workflow runs while preserving the same runtime behavior under test

## Validation
- `uv run pytest tests/unit/test_a2a_jsonrpc_runtime.py::test_task_projection_preserves_every_data_json_value -q`
- `uv run pytest tests/unit/test_a2a_jsonrpc_runtime.py -q`
- `uv run ruff check tests/unit/test_a2a_jsonrpc_runtime.py`
- `git diff --check`

This follows the release checklist recovery path: no tag has been created; the fix must land on `main` before rerunning the exact-commit pre-release image workflow.