### PR TITLE
docs: define v0.14 MCP runtime contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 | 2026-04-09 | **Defer runtime-controlled repo bootstrap for strict git isolation** — current local backend now provides session-scoped sandbox roots, but successful agent runs can still choose a shared clone destination like `/workspace/Cognition-Gateway`. Future work should move repo bootstrap under runtime control or per-session Docker sandboxes so clone destination is enforced structurally instead of via prompt guidance. | 4, 3 | Follow-on change after local sandbox rollout: introduce runtime-managed clone/bootstrap into `<session.workspace_path>/<repo>` or migrate to per-session Docker sandboxes. Keep current prompt guidance as a temporary mitigation until structural enforcement exists. | Planned |
 | 2026-04-12 | **Refactor `create_cognition_agent()` into `CognitionAgentParams` + `RuntimeContext`** — replace the 17-arg agent construction path with a structured parameter object, use runtime-context cache keys instead of MD5, and ensure subagent security middleware is injected into nested agent specs. | 4 | Migrate all internal callers to `CognitionAgentParams`, keep a compatibility wrapper only until callers are updated, then remove the keyword-based entry point and validate with boundary tests. | In Progress |
 | 2026-05-01 | **Unify file/API skills and tools through ConfigRegistry** — introduce workspace-level `skill_sources` / `tool_sources` bootstrap config, seed file-managed skills/tools into ConfigRegistry at startup, lock file-managed records from API mutation, and make agent `skills` / `tools` attach registry names only. Runtime resolves selected names through registry-backed backends/loaders instead of direct filesystem paths from agent definitions. | 4, 2, 6 | Non-backward-compatible config cleanup: agent `skills` / `tools` now mean selected registry names only; file source directories move to workspace config. Existing path-based agent attachments must migrate to seeded names. | Completed |
+| 2026-08-03 | **v0.14.0: Deep Agents-native agent-owned skills and MCP with zero-host durable file storage** — replace standalone skills and global MCP resolution with complete, internally snapshotted per-agent configuration; add standards-based, per-server MCP transport authentication; route durable file bodies through an exact-scope S3-compatible Deep Agents backend; require database/S3 persistence in production while retaining SQLite, in-memory, local-file, and local-sandbox support for local/dev. | 1, 2, 3, 4, 6, 7 | Intentional breaking upgrade: no compatibility layer or automatic conversion for standalone skills, global MCP records, legacy MCP SSE, or removed endpoints. Builders back up v0.13 if needed and redeploy complete agents in the v0.14 schema. Architecture: [`docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md`](docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md). MCP contract: [`docs/proposals/v0.14.0-mcp-runtime-contract.md`](docs/proposals/v0.14.0-mcp-runtime-contract.md). | Proposed |
 
 ---
 
@@ -130,6 +131,7 @@ The following fallback patterns exist and are tracked for removal. They produce 
 | Core runtime and framework refresh | deepagents 0.4.12, fastapi 0.128.6, starlette 0.52.1, langgraph 1.1.3, langchain 1.2.13, langsmith 0.6.9, openai 2.17.0, typer 0.23.0, rich 14.3.2, uvicorn 0.40.0, websockets 15.0.1 | deepagents 0.5.2, fastapi 0.135.3, starlette 1.0.0, langgraph 1.1.6, langchain 1.2.15, langsmith 0.7.30, openai 2.31.0, typer 0.24.1, rich 15.0.0, uvicorn 0.44.0, websockets 16.0 | `deepagents` composite backend now expects routed backends to implement `ls()` in addition to legacy `ls_info()`; test shim updated. Verified with full unit suite after lock refresh. | Completed |
 | v0.11.0 RC2 runtime/security refresh | deepagents 0.6.3, fastapi 0.135.3, starlette 1.0.0, langchain 1.3.1, langgraph 1.2.0, langsmith 0.8.5, openai 2.31.0, opentelemetry 1.41.0, cryptography 46.0.7 | deepagents 0.6.12, fastapi 0.138.1, starlette 1.3.1, langchain 1.3.11, langgraph 1.2.6, langsmith 0.9.3, openai 2.44.0, opentelemetry 1.43.0, cryptography 48.0.1 | No intentional API changes; conservative resolver refresh to close Dependabot alerts and keep the v0.11 runtime family current. | Completed |
 | deepagents → 0.6.2 + LangChain family upgrade | deepagents 0.5.2, langchain-core >=0.3.0,<1.3.0 | deepagents 0.6.2, langchain-core >=1.4.0, langchain >=1.3.0 | deepagents 0.6.2 requires langchain-core>=1.4.0; removes current `<1.3.0` cap. Async subagents, v3 event streaming, ContextHubBackend, interpreter middleware. Blocked by: none → unblocks all v0.10.0 features. | Planned |
+| v0.14.0 Deep Agents and MCP adapter alignment | deepagents 0.6.12, langchain-mcp-adapters 0.3.0 (resolved) | deepagents 0.7.1, langchain-mcp-adapters 0.3.1 | Deep Agents 0.7 removes backend compatibility shims, changes `write` to overwrite, exposes `delete` when supported, requires explicit StoreBackend namespaces, and tightens file-result contracts. Cognition backends require protocol adaptation before the lock update. | Proposed |
 
 ### Post-RFC Cleanup Train
 
@@ -400,6 +402,79 @@ All write endpoints respect `X-Cognition-Scope-{key}` headers for multi-tenant s
 
 ---
 
+## v0.14.0 Release Proposal
+
+- **Category:** Architectural change and feature
+- **Priority:** P1 production readiness
+- **Layers:** 1/2/3/4/6/7
+- **Status:** Proposed
+- **Estimated effort:** 20–30 engineering days across five gated waves
+- **Dependencies:** `pyproject.toml` parser fix; approved C4 and MCP contracts;
+  PostgreSQL-compatible persistence and S3-compatible object storage for
+  production; SQLite, in-memory, local-file, and local-sandbox backends for
+  local/dev; Deep Agents 0.7.x and LangChain MCP adapters 0.3.x
+
+**Problem:** Cognition's standalone skill registry and global scoped MCP registry
+do not match Deep Agents' skill-directory and per-agent tool inputs. Durable
+file-shaped state can also land on the Cognition host, which is unsafe for a
+multi-tenant production backend.
+
+**Proposed outcome:** Complete agent revisions own skill bundles and remote MCP
+connections. Cognition materializes skills into exact-scope S3-backed Deep Agents
+paths, loads each selected agent's MCP servers independently, and binds transport
+authentication to validated configuration and trusted, model-invisible runtime
+context. Direct standard MCP OAuth and optional builder workload token exchange
+are supported without making Cognition a general credential vault or
+authorization service. Production durable state is stored in the configured
+database or S3-compatible object store; local/dev retains supported host-backed
+options. The standalone/global MCP subsystem is removed.
+
+**Acceptance criteria:**
+
+- Deep Agents 0.7.x and MCP adapters 0.3.x are adopted with current backend
+  protocol tests and no legacy compatibility shims.
+- One exact-scope agent update atomically versions its complete skills and MCP
+  configuration; same-named agents in other scopes are unaffected.
+- Agent Skills support `SKILL.md`, `scripts/`, `references/`, and `assets/`, and
+  custom subagents use explicit upstream-aligned skill selection.
+- Only per-agent remote MCP servers contribute tools. Each declares `none`,
+  standard `mcp_oauth`, `workload_token_exchange`, or local/dev-only
+  `static_bearer`; production rejects static bearer, raw headers, and raw-secret
+  injection.
+- Authentication covers discovery and invocation. Required failures fail closed,
+  optional failures preserve healthy tools and emit structured degraded status,
+  canonical tool identities are unique, and readiness becomes stale rather than
+  claiming authorization truth.
+- All executable acceptance criteria in the MCP runtime contract pass, including
+  cross-scope authorization, trusted-context integrity, live revocation,
+  redaction, and low-cardinality metrics.
+- `/mcp-servers`, global MCP registry records, global runtime resolution, and the
+  custom MCP connection translation layer are removed.
+- Standalone skill mutation, legacy MCP SSE, removed registry entities, and old
+  agent configuration shapes have no compatibility handler or automatic
+  conversion.
+- Production startup rejects SQLite, in-memory persistence, local durable-file
+  routes, local execution, workspace watchers, and any other host-persistent
+  runtime configuration. No database or S3 failure falls back locally.
+- Local/dev supports SQLite, in-memory persistence, local file backends, and
+  local sandbox execution without an unsafe override.
+- Exact-scope isolation tests cover agent CRUD, skill and file objects, caches,
+  checkpoints, MCP, list operations, and deletion for arbitrary
+  builder-defined scope keys.
+- Builders must redeploy complete agents using the v0.14 schema; returning to
+  v0.13 requires restoring the prior application and operator-created backup.
+- Storage, MCP, skill loading, revision activation, breaking-surface rejection,
+  and startup policy emit scope-safe logs, metrics, events, and traces.
+
+Architecture and breaking-upgrade boundary:
+[`docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md`](docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md).
+MCP runtime and authentication contract:
+[`docs/proposals/v0.14.0-mcp-runtime-contract.md`](docs/proposals/v0.14.0-mcp-runtime-contract.md).
+
+No implementation or release branch is authorized by this draft.
+
+---
+
 ## v0.10.0 Release Tracking
 
 This section tracks the v0.10.0 long-running agents release. See `localdocs/v0.10.0-plan.md` for the full branching strategy, wave schedule, and K8s cluster context.
@@ -451,4 +526,4 @@ Per AGENTS.md requirements:
    - Features/Architectural: Before starting work
    - Security/Bug/Performance/Dependency: As part of PR
 
-**Last Updated**: 2026-05-25 (v0.10.0 final release validation complete — `0.10.0-rc1` app and sandbox image gate passed)
+**Last Updated**: 2026-08-03 (v0.14.0 MCP runtime and authentication contract incorporated)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 Cognition is a **headless agent orchestration backend**. Define your agent — get REST API, streaming, persistence, sandboxing, and observability automatically.
 
-The documentation is organized into two sections: **Concepts** explain how Cognition works internally; **Guides** are task-oriented and tell you how to do specific things.
+The documentation is organized into **Concepts**, task-oriented **Guides**,
+reference **Blueprints**, and forward-looking **Proposals**.
 
 ---
 
@@ -34,6 +35,15 @@ The documentation is organized into two sections: **Concepts** explain how Cogni
 | [Deployment](./guides/deployment.md) | Docker Compose stack, PostgreSQL, Alembic migrations, and production hardening |
 | [API Reference](./guides/api-reference.md) | Every REST endpoint, SSE event type, MCP servers, artifacts, A2A protocol, capabilities, and scoping headers |
 | [Release Checklist](./guides/release-checklist.md) | Standard release process for Cognition versions |
+
+---
+
+## Proposals
+
+| Document | Description |
+|---|---|
+| [v0.14.0 C4 Model: Agent Capabilities and Durable Storage](./proposals/v0.14.0-deep-agents-skills-mcp-storage.md) | C4 context, container, component, dynamic, and deployment views for agent-owned skills and MCP plus S3-compatible durable storage |
+| [v0.14.0 MCP Runtime and Authentication Contract](./proposals/v0.14.0-mcp-runtime-contract.md) | Per-server MCP discovery, authentication modes, trusted-context boundaries, failure semantics, and executable acceptance criteria |
 
 ---
 

--- a/docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md
+++ b/docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md
@@ -74,7 +74,7 @@ flowchart LR
     telemetry["External Software System<br/>Observability platform<br/><br/>Receives logs, metrics, and traces"]
 
     builder -->|"Deploys agents; starts sessions and runs"| cognition
-    cognition -->|"OAuth or workload token exchange when configured"| identity
+    cognition -->|"OAuth or builder-provided transport auth when configured"| identity
     cognition -->|"Discovers and invokes agent-selected tools"| mcp
     cognition -->|"Exports scope-safe telemetry"| telemetry
 ```
@@ -220,7 +220,7 @@ flowchart TB
 | Scoped Runtime Resolver | Resolves active revision once and pins it for the run |
 | Composite Backend Factory | Builds upstream-aligned `StateBackend`, S3, and sandbox routing |
 | MCP Tool Loader | Discovers each declared server independently and builds canonical tool identities |
-| MCP Transport Security | Enforces endpoint-bound `none`, MCP OAuth, workload exchange, or local-only bearer policy for discovery and invocation |
+| MCP Transport Security | Enforces endpoint-bound `none`, MCP OAuth, optional outbound auth provider, or local-only bearer policy for discovery and invocation |
 | S3CompatibleBackend | Implements the current Deep Agents file protocol over DB manifests and S3 bodies |
 
 ## Dynamic View 1: Update One Agent
@@ -316,7 +316,7 @@ flowchart LR
 
     subgraph integrations["Builder-operated integrations"]
         mcp_gateway["Remote MCP gateway/services"]
-        identity["Optional identity service<br/>OAuth / workload token exchange"]
+        identity["Optional identity service<br/>OAuth / builder transport auth"]
         observability["OTLP / logs / metrics platform"]
     end
 
@@ -414,17 +414,17 @@ isolation.
 - Canonical tool identity is `(server_alias, provider_tool_name)`. Visible name
   rendering is deterministic and not Agent-configurable; identity or rendering
   collisions fail before model execution.
-- Production authentication types are `none`, `mcp_oauth`, and
-  `workload_token_exchange`. `static_bearer` is a local/dev-only environment
+- Production authentication types are `none`, `mcp_oauth`, and optional
+  `outbound_auth_provider`. `static_bearer` is a local/dev-only environment
   adapter and is rejected in production.
 - Raw credentials, headers, API keys, custom authentication callbacks, URLs,
   audiences, scope, and server aliases never come from model-controlled values.
 - Authentication covers discovery and invocation through Cognition's mandatory
   MCP client factory. LangChain interceptors provide runtime access but are not
   an optional Agent middleware security boundary.
-- Workload exchange authenticates the Cognition service and exact target. A
-  builder-controlled endpoint remains authoritative for live Agent-level
-  authorization and upstream provider credentials.
+- An outbound auth provider may authenticate the Cognition service and exact
+  target. A builder-controlled endpoint remains authoritative for live
+  Agent-level authorization and upstream provider credentials.
 - MCP resources and prompts are deferred; this release aligns the documented
   Deep Agents MCP-tools surface.
 
@@ -477,7 +477,7 @@ authorization.
 | D6 | Default-deny trusted runtime-context projection | Keeps authority outside model-controlled arguments and projects only deployment-approved fields |
 | D7 | Deployment-profile storage policy | Production fails closed on host persistence; local/dev supports host-backed stores |
 | D8 | No v0.13 compatibility surface | Removes dual behavior and makes the new agent contract authoritative |
-| D9 | Standards-based MCP transport authentication | Direct MCP OAuth plus optional workload exchange avoids raw credentials and builder-installed code |
+| D9 | Standards-based MCP transport authentication | Direct MCP OAuth plus an optional builder-installed outbound auth provider avoids raw credentials and Cognition-owned identity-provider code |
 
 ## Existing-to-Target Mapping
 
@@ -527,7 +527,8 @@ The dependency and behavior snapshot is dated 2026-08-03:
 - [MCP Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
   defines the standard direct-provider OAuth path and target-resource binding.
 - [OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693.html)
-  defines the optional workload exchange used with builder-controlled endpoints.
+  defines the optional outbound auth provider used with builder-controlled
+  endpoints.
 - [Deep Agents backends](https://docs.langchain.com/oss/python/deepagents/backends)
   provide `StateBackend`, `StoreBackend`, `FilesystemBackend`,
   `CompositeBackend`, and the public backend protocol.
@@ -625,16 +626,17 @@ the observation timestamp so stale discovery cannot appear current.
 - Only per-agent MCP servers contribute tools. Required failure stops execution;
   optional failure produces visible degraded status.
 - Every MCP server declares exactly one supported authentication type: `none`,
-  `mcp_oauth`, `workload_token_exchange`, or local/dev-only `static_bearer`.
+  `mcp_oauth`, optional `outbound_auth_provider`, or local/dev-only
+  `static_bearer`.
   Production rejects static bearer configuration and all raw-header or raw-secret
   injection shapes.
 - Authentication is applied uniformly to independent per-server discovery and
   invocation. Canonical tool identity is `(server_alias, provider_tool_name)`,
   and duplicate identities fail configuration or discovery.
-- Direct MCP OAuth follows the server's standard authorization flow. Builder
-  workload exchange uses only an opaque deployment profile and trusted,
-  model-invisible runtime context; externally revoked authorization denies the
-  next invocation even during a pinned run.
+- Direct MCP OAuth follows the server's standard authorization flow. A builder
+  outbound auth provider is selected only by an opaque deployment profile and
+  receives trusted, model-invisible runtime context; externally revoked
+  authorization denies the next invocation even during a pinned run.
 - Optional server failure preserves tools from healthy servers. Required server
   failure stops before model execution with a typed, redacted error. Readiness
   becomes stale or unknown without being represented as authorization truth.

--- a/docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md
+++ b/docs/proposals/v0.14.0-deep-agents-skills-mcp-storage.md
@@ -1,0 +1,682 @@
+# v0.14.0 C4 Model: Agent Capabilities and Durable Storage
+
+- **Status:** Revised draft proposal
+- **Target:** v0.14.0
+- **Date:** 2026-08-03
+- **Audience:** Cognition maintainers, platform architects, security reviewers,
+  and operators
+- **Category:** Architectural change and feature
+- **Layers:** 1 (Foundation), 2 (Persistence), 3 (Execution), 4 (Agent Runtime),
+  6 (API & Streaming), and 7 (Observability)
+
+## Purpose
+
+This document uses the C4 model to describe the proposed v0.14.0 architecture:
+
+1. Adopt Deep Agents 0.7.x and its current backend protocol.
+2. Make Agent Skills bundles part of each agent's configuration.
+3. Make remote MCP connections part of each agent's configuration and remove
+   Cognition's global MCP-server subsystem.
+4. Store durable records in the configured database and durable file bodies in
+   S3-compatible storage. A production Cognition process must not persist runtime
+   state on its host filesystem.
+
+!!! important "One agent, versioned configuration"
+
+    One logical agent exists per exact `effective_scope`. `PUT` and `PATCH`
+    continue to update that agent. Each successful update creates an internal,
+    immutable configuration revision that is activated atomically; it does not
+    create another agent. A run pins the active revision at startup, and the next
+    run uses the latest active revision.
+
+!!! warning "Intentional breaking change"
+
+    v0.14.0 does not provide dual-read, dual-write, compatibility endpoints,
+    legacy MCP transport adapters, or automatic conversion of existing skill and
+    MCP records. Builders must redeploy agents using the new configuration shape.
+
+This is a proposal only. It does not authorize implementation, schema changes,
+or dependency updates.
+
+The detailed MCP schema, transport-security profiles, readiness states, and
+executable security tests are defined in the
+[v0.14.0 MCP Runtime and Authentication Contract](./v0.14.0-mcp-runtime-contract.md).
+
+## C4 Scope and Notation
+
+The document provides the five views relevant to this change:
+
+| View | Question answered |
+|---|---|
+| Level 1: System context | Who uses Cognition, and which external systems does it use? |
+| Level 2: Containers | Which deployable applications and data stores make up the solution? |
+| Level 3: Components | Which major components inside the Cognition service implement it? |
+| Dynamic | How do configuration activation and run startup behave over time? |
+| Deployment | Where does each container run, and how is host persistence prevented? |
+
+The diagrams use standard Mermaid shapes for compatibility with the existing
+MkDocs renderer. C4 defines the abstraction and relationships; it does not
+require a particular drawing notation. See the official C4 descriptions of
+[system context](https://c4model.com/diagrams/system-context),
+[container](https://c4model.com/diagrams/container),
+[component](https://c4model.com/diagrams/component),
+[dynamic](https://c4model.com/diagrams/dynamic), and
+[deployment](https://c4model.com/diagrams/deployment) diagrams.
+
+## Level 1: System Context
+
+```mermaid
+flowchart LR
+    builder["Person / External System<br/>Builder control plane<br/><br/>Defines agents and supplies authorized scope"]
+    cognition["Software System<br/>Cognition v0.14<br/><br/>Runs scoped AI agents with API, streaming, persistence, sandboxing, and observability"]
+    identity["External Software System<br/>Identity service<br/><br/>Optional OAuth and workload-token authority"]
+    mcp["External Software System<br/>Remote MCP service or builder endpoint<br/><br/>Provides tools selected by an agent definition"]
+    telemetry["External Software System<br/>Observability platform<br/><br/>Receives logs, metrics, and traces"]
+
+    builder -->|"Deploys agents; starts sessions and runs"| cognition
+    cognition -->|"OAuth or workload token exchange when configured"| identity
+    cognition -->|"Discovers and invokes agent-selected tools"| mcp
+    cognition -->|"Exports scope-safe telemetry"| telemetry
+```
+
+### System responsibilities
+
+Cognition is responsible for:
+
+- validating and serving complete agent configuration;
+- carrying builder-authorized `effective_scope: dict[str, str]` unchanged;
+- translating skill bundles into Deep Agents skill directories;
+- loading only an agent's declared MCP tools;
+- enforcing explicit MCP authentication and endpoint policy outside model
+  control;
+- routing production durable data to database or object storage;
+- isolating execution in a non-host sandbox; and
+- reporting configuration, storage, MCP, and runtime behavior explicitly.
+
+Cognition is not responsible for builder IAM, tenant authorization, roles,
+bindings, billing, entitlement logic, upstream provider credentials, or a
+general credential vault. The builder establishes authority before calling
+Cognition. Cognition may act as a standard MCP OAuth client or authenticate its
+workload to a builder-controlled endpoint.
+
+## Level 2: Container View
+
+This logical view shows the production container set. The deployment views later
+in the document define the supported local/dev substitutions.
+
+```mermaid
+flowchart LR
+    builder["External System<br/>Builder control plane"]
+    identity["External System<br/>OAuth / workload identity service"]
+    mcp["External System<br/>Remote MCP gateway/services"]
+    obs["External System<br/>OTLP / metrics / logs platform"]
+
+    subgraph cognition_boundary["Cognition v0.14 system boundary"]
+        service["Application Container<br/>Cognition service<br/><br/>FastAPI, streaming, Deep Agents runtime"]
+        database[("Data Store<br/>PostgreSQL-compatible database<br/><br/>Definitions, revisions, manifests, sessions, runs, checkpoints")]
+        objects[("Data Store<br/>S3-compatible object storage<br/><br/>Skills, artifacts, files, memories, contracts, evals, policies")]
+        sandbox["Execution Container Pool<br/>Isolated sandboxes<br/><br/>Ephemeral per-session workspaces"]
+    end
+
+    builder -->|"HTTPS + exact trusted scope"| service
+    service -->|"Definitions, state, manifests"| database
+    service -->|"Durable file bodies"| objects
+    service -->|"Commands and file transfer"| sandbox
+    service -->|"Optional OAuth / token exchange"| identity
+    service -->|"Streamable HTTP MCP"| mcp
+    service -->|"Logs, metrics, traces"| obs
+```
+
+### Container catalog
+
+| Container | Responsibility | Scaling and tenancy |
+|---|---|---|
+| Cognition service | API, streaming, configuration activation, runtime assembly, policy enforcement | Stateless replicas; exact scope on every request and run |
+| Database | Transactional metadata and LangGraph durability | Canonical scope stored with every runtime-owned record |
+| S3-compatible store | Immutable durable file bodies | Opaque scope-derived key prefixes; manifest remains the authority |
+| Sandbox pool | Code execution and temporary workspace | Isolated per session; never the durable source of record |
+
+### Production data placement
+
+| Data class | Production location |
+|---|---|
+| Agent identity, active revision, configuration manifests | Database |
+| Sessions, runs, events, messages, checkpoints | Database |
+| Encrypted MCP OAuth token state | Database |
+| Skill, artifact, file, memory, contract, eval, and policy bodies | S3-compatible store |
+| Deep Agents transient state | DB-backed checkpointer through `StateBackend` |
+| Execution workspace | Ephemeral isolated sandbox |
+| Telemetry | External stdout, OTLP, or metrics exporter |
+
+## Level 3: Cognition Service Components
+
+```mermaid
+flowchart TB
+    client["External builder or runtime client"]
+    mcp_ext["Remote MCP services"]
+    identity_ext["Identity service"]
+    db[("Database")]
+    s3[("S3-compatible store")]
+    sandbox_ext["Sandbox pool"]
+    obs_ext["Observability platform"]
+
+    subgraph service["Cognition service container"]
+        api["Component · Layer 6<br/>Agent and Run API<br/><br/>HTTP, validation, streaming"]
+        scope["Component · Layer 1<br/>Trusted Scope Context<br/><br/>Canonical scope and correlation IDs"]
+        revision["Component · Layer 4<br/>Agent Revision Coordinator<br/><br/>Validates, stages, and activates config"]
+        skill["Component · Layer 4<br/>Skill Bundle Adapter<br/><br/>Agent Skills validation and paths"]
+        resolver["Component · Layer 4<br/>Scoped Runtime Resolver<br/><br/>Pins active agent revision"]
+        backend_factory["Component · Layer 4<br/>Composite Backend Factory<br/><br/>State, S3, and sandbox routes"]
+        mcp_loader["Component · Layer 4<br/>MCP Tool Loader<br/><br/>Independent discovery and canonical tools"]
+        mcp_security["Component · Layer 4<br/>MCP Transport Security<br/><br/>OAuth, workload identity, endpoint policy"]
+        runtime["Component · Layer 4<br/>Deep Agents Runtime<br/><br/>Model, tools, skills, middleware"]
+        execution["Component · Layer 3<br/>Sandbox Adapter<br/><br/>Isolated commands and transfers"]
+        repository["Component · Layer 2<br/>Config and Manifest Repositories<br/><br/>Exact-scope persistence"]
+        object_backend["Component · Layer 2<br/>S3CompatibleBackend<br/><br/>Deep Agents BackendProtocol"]
+        telemetry["Component · Layer 7<br/>Telemetry Adapters<br/><br/>Events, logs, metrics, traces"]
+    end
+
+    client --> api
+    api --> scope
+    api --> revision
+    api --> resolver
+    revision --> skill
+    revision --> repository
+    skill --> object_backend
+    resolver --> repository
+    resolver --> backend_factory
+    resolver --> mcp_loader
+    mcp_loader --> mcp_security
+    resolver --> runtime
+    backend_factory --> object_backend
+    backend_factory --> execution
+    runtime --> backend_factory
+    runtime --> mcp_loader
+    repository --> db
+    object_backend --> s3
+    execution --> sandbox_ext
+    mcp_security --> mcp_ext
+    mcp_security --> identity_ext
+    mcp_security -.-> telemetry
+    scope -.->|"Trusted runtime context"| revision
+    scope -.->|"Trusted runtime context"| resolver
+    scope -.->|"Model-invisible runtime context"| mcp_security
+    api -.-> telemetry
+    revision -.-> telemetry
+    resolver -.-> telemetry
+    object_backend -.-> telemetry
+    mcp_loader -.-> telemetry
+    telemetry --> obs_ext
+```
+
+### Component responsibilities
+
+| Component | Key contract |
+|---|---|
+| Agent and Run API | `PUT`/`PATCH` mutate one logical agent; run creation supplies exact scope |
+| Trusted Scope Context | Runtime authority comes from trusted ingress, never model arguments |
+| Agent Revision Coordinator | Publishes either the old complete revision or the new complete revision |
+| Skill Bundle Adapter | Validates `SKILL.md`, regular files, paths, quotas, and subagent selection |
+| Scoped Runtime Resolver | Resolves active revision once and pins it for the run |
+| Composite Backend Factory | Builds upstream-aligned `StateBackend`, S3, and sandbox routing |
+| MCP Tool Loader | Discovers each declared server independently and builds canonical tool identities |
+| MCP Transport Security | Enforces endpoint-bound `none`, MCP OAuth, workload exchange, or local-only bearer policy for discovery and invocation |
+| S3CompatibleBackend | Implements the current Deep Agents file protocol over DB manifests and S3 bodies |
+
+## Dynamic View 1: Update One Agent
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Builder
+    participant A as Agent API
+    participant R as Revision Coordinator
+    participant S as Skill Adapter
+    participant O as S3 Store
+    participant D as Database
+
+    B->>A: PUT /agents/{name} + exact scope + complete config
+    A->>R: Update logical agent
+    R->>S: Validate skill bundles and MCP declarations
+    S-->>R: Canonical manifest
+    R->>O: Upload immutable file bodies
+    O-->>R: Object keys + checksums
+    R->>D: Transaction: insert inactive revision and manifests
+    R->>D: Atomically set agent.active_revision
+    D-->>R: Activated revision
+    R-->>A: Same agent identity + new config revision
+    A-->>B: 200 with active revision
+
+    Note over R,D: A failure before activation leaves the previous revision active.
+    Note over R,O: Unreferenced uploads are observable and lifecycle-cleaned.
+```
+
+The public operation updates one agent. Immutable revisions are an internal
+run-consistency, audit, and cache mechanism—not separate Agents or a public
+historic-version selector. A builder rollback re-submits the desired complete
+configuration and creates a new active snapshot.
+
+## Dynamic View 2: Start a Run
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant A as Run API
+    participant R as Runtime Resolver
+    participant D as Database
+    participant O as S3 Backend
+    participant M as MCP Tool Loader
+    participant I as Transport Security
+    participant X as Remote MCP
+    participant G as Deep Agents Runtime
+
+    C->>A: Start run + session + exact scope
+    A->>R: Resolve scoped agent
+    R->>D: Read logical agent and active revision by exact scope
+    D-->>R: Agent config revision
+    R->>O: Resolve skill paths and manifests
+    R->>M: Build declared MCP tool set with trusted runtime context
+    M->>I: Resolve each server's declared auth type
+    I->>X: Per-server discovery over authenticated streamable HTTP
+    X-->>M: Tools or explicit failure
+    R->>G: Model + revisioned skills + tools + CompositeBackend
+    G-->>A: Stream events pinned to revision
+    A-->>C: SSE response
+
+    Note over R,G: The run never changes revision mid-execution.
+    Note over A,R: A later run in the same session resolves the latest active revision.
+```
+
+Required MCP failures stop before model execution. Optional failures emit a
+structured degraded-capability event and status. Authentication applies to both
+discovery and later invocation; readiness is a freshness-qualified observation,
+not authorization truth.
+
+## Deployment Views
+
+### Production: no host persistence
+
+```mermaid
+flowchart LR
+    operator["Operator / deployment platform"]
+
+    subgraph compute["Stateless compute cluster"]
+        service["Cognition service replicas<br/>Read-only image<br/>No durable volume<br/>No local sandbox"]
+    end
+
+    subgraph execution["Isolated execution infrastructure"]
+        sandboxes["Docker, Kubernetes, or Lambda MicroVM sandboxes<br/>Ephemeral session workspaces"]
+    end
+
+    subgraph data["Durable managed infrastructure"]
+        postgres[("PostgreSQL-compatible database")]
+        object_store[("S3-compatible object storage")]
+    end
+
+    subgraph integrations["Builder-operated integrations"]
+        mcp_gateway["Remote MCP gateway/services"]
+        identity["Optional identity service<br/>OAuth / workload token exchange"]
+        observability["OTLP / logs / metrics platform"]
+    end
+
+    operator --> service
+    service --> postgres
+    service --> object_store
+    service --> sandboxes
+    service --> mcp_gateway
+    service --> identity
+    service --> observability
+```
+
+Production startup must reject SQLite, in-memory persistence, local durable-file
+routes, local execution, workspace source watchers, runtime-created `.cognition`
+directories, and file-based logs or checkpoints. Failure of the database or S3
+store must never select a local or memory fallback.
+
+### Local and development: host-backed storage is supported
+
+```mermaid
+flowchart LR
+    developer["Developer"]
+
+    subgraph workstation["Local workstation or development container"]
+        service["Cognition service<br/>Development profile"]
+        local_db[("SQLite or in-memory persistence")]
+        local_files[("Local filesystem or S3-compatible file backend")]
+        local_sandbox["Local or Docker sandbox"]
+    end
+
+    developer --> service
+    service --> local_db
+    service --> local_files
+    service --> local_sandbox
+```
+
+SQLite, in-memory persistence, local file backends, and local sandbox execution
+are supported for local and development setups. They do not require an "unsafe"
+override. The selected deployment profile makes the boundary explicit:
+development permits host-backed resources; production rejects them.
+
+## Agent Configuration Mapping
+
+The external shape remains one complete agent definition:
+
+```yaml
+name: support-agent
+skills:
+  support-policy:
+    files:
+      SKILL.md:
+        text: |
+          ---
+          name: support-policy
+          description: Apply the support escalation policy.
+          ---
+          Read references/escalation.md before escalating.
+      references/escalation.md:
+        text: "# Escalation policy"
+mcp:
+  servers:
+    records:
+      transport: streamable_http
+      url: https://mcp.example.internal/api
+      required: true
+      auth:
+        type: mcp_oauth
+```
+
+### Skills mapping
+
+- `SKILL.md` is required and follows the Agent Skills frontmatter contract.
+- Bundles may contain regular files under `scripts/`, `references/`, and
+  `assets/`; symlinks, special files, traversal, and normalized duplicates are
+  rejected.
+- Scripts are builder-authored code and execute only in the selected session
+  sandbox, never in the Cognition service process.
+- Cognition materializes an active revision under a private virtual directory and
+  passes that directory through `create_deep_agent(skills=[...])`.
+- The general-purpose subagent inherits parent skills. A custom subagent selects
+  bundle keys and cannot supply an arbitrary object-store path.
+- Skill metadata and compiled-runtime caches include the configuration revision.
+
+Shared skill catalogs and arbitrary host paths are deferred. The v0.14 contract
+is deliberately agent-owned to preserve atomic deployment and exact-scope
+isolation.
+
+### MCP mapping
+
+- Only servers declared by the active agent revision contribute tools.
+- v0.14 supports remote `streamable_http` only. Legacy MCP SSE, local `stdio`,
+  websocket, and stateful sessions are not accepted.
+- Cognition uses the upstream `MultiServerMCPClient` and discovers each server
+  independently so an optional failure cannot discard healthy tools.
+- Canonical tool identity is `(server_alias, provider_tool_name)`. Visible name
+  rendering is deterministic and not Agent-configurable; identity or rendering
+  collisions fail before model execution.
+- Production authentication types are `none`, `mcp_oauth`, and
+  `workload_token_exchange`. `static_bearer` is a local/dev-only environment
+  adapter and is rejected in production.
+- Raw credentials, headers, API keys, custom authentication callbacks, URLs,
+  audiences, scope, and server aliases never come from model-controlled values.
+- Authentication covers discovery and invocation through Cognition's mandatory
+  MCP client factory. LangChain interceptors provide runtime access but are not
+  an optional Agent middleware security boundary.
+- Workload exchange authenticates the Cognition service and exact target. A
+  builder-controlled endpoint remains authoritative for live Agent-level
+  authorization and upstream provider credentials.
+- MCP resources and prompts are deferred; this release aligns the documented
+  Deep Agents MCP-tools surface.
+
+The complete schema, deployment profiles, context-projection rules, readiness
+model, and acceptance tests are in the
+[MCP Runtime and Authentication Contract](./v0.14.0-mcp-runtime-contract.md).
+
+## Deep Agents Backend Composition
+
+```python
+CompositeBackend(
+    default=StateBackend(runtime),
+    routes={
+        "/workspace/": sandbox_backend,
+        "/skills/": scoped_s3_backend,
+        "/artifacts/": scoped_s3_backend,
+        "/files/": scoped_s3_backend,
+        "/memories/": scoped_s3_backend,
+        "/contracts/": scoped_s3_backend,
+        "/evals/": scoped_s3_backend,
+        "/policies/": scoped_s3_backend,
+    },
+)
+```
+
+The S3 backend uses database manifests and immutable object bodies. A write
+uploads a body, verifies its checksum, and atomically advances the manifest.
+`ls`, `glob`, and metadata filtering use the database index; bounded reads and
+grep obtain eligible object bodies. `write` follows the Deep Agents 0.7 overwrite
+contract, and `delete` is enabled only for routes whose policy permits it.
+
+In local/dev, the routed S3 backend may be replaced by a local filesystem or
+in-memory backend. The virtual paths, scope behavior, and Deep Agents protocol
+remain the same across deployment profiles.
+
+Every manifest stores canonical `effective_scope`, an opaque scope digest,
+normalized path, media type, size, checksum, version, agent identity, resource
+class, object key, and audit metadata. Knowledge of an object key is never
+authorization.
+
+## Architectural Decisions
+
+| ID | Decision | Rationale |
+|---|---|---|
+| D1 | One scoped logical agent with immutable internal runtime snapshots | Atomic activation, run consistency, audit, and cache identity without a public historic-version selector |
+| D2 | Agent-owned skill bundles | Matches Agent Skills and makes deployment complete and transactional |
+| D3 | Per-agent remote MCP | Prevents global capability leakage and matches Deep Agents tool inputs |
+| D4 | DB manifests plus immutable S3 bodies | Transactional metadata, scalable bodies, and atomic publication |
+| D5 | `StateBackend` default with explicit S3 and sandbox routes | Aligns with Deep Agents and separates transient, durable, and execution data |
+| D6 | Default-deny trusted runtime-context projection | Keeps authority outside model-controlled arguments and projects only deployment-approved fields |
+| D7 | Deployment-profile storage policy | Production fails closed on host persistence; local/dev supports host-backed stores |
+| D8 | No v0.13 compatibility surface | Removes dual behavior and makes the new agent contract authoritative |
+| D9 | Standards-based MCP transport authentication | Direct MCP OAuth plus optional workload exchange avoids raw credentials and builder-installed code |
+
+## Existing-to-Target Mapping
+
+| Existing Cognition surface | v0.14 target |
+|---|---|
+| `AgentDefinition.skills: list[str]` registry attachments | Complete skill bundles in agent configuration |
+| Single-string registered skill content | `SKILL.md` directory with supporting files in S3 |
+| Standalone `/skills` as authoritative runtime source | Removed; builders redeploy skills inside agent configuration |
+| Global `/mcp-servers` CRUD and ConfigRegistry entity | Removed |
+| Runtime-wide `resolve_mcp_configs()` | Active agent revision's MCP declarations |
+| Custom MCP connection models and translation | Upstream client plus mandatory transport-security and per-server discovery adapters |
+| Scope injected into MCP tool arguments | Default-deny deployment-approved context from `request.runtime`; never model arguments |
+| Artifact bodies in database | Manifest in database, body in S3-compatible storage |
+| Host workspace watchers and `.cognition` runtime state | Supported in local/dev; explicitly rejected in production |
+
+No automatic conversion maps global MCP or standalone skill records into agents.
+Builders explicitly redeploy the desired capabilities in each v0.14 agent.
+
+## Multi-Tenancy Invariants
+
+1. Agent lookup and mutation use exact trusted scope.
+2. Same-named agents in different scopes have distinct revisions, manifests,
+   objects, MCP sets, checkpoints, caches, and sandboxes.
+3. Builder-defined scope keys are preserved; no fixed user/org/project vocabulary
+   is assumed.
+4. Session and run scope is immutable. Each run also pins one agent revision.
+5. Exact scope is checked before manifest access or object-store operations.
+6. Scope is never model-supplied authority.
+7. Read, list, update, delete, clone, export, cache, and administrative paths receive
+   the same cross-scope tests as runtime reads.
+8. Quotas cover skill bytes, object bytes, file count, MCP servers, discovered
+   tools, and concurrent discovery attempts per exact scope and agent.
+
+## Research Baseline
+
+The dependency and behavior snapshot is dated 2026-08-03:
+
+- [`deepagents` 0.7.1](https://pypi.org/project/deepagents/0.7.1/) is the latest
+  published release; Cognition currently resolves 0.6.12.
+- [Deep Agents skills](https://docs.langchain.com/oss/python/deepagents/skills)
+  use Agent Skills directories and backend-relative paths.
+- [Deep Agents MCP tools](https://docs.langchain.com/oss/python/deepagents/tools#mcp-tools)
+  use `MultiServerMCPClient.get_tools()` and pass the result as agent tools.
+- [LangChain MCP adapters](https://docs.langchain.com/oss/python/langchain/mcp)
+  support streamable HTTP, standard authentication, per-server discovery, and
+  runtime-aware tool interceptors.
+- [MCP Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+  defines the standard direct-provider OAuth path and target-resource binding.
+- [OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693.html)
+  defines the optional workload exchange used with builder-controlled endpoints.
+- [Deep Agents backends](https://docs.langchain.com/oss/python/deepagents/backends)
+  provide `StateBackend`, `StoreBackend`, `FilesystemBackend`,
+  `CompositeBackend`, and the public backend protocol.
+- The [Deep Agents 0.7 changelog](https://docs.langchain.com/oss/python/releases/changelog#deepagents-v0-7-0)
+  removes compatibility shims, changes write semantics, exposes delete when
+  supported, and tightens file-result contracts.
+- [`langchain-mcp-adapters` 0.3.1](https://pypi.org/project/langchain-mcp-adapters/0.3.1/)
+  is the current adapter release; Cognition currently resolves 0.3.0.
+
+The target constraints should be compatible-minor ranges:
+
+```toml
+deepagents = "~=0.7.1"
+langchain-mcp-adapters = "~=0.3.1"
+```
+
+Cognition's skills and artifact backends use legacy compatibility methods, so
+they must be adapted to the 0.7 protocol before the lock update. The repository
+also has a pre-existing duplicate `docs` optional-dependency key in
+`pyproject.toml`; fixing that parser error is Phase 0 but outside this proposal.
+
+## Delivery and Upgrade Boundary
+
+| Phase | Outcome |
+|---|---|
+| Phase 0 | Fix project parsing, approve the C4 and MCP contracts, and finalize OpenAPI fields and deployment profiles |
+| Wave 1 | Upgrade Deep Agents and MCP adapters; implement current backend contracts without shims |
+| Wave 2 | Add per-agent MCP, explicit auth types, per-server discovery, readiness, canonical tool identity, and remove global MCP logic |
+| Wave 3 | Add manifests, S3 backend, durable routes, storage health, and zero-host startup checks |
+| Wave 4 | Add agent-owned skill bundles, subagent selection, and metadata invalidation |
+| Wave 5 | Run isolation, deployment-profile, breaking-surface, and release-image gates |
+
+v0.14 has no runtime or data compatibility contract with the removed skill and
+MCP configuration surfaces:
+
+1. `/skills` mutation, `/mcp-servers`, global MCP resolution, legacy MCP SSE, and
+   their registry entities are removed without adapters or dual reads.
+2. Existing skill and MCP records are not loaded or converted automatically.
+3. Builders deploy complete agent definitions using the new v0.14 schema.
+4. The database schema change may remove or archive obsolete records, but the
+   v0.14 runtime never consumes them.
+5. Operators that may need to return to v0.13 must take a database and object
+   store backup before upgrading.
+
+Internal snapshots provide run consistency but are not a public rollback or
+historic-selection API. A builder restores an earlier definition by submitting
+it again, which creates a new active snapshot. A release rollback to v0.13
+requires restoring the v0.13 application and its backup; v0.14 does not emulate
+the old data model.
+
+## Observability
+
+Logs, metrics, events, and traces must cover:
+
+- agent revision validation, activation, and cache invalidation;
+- skill upload, manifest commit, load, and metadata refresh;
+- object-store latency, bytes, checksum failures, health, and orphan cleanup;
+- MCP discovery, readiness, tool count, required failure, and optional
+  degradation;
+- rejection of removed configuration fields and endpoints; and
+- startup rejection of host-backed production configuration.
+
+Logs and traces may contain bounded correlation identifiers, configuration
+revision, resource class, server alias, authentication type, and opaque scope
+digest. Metrics use low-cardinality dimensions only; session, run, agent,
+revision, server, and scope identifiers must never become metric labels. Signals
+must not contain raw scope values, file or skill bodies, OAuth payloads, MCP
+headers, credentials, tool arguments, or tool results. Readiness signals include
+the observation timestamp so stale discovery cannot appear current.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Deep Agents 0.7 breaks existing adapters | Complete Wave 1 backend contract tests before configuration work |
+| An agent update exposes partial S3 state | Upload immutable bodies, then atomically activate the database manifest |
+| A cached graph retains old capabilities | Include the active configuration revision in cache identity |
+| Global MCP removal changes tool availability | Document the break and require explicit per-agent redeployment |
+| Model content changes endpoint, identity, or authorization | Bind transport to validated agent configuration and trusted runtime context; never accept transport controls from tool arguments |
+| Shared workload identity is mistaken for Agent isolation | Treat it as workload authentication only; require live builder authorization and separate workload identities where cryptographic Agent or tenant isolation is required |
+| Revocation is delayed by cached workload tokens | Use short expiry, prohibit refresh-token persistence for this mode, and authorize every invocation at the builder endpoint |
+| OAuth discovery expands the egress or redirect surface | Pin the configured MCP origin, validate redirects and metadata, and apply deployment DNS and egress policy |
+| Object keys expose tenant vocabulary | Use opaque keyed scope digests and authorize through manifests |
+| Database or S3 outage causes local fallback | Fail explicitly; production has no fallback backend |
+| Broad delete removes durable data | Exact-scope checks, route permissions, immutable bodies, delayed cleanup |
+
+## Acceptance Criteria
+
+- One exact-scope logical agent is updated atomically; revisions are internal
+  configuration snapshots, not additional agents.
+- A run pins one revision, while the next run in an existing session uses the
+  latest active revision.
+- Deep Agents discovers `SKILL.md` and supporting files from the routed backend;
+  custom-subagent selection matches upstream behavior.
+- Only per-agent MCP servers contribute tools. Required failure stops execution;
+  optional failure produces visible degraded status.
+- Every MCP server declares exactly one supported authentication type: `none`,
+  `mcp_oauth`, `workload_token_exchange`, or local/dev-only `static_bearer`.
+  Production rejects static bearer configuration and all raw-header or raw-secret
+  injection shapes.
+- Authentication is applied uniformly to independent per-server discovery and
+  invocation. Canonical tool identity is `(server_alias, provider_tool_name)`,
+  and duplicate identities fail configuration or discovery.
+- Direct MCP OAuth follows the server's standard authorization flow. Builder
+  workload exchange uses only an opaque deployment profile and trusted,
+  model-invisible runtime context; externally revoked authorization denies the
+  next invocation even during a pinned run.
+- Optional server failure preserves tools from healthy servers. Required server
+  failure stops before model execution with a typed, redacted error. Readiness
+  becomes stale or unknown without being represented as authorization truth.
+- All executable criteria in the
+  [MCP Runtime and Authentication Contract](./v0.14.0-mcp-runtime-contract.md)
+  are release-blocking.
+- Scope and correlation metadata comes from trusted runtime context and is absent
+  from model-visible tool schemas and arguments.
+- The global MCP routes, registry entity, runtime resolver, and custom connection
+  translation layer are removed.
+- Production writes no durable runtime state to the Cognition host and refuses to
+  start with a non-compliant persistence, file, watcher, logging, or sandbox
+  configuration.
+- Local and development profiles support SQLite, in-memory persistence, local
+  file backends, and local sandbox execution without an unsafe override.
+- Production database and S3 failures are explicit and never fall back locally.
+- Cross-scope tests cover agent CRUD, revisions, skills, files, caches,
+  checkpoints, MCP, listing, and deletion for arbitrary scope keys.
+- Removed APIs, registry records, legacy SSE, and global resolution have no
+  compatibility handler, dual-read path, or automatic conversion.
+- API, runtime, deployment, upgrade, security, and capability documentation is
+  updated, and the category-specific Definition of Done in `AGENTS.md` is met.
+
+## Non-Goals
+
+- Multiple agent records for configuration history
+- Backward compatibility or automatic conversion for v0.13 skill and MCP records
+- Cognition-managed IAM, authorization, roles, billing, or entitlements
+- A general credential vault, arbitrary secret-reference API, raw credential or
+  header injection, or provider-specific identity implementation
+- Experimental OAuth delegation or a claim that one shared workload identity
+  provides cryptographic Agent-level isolation
+- Shared skill catalogs or arbitrary production host paths
+- MCP resources, prompts, local stdio, or stateful sessions
+- Durable execution workspaces on the Cognition host
+- Provider-specific storage abstractions beyond the S3-compatible contract
+
+## Decision Requested
+
+Approve this C4 model and its
+[MCP Runtime and Authentication Contract](./v0.14.0-mcp-runtime-contract.md) as
+the v0.14.0 architecture baseline. After approval, the next planning artifact
+should define the final OpenAPI schemas, breaking-change notice, implementation
+issues, ownership, and release branch schedule. No implementation should begin
+before approval.

--- a/docs/proposals/v0.14.0-mcp-runtime-contract.md
+++ b/docs/proposals/v0.14.0-mcp-runtime-contract.md
@@ -16,7 +16,7 @@ upstream LangChain MCP client and exposes four explicit authentication types:
 |---|---|---|
 | `none` | Public or infrastructure-protected endpoint | None or external infrastructure |
 | `mcp_oauth` | Direct protected MCP endpoint | Standard MCP OAuth flow, scoped token store |
-| `workload_token_exchange` | Builder-controlled production endpoint | Workload identity and OAuth token exchange |
+| `outbound_auth_provider` | Builder-controlled protected endpoint | Builder-installed transport auth provider |
 | `static_bearer` | Local development only | Local operator environment |
 
 The first three are production-capable. `static_bearer` is rejected by the
@@ -52,7 +52,7 @@ The following common fields are supported:
 | `url` | Builder-authored HTTPS endpoint; canonicalized before policy matching |
 | `required` | Required failure stops execution; optional failure degrades only that server |
 | `auth.type` | One of the four explicit authentication types |
-| `auth.profile` | Opaque deployment-profile name, required only for `workload_token_exchange` |
+| `auth.profile` | Opaque authentication-profile name, required only for `outbound_auth_provider` |
 | `auth.env` | Environment-variable name, required only for local/dev `static_bearer` |
 
 Tool prefixes and raw connection headers are not configurable. Cognition owns
@@ -98,59 +98,38 @@ If the required OAuth capability, encrypted token store, or authorization state
 is unavailable, the server is not ready. Cognition does not downgrade to
 `none`.
 
-### `workload_token_exchange`
+### `outbound_auth_provider`
 
 This optional type supports builders that put a policy enforcement point,
-gateway, service mesh, or connection service in front of remote MCP providers:
+gateway, service mesh, connection service, or token exchange in front of
+remote MCP providers:
 
 ```yaml
 auth:
-  type: workload_token_exchange
+  type: outbound_auth_provider
   profile: production_egress
 ```
 
-The opaque profile resolves only from trusted deployment configuration:
+The profile is a selector, not a credential. Cognition looks up a builder-
+installed `OutboundAuthProvider`; it does not resolve a secret, know an identity
+provider, or persist the provider's configuration. The provider receives only
+the immutable Cognition Agent identity, pinned runtime snapshot, server alias,
+trusted runtime context, and request deadline. It returns `httpx.Auth` or
+bounded allowlisted headers, token expiry, and a redacted failure category.
 
-```yaml
-mcp_auth_profiles:
-  production_egress:
-    type: oauth_token_exchange
-    token_endpoint: https://identity.internal/token
-    subject_token_source: workload_identity
-    target:
-      parameter: audience
-      value: canonical_server_uri
-    max_access_token_ttl_seconds: 300
-    allow_refresh_token: false
-    trusted_context:
-      fields:
-        - agent_id
-        - runtime_snapshot
-        - server_alias
-        - effective_scope
-```
+The provider cannot return data to model context, API responses, persisted
+configuration, logs, traces, or readiness projections. It may keep an
+expiry-bounded in-memory token cache. Cognition validates the provider's header
+allowlist and owns no client, realm, role, claim, token-exchange, or credential
+logic.
 
-The profile is not a credential and cannot supply arbitrary headers. Activation
-must prove that the profile, canonical server URI, target parameter, and exact
-target value form an allowed deployment binding.
-
-The generic contract supports RFC 8693 `resource` or `audience` target
-parameters. `resource` is preferred where supported. An `audience` profile must
-request exactly one audience and bind it to the canonical endpoint. Cognition
-does not contain identity-provider-specific client, realm, role, or claim logic.
-
-The exchanged token authenticates the Cognition workload and restricts its
-destination. It does not manufacture cryptographic identity for a logical
-Agent. Agent-level authorization remains live at the builder-controlled
-endpoint, using model-invisible runtime context supplied by Cognition over the
-authenticated channel.
-
-An expiry-bounded in-memory cache may reuse a workload token for the same
-workload identity, profile, and exact target. Such a token may be shared by
-multiple logical Agents because it does not grant Agent-level authority. The
-builder endpoint must still authorize every discovery and invocation. Agent
-revocation therefore takes effect on the next operation; workload revocation is
-bounded by the exchanged token's short lifetime.
+A builder may implement short-lived OAuth token exchange behind this interface.
+For example, it can exchange the Cognition workload identity for exactly one
+audience-bound gateway token. That token proves the workload and constrains its
+destination; it does not manufacture cryptographic identity for a logical
+Agent. The builder endpoint must therefore make fail-closed, live Agent
+authorization decisions on each discovery and invocation using Cognition's
+trusted, model-invisible runtime context.
 
 ### `static_bearer`
 
@@ -186,9 +165,9 @@ sequenceDiagram
 
     R->>F: Server config + pinned runtime snapshot
     F->>I: Resolve declared auth type
-    alt workload token exchange
-        I->>I: Acquire ambient workload subject token
-        I->>I: Exchange for exact target and short lifetime
+    alt outbound auth provider
+        I->>I: Resolve builder provider by opaque profile
+        I->>I: Obtain bounded transport auth for this request
     else direct MCP OAuth
         I->>M: Standard MCP OAuth discovery/authorization
     end
@@ -304,11 +283,10 @@ the latest readiness observation is `ready`.
 11. Direct OAuth tokens for the same canonical server are isolated across exact
     scopes and Agent identities.
 12. `mcp_oauth` failure never downgrades to anonymous transport.
-13. Workload token exchange requests one exact target, enforces the configured
-    maximum lifetime, requests no refresh token, and fails closed on any
-    endpoint/profile/audience mismatch.
-14. Workload-level revocation is bounded and tested against the configured token
-    lifetime; Agent-level revocation is checked live on the next operation.
+13. An outbound auth provider cannot add non-allowlisted headers and fails
+    closed on profile, endpoint, or policy mismatch.
+14. Provider credential revocation is bounded by its expiry; Agent-level
+    revocation is checked live on the next operation.
 15. Authentication applies to both tool discovery and tool invocation.
 16. Production startup and activation reject `static_bearer`; local/dev reads the
     configured environment value without persisting or projecting it.
@@ -320,7 +298,8 @@ the latest readiness observation is `ready`.
 
 ## Non-Goals
 
-- Identity-provider-specific configuration or claims
+- Identity-provider-specific configuration or claims, including Keycloak
+  configuration
 - Cognition-managed Agent IAM, roles, bindings, or entitlements
 - A general credential vault or arbitrary secret-reference API
 - Raw authentication headers or custom `httpx.Auth` objects in Agent definitions

--- a/docs/proposals/v0.14.0-mcp-runtime-contract.md
+++ b/docs/proposals/v0.14.0-mcp-runtime-contract.md
@@ -1,0 +1,337 @@
+# v0.14.0 MCP Runtime and Authentication Contract
+
+- **Status:** Draft proposal
+- **Target:** v0.14.0
+- **Date:** 2026-08-03
+- **Audience:** Cognition maintainers, builders, security reviewers, and operators
+- **Parent:** [v0.14.0 C4 Model](./v0.14.0-deep-agents-skills-mcp-storage.md)
+
+## Outcome
+
+v0.14 makes remote Model Context Protocol (MCP) servers part of an Agent
+revision and removes Cognition's global MCP-server subsystem. Cognition uses the
+upstream LangChain MCP client and exposes four explicit authentication types:
+
+| Type | Intended use | Credential authority |
+|---|---|---|
+| `none` | Public or infrastructure-protected endpoint | None or external infrastructure |
+| `mcp_oauth` | Direct protected MCP endpoint | Standard MCP OAuth flow, scoped token store |
+| `workload_token_exchange` | Builder-controlled production endpoint | Workload identity and OAuth token exchange |
+| `static_bearer` | Local development only | Local operator environment |
+
+The first three are production-capable. `static_bearer` is rejected by the
+production deployment profile. Raw headers, API keys, bearer values, provider
+credentials, and custom Python authentication callbacks are never valid Agent
+configuration.
+
+## Agent Configuration
+
+Each server is declared inside the complete Agent definition:
+
+```yaml
+mcp:
+  servers:
+    github:
+      transport: streamable_http
+      url: https://mcp.example.com/github
+      required: true
+      auth:
+        type: mcp_oauth
+```
+
+The server alias is `github`. It is configuration identity, not a model
+argument. Production activation canonicalizes the URL, checks it against
+deployment egress policy, and binds the canonical endpoint to its selected
+authentication type.
+
+The following common fields are supported:
+
+| Field | Contract |
+|---|---|
+| `transport` | Must be `streamable_http` in v0.14 |
+| `url` | Builder-authored HTTPS endpoint; canonicalized before policy matching |
+| `required` | Required failure stops execution; optional failure degrades only that server |
+| `auth.type` | One of the four explicit authentication types |
+| `auth.profile` | Opaque deployment-profile name, required only for `workload_token_exchange` |
+| `auth.env` | Environment-variable name, required only for local/dev `static_bearer` |
+
+Tool prefixes and raw connection headers are not configurable. Cognition owns
+the deterministic visible tool-name rendering.
+
+## Authentication Types
+
+### `none`
+
+`none` sends no Cognition-managed credential:
+
+```yaml
+auth:
+  type: none
+```
+
+Infrastructure may still protect the endpoint outside Cognition. An unexpected
+authentication challenge is surfaced as a typed, redacted failure; Cognition
+does not silently switch authentication modes.
+
+### `mcp_oauth`
+
+`mcp_oauth` is the direct-provider path:
+
+```yaml
+auth:
+  type: mcp_oauth
+```
+
+Cognition follows the standard MCP HTTP authorization flow supported by the
+upstream MCP SDK, including protected-resource metadata, OAuth authorization
+server discovery, Proof Key for Code Exchange (PKCE), resource indicators,
+scope challenges, and audience validation.
+
+OAuth tokens are namespaced by exact `effective_scope`, immutable Agent
+identity, and canonical server URI. Production persistence uses an encrypted
+database token store whose encryption authority comes from deployment
+configuration or ambient workload identity. Tokens never use host files or S3,
+and never appear in Agent definitions, model context, API projections, events,
+logs, metrics, or traces.
+
+If the required OAuth capability, encrypted token store, or authorization state
+is unavailable, the server is not ready. Cognition does not downgrade to
+`none`.
+
+### `workload_token_exchange`
+
+This optional type supports builders that put a policy enforcement point,
+gateway, service mesh, or connection service in front of remote MCP providers:
+
+```yaml
+auth:
+  type: workload_token_exchange
+  profile: production_egress
+```
+
+The opaque profile resolves only from trusted deployment configuration:
+
+```yaml
+mcp_auth_profiles:
+  production_egress:
+    type: oauth_token_exchange
+    token_endpoint: https://identity.internal/token
+    subject_token_source: workload_identity
+    target:
+      parameter: audience
+      value: canonical_server_uri
+    max_access_token_ttl_seconds: 300
+    allow_refresh_token: false
+    trusted_context:
+      fields:
+        - agent_id
+        - runtime_snapshot
+        - server_alias
+        - effective_scope
+```
+
+The profile is not a credential and cannot supply arbitrary headers. Activation
+must prove that the profile, canonical server URI, target parameter, and exact
+target value form an allowed deployment binding.
+
+The generic contract supports RFC 8693 `resource` or `audience` target
+parameters. `resource` is preferred where supported. An `audience` profile must
+request exactly one audience and bind it to the canonical endpoint. Cognition
+does not contain identity-provider-specific client, realm, role, or claim logic.
+
+The exchanged token authenticates the Cognition workload and restricts its
+destination. It does not manufacture cryptographic identity for a logical
+Agent. Agent-level authorization remains live at the builder-controlled
+endpoint, using model-invisible runtime context supplied by Cognition over the
+authenticated channel.
+
+An expiry-bounded in-memory cache may reuse a workload token for the same
+workload identity, profile, and exact target. Such a token may be shared by
+multiple logical Agents because it does not grant Agent-level authority. The
+builder endpoint must still authorize every discovery and invocation. Agent
+revocation therefore takes effect on the next operation; workload revocation is
+bounded by the exchanged token's short lifetime.
+
+### `static_bearer`
+
+`static_bearer` exists only for local development:
+
+```yaml
+auth:
+  type: static_bearer
+  env: LOCAL_MCP_TOKEN
+```
+
+The environment variable name may be persisted, but its value may not. The
+value is read into bounded process memory and is excluded from every projection
+and telemetry path. Production startup and production Agent activation reject
+this type.
+
+## Runtime Components and Flow
+
+Authentication is transport security, not optional Agent middleware. Cognition's
+MCP client factory installs it for discovery, readiness probes, and invocation.
+The LangChain MCP interceptor is used for invocation-time runtime access and
+request overrides, but it is not independently configurable or removable by an
+Agent.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant R as Runtime Resolver
+    participant F as MCP Client Factory
+    participant I as Transport Identity
+    participant P as Builder Policy Endpoint
+    participant M as Remote MCP
+
+    R->>F: Server config + pinned runtime snapshot
+    F->>I: Resolve declared auth type
+    alt workload token exchange
+        I->>I: Acquire ambient workload subject token
+        I->>I: Exchange for exact target and short lifetime
+    else direct MCP OAuth
+        I->>M: Standard MCP OAuth discovery/authorization
+    end
+    F->>M: Discover this server with authenticated transport
+    M-->>F: Tools or typed redacted failure
+    R->>F: Invoke canonical server/tool identity
+    F->>P: Trusted runtime context when profile permits it
+    P-->>F: Live allow or deny
+    F->>M: MCP invocation with transport-owned authentication
+```
+
+For a builder-controlled endpoint, the policy endpoint and MCP endpoint may be
+the same external system. Cognition does not model the builder's internal
+gateway, connection, credential, or authorization-service hierarchy.
+
+## Trusted Runtime Context
+
+Context projection is default-deny and deployment-controlled. It may include
+only fixed Cognition-owned fields selected by the profile. Agent configuration
+cannot define header names or values.
+
+The transport layer overwrites reserved headers from trusted runtime context.
+Model-supplied tool arguments, prompts, MCP results, inbound client headers, and
+Agent-authored skill content cannot affect:
+
+- `Authorization` or proof-of-possession material;
+- canonical server URI, redirect target, target parameter, or audience;
+- server alias or provider tool name;
+- Agent identity, runtime snapshot, or `effective_scope`; or
+- required/optional server policy.
+
+The receiving endpoint must trust projected context only when the request is
+authenticated as the configured Cognition workload. External ingress must strip
+the same reserved headers. A shared workload identity provides logical Agent
+isolation only; cryptographic Agent or tenant isolation requires separate
+workload execution identities.
+
+## Discovery, Tool Identity, and Readiness
+
+Cognition discovers each server independently with
+`MultiServerMCPClient.get_tools(server_name=alias)` or an equivalent upstream
+per-server operation. Independent tasks may run concurrently, but one server's
+failure cannot discard tools discovered from healthy optional servers.
+
+The canonical tool identity is the tuple:
+
+```text
+(server_alias, provider_tool_name)
+```
+
+Visible tool-name rendering is deterministic but is not canonical identity.
+Duplicate canonical identities or rendered-name collisions fail activation or
+discovery before model execution.
+
+Readiness is a freshness-qualified runtime observation, never authorization
+truth. Each server reports:
+
+- `ready`, `degraded`, `unavailable`, `unknown`, or `stale`;
+- required/optional status;
+- last observation time and freshness deadline;
+- discovered tool count and schema digest; and
+- a typed, redacted failure category.
+
+Authorization is still evaluated at the next discovery or invocation even when
+the latest readiness observation is `ready`.
+
+## Security and Observability Invariants
+
+1. Production endpoints use HTTPS, exact canonical endpoint policy, bounded
+   redirects, and network egress controls. OAuth metadata URLs receive the same
+   server-side request forgery protections.
+2. `mcp_oauth` tokens are exact-scope and server partitioned.
+3. Workload-exchange tokens are short-lived, single-target, and have no refresh
+   token. Sender constraint through mTLS or DPoP is used when the deployment
+   supports and verifies it.
+4. Builder endpoints perform fail-closed live Agent authorization on every
+   discovery and invocation; a pinned Agent revision never preserves a revoked
+   authorization decision.
+5. Cognition never receives the builder endpoint's upstream provider credential.
+6. Authentication failures are typed and redacted. Cognition never retries a
+   protected request anonymously.
+7. Credentials, token values, authentication headers, raw scope values, tool
+   arguments, tool results, and OAuth payloads never enter persistence or
+   telemetry.
+8. High-cardinality Agent, session, run, scope, revision, and server identifiers
+   never become metric labels. Redacted identifiers may appear in bounded logs
+   and trace attributes when operationally required.
+9. Callback handlers do not log raw MCP server messages or result bodies.
+10. A configuration or code path that constructs an MCP client without the
+    mandatory transport-security factory fails review and testing.
+
+## Executable Acceptance Criteria
+
+1. Two scoped Agents using the same server alias resolve different live upstream
+   provider authorization when their builder bindings differ, without cross-use.
+   They may share a workload route token only when it carries no Agent authority.
+2. Agent configuration, skills, tools, and models cannot add non-allowlisted
+   transport headers.
+3. A model-supplied `Authorization`, URL, redirect, scope, server alias, auth
+   profile, or target value cannot affect discovery or invocation transport.
+4. Revoking an Agent or binding during an already-pinned run denies the next
+   discovery or invocation.
+5. One optional server failing does not remove tools from healthy servers.
+6. One required server failing stops execution before the model runs with a
+   typed, redacted error.
+7. Duplicate canonical tool identities and rendered-name collisions fail
+   configuration activation or discovery.
+8. No credential, token, authentication header, raw scope value, tool argument,
+   tool result, or OAuth payload appears in persistence or telemetry.
+9. High-cardinality identifiers never become metric labels.
+10. Readiness becomes `stale` or `unknown` after its freshness deadline and is
+    never presented as authorization truth.
+11. Direct OAuth tokens for the same canonical server are isolated across exact
+    scopes and Agent identities.
+12. `mcp_oauth` failure never downgrades to anonymous transport.
+13. Workload token exchange requests one exact target, enforces the configured
+    maximum lifetime, requests no refresh token, and fails closed on any
+    endpoint/profile/audience mismatch.
+14. Workload-level revocation is bounded and tested against the configured token
+    lifetime; Agent-level revocation is checked live on the next operation.
+15. Authentication applies to both tool discovery and tool invocation.
+16. Production startup and activation reject `static_bearer`; local/dev reads the
+    configured environment value without persisting or projecting it.
+17. Production endpoint, OAuth metadata, DNS, private-network, and redirect
+    policies prevent unapproved server-side requests while allowing explicitly
+    admitted internal endpoints.
+18. MCP callbacks and errors remain redacted even when a remote server emits
+    credential-shaped or high-cardinality content.
+
+## Non-Goals
+
+- Identity-provider-specific configuration or claims
+- Cognition-managed Agent IAM, roles, bindings, or entitlements
+- A general credential vault or arbitrary secret-reference API
+- Raw authentication headers or custom `httpx.Auth` objects in Agent definitions
+- Experimental OAuth impersonation or delegation
+- Cryptographic isolation between logical Agents sharing one Cognition workload
+- MCP resources, prompts, local `stdio`, or stateful sessions in v0.14
+
+## Standards and Upstream References
+
+- [LangChain MCP adapters](https://docs.langchain.com/oss/python/langchain/mcp)
+- [MCP Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
+- [OAuth 2.0 Token Exchange, RFC 8693](https://www.rfc-editor.org/rfc/rfc8693.html)
+- [OAuth 2.0 Security Best Current Practice, RFC 9700](https://www.rfc-editor.org/rfc/rfc9700.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,9 @@ nav:
       - Deployment: guides/deployment.md
       - API Reference: guides/api-reference.md
       - Release Checklist: guides/release-checklist.md
+  - Proposals:
+      - "v0.14.0 C4 Model: Agent Capabilities and Durable Storage": proposals/v0.14.0-deep-agents-skills-mcp-storage.md
+      - "v0.14.0 MCP Runtime and Authentication Contract": proposals/v0.14.0-mcp-runtime-contract.md
   - Blueprints:
       - Cognition CLI: blueprints/cognition-cli.md
       - BreachLens: blueprints/cyber-investigation.md


### PR DESCRIPTION
## Summary
- add the v0.14 C4 architecture and MCP runtime/authentication contract
- document per-agent MCP authentication, discovery, readiness, and release-blocking acceptance criteria
- update roadmap and documentation navigation

## Validation
- proposal Markdown lint
- proposal link checks
- strict MkDocs build
- Git whitespace check