### PR TITLE
chore: upgrade Deep Agents runtime to 0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     # Core framework
-    "deepagents>=0.6.2",
+    "deepagents>=0.7.1",
     "langchain>=1.3.0",
     "langgraph>=0.2.0",
     "langchain-core>=1.4.0",
@@ -53,7 +53,7 @@ dependencies = [
     "langsmith[otel]>=0.4.25",
     "langgraph-checkpoint-sqlite>=1.0.0",
     # MCP (Model Context Protocol) - Remote-only support via langchain-mcp-adapters
-    "langchain-mcp-adapters>=0.2.0",
+    "langchain-mcp-adapters>=0.3.1",
     # A2A (Agent-to-Agent Protocol) - Inbound server adapter
     "a2a-sdk>=1.0.3",
     # AWS Lambda MicroVM sandbox adapter (boto3 is optional/lazy)
@@ -64,6 +64,9 @@ dependencies = [
 # LLM providers (install as needed)
 openai = ["langchain-openai>=0.2.0", "openai>=1.52.0"]
 bedrock = ["langchain-aws>=0.2.0", "boto3>=1.35.0"]
+
+# S3-compatible durable file backend (AWS S3, Garage, and other S3 APIs)
+s3 = ["boto3>=1.35.0"]
 
 # Testing
 test = [
@@ -101,11 +104,6 @@ k8s = [
     "langchain-k8s-sandbox[k8s]",
 ]
 
-# Documentation site
-docs = [
-    "mkdocs-material>=9.6.0",
-]
-
 # AWS Lambda MicroVM sandbox backend
 aws-lambda-microvms = [
     "langchain-aws-lambda-microvms[aws]",
@@ -113,7 +111,7 @@ aws-lambda-microvms = [
 
 # All extras
 all = [
-    "cognition[openai,bedrock,test,deploy,k8s,aws-lambda-microvms]",
+    "cognition[openai,bedrock,s3,test,deploy,k8s,aws-lambda-microvms]",
 ]
 
 [project.scripts]

--- a/server/app/agent/artifacts_backend.py
+++ b/server/app/agent/artifacts_backend.py
@@ -160,13 +160,15 @@ class ArtifactBackend(BackendProtocol):
                 scope=self._scope,
                 artifact_type=artifact_type,
             )
-            return LsResult(entries=[
-                FileInfo(
-                    path=f"/{artifact_type}/{a.id}",
-                    size=len(a.content.encode("utf-8")),
-                )
-                for a in artifacts
-            ])
+            return LsResult(
+                entries=[
+                    FileInfo(
+                        path=f"/{artifact_type}/{a.id}",
+                        size=len(a.content.encode("utf-8")),
+                    )
+                    for a in artifacts
+                ]
+            )
 
         return LsResult(entries=[])
 
@@ -200,13 +202,25 @@ class ArtifactBackend(BackendProtocol):
         return []
 
     async def agrep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
+        del pattern, path, glob, max_count
         return GrepResult(matches=[])
 
     def grep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
+        del pattern, path, glob, max_count
         return GrepResult(matches=[])
 
     async def agrep_raw(
@@ -307,9 +321,7 @@ class ArtifactBackend(BackendProtocol):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return EditResult(error="ArtifactBackend requires an async event loop")
-        return loop.run_until_complete(
-            self.aedit(file_path, old_string, new_string, replace_all)
-        )
+        return loop.run_until_complete(self.aedit(file_path, old_string, new_string, replace_all))
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> Any:
         return None

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -535,7 +535,10 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files in the AWS Lambda MicroVM sandbox."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def glob(self, pattern: str, path: str | None = "/") -> GlobResult:
@@ -849,7 +852,10 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files using Deep Agents' current result API."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def grep_raw(

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -530,10 +530,12 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search files in the AWS Lambda MicroVM sandbox."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob)
+        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
         return result
 
     def glob(self, pattern: str, path: str | None = "/") -> GlobResult:
@@ -705,12 +707,16 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
 
         # Check workspace root
         expected_root = str(self._root_dir)
-        result = self._backend.execute(f'test -d {shlex.quote(expected_root)} && echo "ok" || echo "missing"')
+        result = self._backend.execute(
+            f'test -d {shlex.quote(expected_root)} && echo "ok" || echo "missing"'
+        )
         workspace_ok = result.exit_code == 0
         checks.append(("workspace_root", f"Expected {expected_root}", workspace_ok))
 
         # Check writable workspace
-        result = self._backend.execute(f'test -w {shlex.quote(expected_root)} && echo "ok" || echo "ro"')
+        result = self._backend.execute(
+            f'test -w {shlex.quote(expected_root)} && echo "ok" || echo "ro"'
+        )
         writable_ok = result.exit_code == 0
         checks.append(("workspace_writable", expected_root, writable_ok))
 
@@ -721,7 +727,11 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
 
         # Check env vars
         result = self._backend.execute("env | grep -c COGNITION_WORKSPACE_ROOT")
-        env_ok = result.exit_code == 0 and result.output.strip().isdigit() and int(result.output.strip()) > 0
+        env_ok = (
+            result.exit_code == 0
+            and result.output.strip().isdigit()
+            and int(result.output.strip()) > 0
+        )
         checks.append(("env_var", "COGNITION_WORKSPACE_ROOT", env_ok))
 
         # Check GitHub auth if token is expected
@@ -834,10 +844,12 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search files using Deep Agents' current result API."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob)
+        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
         return result
 
     def grep_raw(
@@ -966,7 +978,9 @@ def create_sandbox_backend(
     aws_lambda_microvm_profile: str = "default",
     aws_lambda_microvm_execution_role_arn: str | None = None,
     aws_lambda_microvm_profile_config: SandboxProfile | None = None,
-) -> FilesystemBackend | CognitionKubernetesSandboxBackend | CognitionAwsLambdaMicroVmSandboxBackend:
+) -> (
+    FilesystemBackend | CognitionKubernetesSandboxBackend | CognitionAwsLambdaMicroVmSandboxBackend
+):
     """Factory for creating sandbox backends from settings.
 
     Args:

--- a/tests/unit/test_composite_backend_skill_routing.py
+++ b/tests/unit/test_composite_backend_skill_routing.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.protocol import LsResult
 
 from server.app.agent.sandbox_backend import CognitionLocalSandboxBackend
 
 
 class StubSkillBackend:
     def ls(self, path: str):
-        return [{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}]
-
-    def ls_info(self, path: str):
-        return [{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}]
-
-    def glob_info(self, pattern: str, path: str = "/"):
-        return []
-
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000):
-        return "stub"
-
-    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
-        return []
+        return LsResult(entries=[{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}])
 
 
 def test_composite_backend_routes_only_skill_paths(tmp_path):
@@ -31,13 +20,14 @@ def test_composite_backend_routes_only_skill_paths(tmp_path):
     sandbox = CognitionLocalSandboxBackend(root_dir=repo_root)
     backend = CompositeBackend(default=sandbox, routes={"/skills/api/": StubSkillBackend()})
 
-    repo_entries = backend.ls_info(str(repo_root / "Cognition-Gateway"))
+    repo_listing = backend.ls(str(repo_root / "Cognition-Gateway"))
+    assert repo_listing.entries is not None
     assert any(
         entry["path"] == str(repo_root / "Cognition-Gateway" / "README.md")
-        for entry in repo_entries
+        for entry in repo_listing.entries
     )
 
-    skill_entries = backend.ls_info("/skills/api/")
-    assert skill_entries == [
+    skill_listing = backend.ls("/skills/api/")
+    assert skill_listing.entries == [
         {"path": "/skills/api/demo/", "is_dir": True, "size": 0, "modified_at": ""}
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.103.1"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -244,9 +244,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/57/0b758b08cf4606c94d63a997d67a0063f7438efbaf81cfedd0d7c0c69d67/anthropic-0.103.1.tar.gz", hash = "sha256:21c12f4fc0fdd87a2e80d58479cd0af640062b3cfb82bbfa01c7977acd4defeb", size = 848877, upload-time = "2026-05-19T15:43:27.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ec/cf357cf571377a39552c1530390a9b79bbdb6ea463f48fbe4e3624141e3b/anthropic-0.103.1-py3-none-any.whl", hash = "sha256:b9a523fac34e64caf6ee55fdbda213950e6a744b906fce100d34909aad2cd8f4", size = 832551, upload-time = "2026-05-19T15:43:29.663Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]
@@ -389,11 +389,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
 ]
 
 [[package]]
@@ -693,6 +693,9 @@ openai = [
     { name = "langchain-openai" },
     { name = "openai" },
 ]
+s3 = [
+    { name = "boto3" },
+]
 test = [
     { name = "httpx" },
     { name = "pytest" },
@@ -713,7 +716,8 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'deploy'", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "deepagents", specifier = ">=0.6.2" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
+    { name = "deepagents", specifier = ">=0.7.1" },
     { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
     { name = "docker", marker = "extra == 'deploy'", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -730,7 +734,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.4.0" },
     { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'all'", editable = "packages/langchain-k8s-sandbox" },
     { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'k8s'", editable = "packages/langchain-k8s-sandbox" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.1" },
     { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2.0" },
@@ -781,7 +785,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["all", "aws-lambda-microvms", "bedrock", "deploy", "dev", "docs", "k8s", "openai", "test"]
+provides-extras = ["all", "aws-lambda-microvms", "bedrock", "deploy", "dev", "docs", "k8s", "openai", "s3", "test"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
@@ -1078,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.6.12"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -1086,11 +1090,12 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e3/00c98c6b677ba89270b09dcb950848c794d507168b3dc53fa4d5cfb6a2e3/deepagents-0.7.1.tar.gz", hash = "sha256:a556a8af8dac84ee5708d7e97752eda40d613d19e25cc79b7d0e8c728da03c40", size = 270546, upload-time = "2026-07-30T20:34:26.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/3306ab2f544e08ea33852f92d0fb3ab8fbf437c84e5f58189f0e4f895087/deepagents-0.7.1-py3-none-any.whl", hash = "sha256:cbcfb856e95ecc8a969b9d036b1d6b760524ca9a5b83f00e53ae568ddebfd343", size = 297359, upload-time = "2026-07-30T20:34:24.846Z" },
 ]
 
 [[package]]
@@ -2080,30 +2085,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.7"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/d0/5b117541b9e13619a387b3c829b97ef8d54f848716c0cb574df35a326dea/langchain_anthropic-1.4.7.tar.gz", hash = "sha256:34a7eb0db6bb7c92ff89b3f985de6417d5ef7a148d4595f4498fd3ca4f14aa77", size = 706692, upload-time = "2026-06-22T22:56:05.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/5b/25ffc9cc66a8260db9e2da2836ee33b260dfbb874d1ea2f99d70023f2b1d/langchain_anthropic-1.5.3.tar.gz", hash = "sha256:48a7e4fc3856c42f9dcb4396ba112afcdd8dee21b70a402bc43283c970de3941", size = 713962, upload-time = "2026-07-28T17:02:55.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/bf/78c71bdd7b9ec6fcd6ca45114d5910bfbad2fba21e5223523e793a17520d/langchain_anthropic-1.4.7-py3-none-any.whl", hash = "sha256:2e9d9dd4cb66de19394d7a9d552e1dbf2cd3c1da9f799a0c372b5fc84e298d8f", size = 51978, upload-time = "2026-06-22T22:56:04.349Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/19/584ab8517718f48bb411d051be713ebd8b58351741f8a4ca23d6a305cb1b/langchain_anthropic-1.5.3-py3-none-any.whl", hash = "sha256:b1b72b7c9e4bf5c044660629ebbcb79cef18c140fdc80174750eb86de13ec8bc", size = 54034, upload-time = "2026-07-28T17:02:54.594Z" },
 ]
 
 [[package]]
@@ -2151,7 +2156,7 @@ provides-extras = ["aws", "test"]
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2164,14 +2169,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/3e/63af6b9d76d9be907c7c524d6ec18a2efed7e0e2d123fea0230d78dbd73f/langchain_core-1.5.3.tar.gz", hash = "sha256:a56457ac444fef41e9404443c187f0ecea708d36e816ea4ba9573c027f7d1a2d", size = 972461, upload-time = "2026-07-30T14:55:55.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e6/c7c39efe0bc7e1b7c3d8f54f85846e04c901913c3d3e99068b218558c6f1/langchain_core-1.5.3-py3-none-any.whl", hash = "sha256:48b56fa580277209594dd7baf837f5b9a2a3651613f34ff9fb1728b429df015f", size = 561687, upload-time = "2026-07-30T14:55:54.419Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.6"
+version = "4.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2179,9 +2184,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/08/68e4f90b273d1d8dc3a7a948e6535e60baac726adbb2a8341dcf17662f54/langchain_google_genai-4.2.6.tar.gz", hash = "sha256:653dc331e691ddd79784d9ff6a4082749e0f873394c6dc782c414eb4409850eb", size = 280074, upload-time = "2026-06-26T06:18:58.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/2f/e03b63ad3a61fd1aa479bbc0f3df5d27abb8f9159d111cba96629df844ef/langchain_google_genai-4.3.2.tar.gz", hash = "sha256:6471769a4463fedb10d2d19a9b56c31de1cde505edf7fffd8cdbf98af8c1d7da", size = 286018, upload-time = "2026-07-27T16:27:39.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/3c/9a6b43bced0238f95640555e14423fe4a8268e3f4f536f67e26e79e633d4/langchain_google_genai-4.2.6-py3-none-any.whl", hash = "sha256:c40db0c2d033a5fb6db8e2cc3fb6d49c5678b89b337a64da095fb73ec9f72021", size = 70457, upload-time = "2026-06-26T06:18:57.781Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/4a2eb187b108a240d57cf8dcf67e818ca75365f769444bf5716e2823cd98/langchain_google_genai-4.3.2-py3-none-any.whl", hash = "sha256:f3b1c09b264612fd1735a9590987bfa0cccca0bc0111691543decb5a03b8667d", size = 72770, upload-time = "2026-07-27T16:27:38.052Z" },
 ]
 
 [[package]]
@@ -2212,16 +2217,16 @@ provides-extras = ["k8s", "test"]
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5d/1f43b6a14cf448ea47bceb2860e9a6e3b0a911de0719aba43ed3eb927195/langchain_mcp_adapters-0.3.1.tar.gz", hash = "sha256:e08d4a74a0934d558ddb807ecbb8f89466c93a0d06c1fb58974b93b4703de01c", size = 47140, upload-time = "2026-07-27T18:36:45.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8d/934946caf18559158678099ac00e6eed67d78e68c4e73c7afd01e19d31ec/langchain_mcp_adapters-0.3.1-py3-none-any.whl", hash = "sha256:1e354d9466db9fab9e30f24419adffbd39a84229e7f452927f99ea799e1937f9", size = 28877, upload-time = "2026-07-27T18:36:44.762Z" },
 ]
 
 [[package]]
@@ -2340,7 +2345,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.3"
+version = "0.10.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2358,9 +2363,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/bb/bce9faa416dfd28e1cf60bf6299e9569f9e8483b0ed22eed1d6aefc9e81c/langsmith-0.10.15.tar.gz", hash = "sha256:eefc562b29eb642a635b459e5bb44ca574380d7f32fe840acf28cd603c168647", size = 4790873, upload-time = "2026-07-31T18:15:18.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fb/dc9f70b5581371fba7b01ba0704fe859bfcd12c4dad82b42ec12bd4160b1/langsmith-0.9.3-py3-none-any.whl", hash = "sha256:aac85686868a7e61d77858b880230e510583c61ea48ac0a197e6ceff64ffb22b", size = 619927, upload-time = "2026-06-26T15:56:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7a/58602b770741bc84b0b35b580914f335f6663f4ea699b95eb12b074e70b8/langsmith-0.10.15-py3-none-any.whl", hash = "sha256:7afd7979a9cdf846a88c980e0a31ed518c33631d29e672adbfbb33446f3817cf", size = 731606, upload-time = "2026-07-31T18:15:16.471Z" },
 ]
 
 [package.optional-dependencies]
@@ -5366,14 +5371,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- repair the duplicate optional-dependency key so uv can resolve the project
- require Deep Agents 0.7.1 and langchain-mcp-adapters 0.3.1
- add an explicit S3-compatible storage extra
- update the composite backend test for the Deep Agents 0.7 protocol

## Validation
- uv lock
- uv sync --all-extras
- focused backend, skills, and MCP tests: 40 passed, 1 skipped
- mypy for touched runtime/backend sources
- ruff check