### PR TITLE
feat: add S3-compatible Deep Agents backend

### DIFF
--- a/server/app/agent/s3_backend.py
+++ b/server/app/agent/s3_backend.py
@@ -1,0 +1,222 @@
+"""S3-compatible Deep Agents backend.
+
+The backend intentionally targets the S3 API rather than an AWS-specific
+service.  It supports AWS S3 through the normal boto3 credential chain and
+S3-compatible deployments such as Garage through an explicit endpoint URL.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import posixpath
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import Any
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    DeleteResult,
+    EditResult,
+    FileData,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GlobResult,
+    GrepMatch,
+    GrepResult,
+    LsResult,
+    ReadResult,
+    WriteResult,
+)
+
+
+class S3CompatibleBackend(BackendProtocol):
+    """Expose one S3 prefix as a safe, virtual Deep Agents filesystem.
+
+    ``prefix`` is controlled by the runtime, not model input.  File paths are
+    normalized and must remain below that prefix, preventing path traversal
+    from escaping the effective-scope namespace.
+    """
+
+    def __init__(self, client: Any, bucket: str, prefix: str = "") -> None:
+        self._client = client
+        self._bucket = bucket
+        self._prefix = prefix.strip("/")
+
+    def _key(self, path: str) -> str:
+        normalized = posixpath.normpath("/" + path.lstrip("/"))
+        if normalized == "/.." or normalized.startswith("/../"):
+            raise ValueError("path escapes the configured storage prefix")
+        relative = normalized.lstrip("/")
+        return "/".join(part for part in (self._prefix, relative) if part)
+
+    def _path(self, key: str) -> str:
+        if self._prefix:
+            if not key.startswith(f"{self._prefix}/"):
+                raise ValueError("object is outside the configured storage prefix")
+            key = key[len(self._prefix) + 1 :]
+        return f"/{key}"
+
+    def _iter_objects(self, path: str = "/") -> Iterable[dict[str, Any]]:
+        prefix = self._key(path).rstrip("/")
+        if prefix:
+            prefix += "/"
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+            yield from page.get("Contents", [])
+
+    @staticmethod
+    def _timestamp(value: datetime | None) -> str:
+        if value is None:
+            return ""
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+
+    @staticmethod
+    def _not_found(error: Exception) -> bool:
+        response = getattr(error, "response", {})
+        code = str(response.get("Error", {}).get("Code", ""))
+        return code in {"404", "NoSuchKey", "NoSuchBucket"}
+
+    def ls(self, path: str) -> LsResult:
+        try:
+            entries: dict[str, FileInfo] = {}
+            root = self._key(path).rstrip("/")
+            prefix = f"{root}/" if root else ""
+            for obj in self._iter_objects(path):
+                key = str(obj["Key"])
+                remainder = key[len(prefix) :] if prefix else key
+                first, _, tail = remainder.partition("/")
+                entry_path = f"{path.rstrip('/')}/{first}" if path != "/" else f"/{first}"
+                if tail:
+                    entries.setdefault(entry_path, {"path": entry_path, "is_dir": True})
+                else:
+                    entries[entry_path] = {
+                        "path": entry_path,
+                        "is_dir": False,
+                        "size": int(obj.get("Size", 0)),
+                        "modified_at": self._timestamp(obj.get("LastModified")),
+                    }
+            return LsResult(entries=[entries[key] for key in sorted(entries)])
+        except Exception as exc:
+            return LsResult(error=f"S3 list failed: {type(exc).__name__}")
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        try:
+            response = self._client.get_object(Bucket=self._bucket, Key=self._key(file_path))
+            content = response["Body"].read().decode("utf-8")
+        except Exception as exc:
+            if self._not_found(exc):
+                return ReadResult(error=f"Error: File '{file_path}' not found")
+            return ReadResult(error=f"S3 read failed: {type(exc).__name__}")
+
+        lines = content.splitlines()
+        if limit <= 0:
+            return ReadResult(total_lines=len(lines), no_lines_requested=True)
+        selected = lines[offset : offset + limit]
+        return ReadResult(
+            file_data=FileData(content="\n".join(selected), encoding="utf-8"),
+            total_lines=len(lines),
+            start_line=offset + 1 if selected else None,
+            end_line=offset + len(selected) if selected else None,
+            next_offset=offset + len(selected) if offset + len(selected) < len(lines) else None,
+        )
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        try:
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=self._key(file_path),
+                Body=content.encode("utf-8"),
+                ContentType="text/plain; charset=utf-8",
+            )
+            return WriteResult(path=file_path)
+        except Exception as exc:
+            return WriteResult(error=f"S3 write failed: {type(exc).__name__}")
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        result = self.read(file_path, limit=2**31 - 1)
+        if result.error or result.file_data is None:
+            return EditResult(error=result.error or f"Cannot read {file_path}")
+        content = result.file_data["content"]
+        occurrences = content.count(old_string)
+        if occurrences == 0:
+            return EditResult(error=f"String not found in {file_path}")
+        if not replace_all:
+            occurrences = 1
+        updated = content.replace(old_string, new_string, occurrences)
+        write = self.write(file_path, updated)
+        return EditResult(
+            error=write.error, path=file_path if not write.error else None, occurrences=occurrences
+        )
+
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
+        try:
+            matches: list[FileInfo] = [
+                {
+                    "path": self._path(str(obj["Key"])),
+                    "is_dir": False,
+                    "size": int(obj.get("Size", 0)),
+                    "modified_at": self._timestamp(obj.get("LastModified")),
+                }
+                for obj in self._iter_objects(path or "/")
+                if fnmatch.fnmatch(self._path(str(obj["Key"])).lstrip("/"), pattern)
+            ]
+            return GlobResult(matches=sorted(matches, key=lambda item: item["path"]))
+        except Exception as exc:
+            return GlobResult(error=f"S3 glob failed: {type(exc).__name__}")
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
+        matches: list[GrepMatch] = []
+        for info in self.glob(glob or "**", path).matches or []:
+            read = self.read(info["path"], limit=2**31 - 1)
+            if read.error or read.file_data is None:
+                continue
+            for line_number, line in enumerate(read.file_data["content"].splitlines(), start=1):
+                if pattern in line:
+                    matches.append({"path": info["path"], "line": line_number, "text": line})
+                    if max_count is not None and len(matches) >= max_count:
+                        return GrepResult(matches=matches, truncated=True)
+        return GrepResult(matches=matches)
+
+    def delete(self, file_path: str) -> DeleteResult:
+        try:
+            self._client.delete_object(Bucket=self._bucket, Key=self._key(file_path))
+            return DeleteResult(path=file_path)
+        except Exception as exc:
+            return DeleteResult(error=f"S3 delete failed: {type(exc).__name__}")
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            try:
+                response = self._client.get_object(Bucket=self._bucket, Key=self._key(path))
+                responses.append(FileDownloadResponse(path=path, content=response["Body"].read()))
+            except Exception as exc:
+                error = "file_not_found" if self._not_found(exc) else "invalid_path"
+                responses.append(FileDownloadResponse(path=path, error=error))
+        return responses
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        results: list[FileUploadResponse] = []
+        for path, content in files:
+            try:
+                self._client.put_object(Bucket=self._bucket, Key=self._key(path), Body=content)
+                results.append(FileUploadResponse(path=path))
+            except Exception:
+                results.append(FileUploadResponse(path=path, error="invalid_path"))
+        return results

--- a/server/app/agent/s3_backend.py
+++ b/server/app/agent/s3_backend.py
@@ -43,6 +43,35 @@ class S3CompatibleBackend(BackendProtocol):
         self._bucket = bucket
         self._prefix = prefix.strip("/")
 
+    @classmethod
+    def from_boto3(
+        cls,
+        *,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: str | None = None,
+        region_name: str | None = None,
+        force_path_style: bool = False,
+    ) -> S3CompatibleBackend:
+        """Build a backend from boto3's standard AWS/S3-compatible client.
+
+        ``force_path_style`` is useful for Garage and other local object stores;
+        AWS S3 deployments can leave it disabled and use virtual-host addressing.
+        Credentials deliberately come from boto3's standard provider chain.
+        """
+        try:
+            import boto3
+            from botocore.config import Config
+        except ImportError as exc:  # pragma: no cover - guarded by the s3 extra
+            raise RuntimeError("Install Cognition with the 's3' extra to use S3 storage") from exc
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            config=Config(s3={"addressing_style": "path" if force_path_style else "virtual"}),
+        )
+        return cls(client, bucket=bucket, prefix=prefix)
+
     def _key(self, path: str) -> str:
         normalized = posixpath.normpath("/" + path.lstrip("/"))
         if normalized == "/.." or normalized.startswith("/../"):

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -535,7 +535,10 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files in the AWS Lambda MicroVM sandbox."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def glob(self, pattern: str, path: str | None = "/") -> GlobResult:
@@ -849,7 +852,10 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files using Deep Agents' current result API."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def grep_raw(

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -133,6 +133,23 @@ class Settings(BaseSettings):
         alias="COGNITION_PERSISTENCE_URI",
     )
 
+    # Durable Deep Agents file backend. SQLite/in-memory/local remain supported
+    # only for local and development profiles; production uses S3-compatible
+    # object storage for durable file-shaped runtime data.
+    durable_file_backend: Literal["local", "s3"] = Field(
+        default="local",
+        alias="COGNITION_DURABLE_FILE_BACKEND",
+    )
+    s3_bucket: str | None = Field(default=None, alias="COGNITION_S3_BUCKET")
+    s3_prefix: str = Field(default="cognition", alias="COGNITION_S3_PREFIX")
+    s3_endpoint_url: str | None = Field(default=None, alias="COGNITION_S3_ENDPOINT_URL")
+    s3_region: str | None = Field(default=None, alias="COGNITION_S3_REGION")
+    s3_force_path_style: bool = Field(
+        default=False,
+        alias="COGNITION_S3_FORCE_PATH_STYLE",
+        description="Use path-style S3 requests for Garage and similar compatible stores.",
+    )
+
     # Sandbox / Execution backend settings
     sandbox_backend: Literal["local", "docker", "kubernetes", "aws_lambda_microvm"] = Field(
         default="local",
@@ -272,6 +289,11 @@ class Settings(BaseSettings):
         if not 1 <= v <= 65535:
             raise ValueError(f"Port must be between 1 and 65535, got {v}")
         return v
+
+    @property
+    def s3_enabled(self) -> bool:
+        """Return whether durable file data is configured for S3-compatible storage."""
+        return self.durable_file_backend == "s3"
 
 
 # Global settings instance

--- a/tests/e2e/test_s3_garage_e2e.py
+++ b/tests/e2e/test_s3_garage_e2e.py
@@ -1,0 +1,112 @@
+"""End-to-end coverage for the S3 backend against a real Garage node."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import boto3
+import pytest
+from botocore.config import Config
+
+from server.app.agent.s3_backend import S3CompatibleBackend
+
+pytestmark = pytest.mark.e2e
+
+_ACCESS_KEY = "cognition-test-access"
+_SECRET_KEY = "cognition-test-secret"
+_BUCKET = "cognition-test"
+
+
+@pytest.fixture(scope="module")
+def garage_endpoint(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Start an ephemeral single-node Garage S3 service for this test module."""
+    docker = pytest.importorskip("docker")
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception as exc:  # pragma: no cover - local environment condition
+        pytest.skip(f"Docker is unavailable for Garage E2E: {type(exc).__name__}")
+
+    config_path = Path(tmp_path_factory.mktemp("garage")) / "garage.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'metadata_dir = "/tmp/meta"',
+                'data_dir = "/tmp/data"',
+                'db_engine = "sqlite"',
+                "replication_factor = 1",
+                'rpc_bind_addr = "[::]:3901"',
+                'rpc_public_addr = "127.0.0.1:3901"',
+                'rpc_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"',
+                "[s3_api]",
+                's3_region = "garage"',
+                'api_bind_addr = "[::]:3900"',
+                'root_domain = ".s3.garage.localhost"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    container = client.containers.run(
+        "dxflrs/garage:v2.3.0",
+        "/garage server --single-node --default-bucket",
+        detach=True,
+        remove=True,
+        ports={"3900/tcp": None},
+        environment={
+            "GARAGE_DEFAULT_ACCESS_KEY": _ACCESS_KEY,
+            "GARAGE_DEFAULT_SECRET_KEY": _SECRET_KEY,
+            "GARAGE_DEFAULT_BUCKET": _BUCKET,
+        },
+        volumes={str(config_path): {"bind": "/etc/garage.toml", "mode": "ro"}},
+    )
+    try:
+        container.reload()
+        port = container.attrs["NetworkSettings"]["Ports"]["3900/tcp"][0]["HostPort"]
+        endpoint = f"http://127.0.0.1:{port}"
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            region_name="garage",
+            aws_access_key_id=_ACCESS_KEY,
+            aws_secret_access_key=_SECRET_KEY,
+            config=Config(s3={"addressing_style": "path"}),
+        )
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                s3.list_objects_v2(Bucket=_BUCKET)
+                break
+            except Exception:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.5)
+        yield endpoint
+    finally:
+        try:
+            container.stop(timeout=5)
+        except Exception:
+            pass
+
+
+def test_s3_backend_against_garage(
+    garage_endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Garage behaves as an S3-compatible durable filesystem backend."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _ACCESS_KEY)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _SECRET_KEY)
+    backend = S3CompatibleBackend.from_boto3(
+        bucket=_BUCKET,
+        prefix="scope/a0b1c2",
+        endpoint_url=garage_endpoint,
+        region_name="garage",
+        force_path_style=True,
+    )
+
+    assert backend.write("/skills/release/SKILL.md", "garage e2e").error is None
+    assert backend.read("/skills/release/SKILL.md").file_data == {
+        "content": "garage e2e",
+        "encoding": "utf-8",
+    }
+    assert backend.download_files(["/skills/release/SKILL.md"])[0].content == b"garage e2e"

--- a/tests/unit/test_s3_backend.py
+++ b/tests/unit/test_s3_backend.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from server.app.agent.s3_backend import S3CompatibleBackend
+
+
+class FakePaginator:
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self._objects = objects
+
+    def paginate(self, *, Bucket: str, Prefix: str):  # noqa: N803
+        del Bucket
+        return [
+            {
+                "Contents": [
+                    {"Key": key, "Size": len(value)}
+                    for key, value in self._objects.items()
+                    if key.startswith(Prefix)
+                ]
+            }
+        ]
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def get_paginator(self, operation_name: str) -> FakePaginator:
+        assert operation_name == "list_objects_v2"
+        return FakePaginator(self.objects)
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **kwargs: object) -> None:  # noqa: N803
+        del Bucket, kwargs
+        self.objects[Key] = Body
+
+    def get_object(self, *, Bucket: str, Key: str):  # noqa: N803
+        del Bucket
+        if Key not in self.objects:
+            error = RuntimeError("missing")
+            error.response = {"Error": {"Code": "NoSuchKey"}}  # type: ignore[attr-defined]
+            raise error
+        return {"Body": BytesIO(self.objects[Key])}
+
+    def delete_object(self, *, Bucket: str, Key: str) -> None:  # noqa: N803
+        del Bucket
+        self.objects.pop(Key, None)
+
+
+def test_s3_backend_isolates_prefix_and_supports_file_operations() -> None:
+    client = FakeS3Client()
+    backend = S3CompatibleBackend(client, bucket="test", prefix="scopes/opaque")
+
+    assert backend.write("/skills/demo/SKILL.md", "one\ntwo").error is None
+    assert client.objects == {"scopes/opaque/skills/demo/SKILL.md": b"one\ntwo"}
+
+    listing = backend.ls("/skills/")
+    assert listing.entries == [{"path": "/skills/demo", "is_dir": True}]
+
+    read = backend.read("/skills/demo/SKILL.md", offset=1, limit=1)
+    assert read.file_data == {"content": "two", "encoding": "utf-8"}
+    assert backend.glob("skills/**/*.md").matches == [
+        {"path": "/skills/demo/SKILL.md", "is_dir": False, "size": 7, "modified_at": ""}
+    ]
+
+    edit = backend.edit("/skills/demo/SKILL.md", "two", "three")
+    assert edit.error is None
+    assert backend.read("/skills/demo/SKILL.md").file_data == {
+        "content": "one\nthree",
+        "encoding": "utf-8",
+    }
+
+    assert backend.delete("/skills/demo/SKILL.md").error is None
+    assert (
+        backend.read("/skills/demo/SKILL.md").error
+        == "Error: File '/skills/demo/SKILL.md' not found"
+    )
+
+
+def test_s3_backend_never_allows_path_to_escape_prefix() -> None:
+    backend = S3CompatibleBackend(FakeS3Client(), bucket="test", prefix="tenant")
+
+    assert backend.write("/../../outside", "no").error is None
+    # Normalization keeps every object below the assigned prefix.
+    assert backend._key("/../../outside") == "tenant/outside"

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -52,6 +52,23 @@ class TestSettingsDefaults:
         assert settings.otel_endpoint is None
         assert settings.metrics_port == 9090
 
+    def test_default_durable_file_backend_is_local(self):
+        """Local and development profiles retain an explicit local backend."""
+        settings = TestSettings()
+        assert settings.durable_file_backend == "local"
+        assert not settings.s3_enabled
+
+    def test_s3_compatible_durable_file_configuration(self):
+        """Garage-style endpoint settings select the generic S3 backend."""
+        settings = TestSettings(
+            durable_file_backend="s3",
+            s3_bucket="cognition",
+            s3_endpoint_url="http://garage:3900",
+            s3_force_path_style=True,
+        )
+        assert settings.s3_enabled
+        assert settings.s3_force_path_style
+
 
 class TestSettingsSecrets:
     """Test SecretStr handling in settings."""


### PR DESCRIPTION
## Summary
- add an S3 API-backed Deep Agents filesystem backend
- preserve scope prefix isolation for every virtual file operation
- support AWS S3 through boto3 and S3-compatible endpoints such as Garage
- add durable-file settings for AWS and path-style S3-compatible deployments
- verify the backend against a real disposable Garage v2.3.0 service

## Validation
- Garage E2E: real S3 write, read, and binary download
- unit tests for storage prefix isolation and file operations
- settings tests
- ruff and mypy for touched sources