### PR TITLE
feat(mcp): define agent-owned configuration contract

### DIFF
--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -21,7 +21,7 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 from langchain_core.tools import BaseTool
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from server.app.agent.mcp_config import AgentMcpServer
 
@@ -170,7 +170,6 @@ class SubagentDefinition(BaseModel):
             )
         return v
 
-
 class AgentDefinition(BaseModel):
     """Declarative agent definition.
 
@@ -219,6 +218,14 @@ class AgentDefinition(BaseModel):
         if not v.replace("-", "").replace("_", "").isalnum():
             raise ValueError(f"Agent name must be alphanumeric with hyphens/underscores only: {v}")
         return v
+
+    @model_validator(mode="after")
+    def validate_mcp_server_aliases(self) -> AgentDefinition:
+        """Reject duplicate aliases before any MCP discovery occurs."""
+        aliases = [server.alias for server in self.mcp_servers]
+        if len(aliases) != len(set(aliases)):
+            raise ValueError("Agent MCP server aliases must be unique")
+        return self
 
     @field_validator("tools")
     @classmethod

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -23,6 +23,8 @@ logger = structlog.get_logger(__name__)
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, field_validator
 
+from server.app.agent.mcp_config import AgentMcpServer
+
 try:
     import yaml
 
@@ -193,6 +195,7 @@ class AgentDefinition(BaseModel):
     system_prompt: str = Field(..., min_length=1)
     tools: list[str] = Field(default_factory=list)
     skills: list[str] = Field(default_factory=list)
+    mcp_servers: list[AgentMcpServer] = Field(default_factory=list)
     memory: list[str] = Field(default_factory=list)
     subagents: list[SubagentDefinition] = Field(default_factory=list)
     async_subagents: list[AsyncSubagentConfig] = Field(default_factory=list)
@@ -414,8 +417,7 @@ class AgentDefinition(BaseModel):
             from deepagents.middleware.filesystem import FilesystemPermission
 
             spec["permissions"] = [
-                FilesystemPermission(**permission.model_dump())
-                for permission in self.permissions
+                FilesystemPermission(**permission.model_dump()) for permission in self.permissions
             ]
 
         return spec

--- a/server/app/agent/mcp_config.py
+++ b/server/app/agent/mcp_config.py
@@ -1,0 +1,86 @@
+"""Declarative, per-agent MCP configuration.
+
+MCP transport configuration is intentionally a capability of an Agent
+definition. It does not expose raw headers, credentials, callback code, or
+model-controlled endpoint selection.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class McpAuthConfig(BaseModel):
+    """A supported MCP transport authentication mode.
+
+    Profiles are opaque deployment references. Cognition never persists a
+    bearer value, provider credential, raw header, or authentication callback
+    in an Agent definition.
+    """
+
+    type: Literal["none", "mcp_oauth", "workload_token_exchange", "static_bearer"] = "none"
+    profile: str | None = Field(default=None, min_length=1, max_length=100)
+    env: str | None = Field(default=None, min_length=1, max_length=200)
+
+    @field_validator("env")
+    @classmethod
+    def validate_env_name(cls, value: str | None) -> str | None:
+        if value is not None and (not value.replace("_", "").isalnum() or value[0].isdigit()):
+            raise ValueError("auth env must be an environment-variable name, not a token value")
+        return value
+
+    @model_validator(mode="after")
+    def validate_mode(self) -> McpAuthConfig:
+        if self.type == "workload_token_exchange":
+            if self.profile is None:
+                raise ValueError("workload_token_exchange requires an opaque auth profile")
+            if self.env is not None:
+                raise ValueError("workload_token_exchange cannot use an environment token")
+        elif self.type == "static_bearer":
+            if self.env is None:
+                raise ValueError("static_bearer requires an environment-variable name")
+            if self.profile is not None:
+                raise ValueError("static_bearer cannot use an auth profile")
+        elif self.profile is not None or self.env is not None:
+            raise ValueError(f"{self.type} authentication does not accept profile or env fields")
+        return self
+
+
+class AgentMcpServer(BaseModel):
+    """One remote MCP service attached directly to an Agent definition."""
+
+    alias: str = Field(..., min_length=1, max_length=100)
+    url: str = Field(..., min_length=1, max_length=2048)
+    required: bool = True
+    transport: Literal["streamable_http"] = "streamable_http"
+    auth: McpAuthConfig = Field(default_factory=McpAuthConfig)
+
+    @field_validator("alias")
+    @classmethod
+    def validate_alias(cls, value: str) -> str:
+        if not value.replace("-", "").replace("_", "").isalnum():
+            raise ValueError("MCP server alias must be alphanumeric with hyphens/underscores only")
+        return value
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("MCP server URL must be an absolute HTTP or HTTPS URL")
+        if parsed.username or parsed.password:
+            raise ValueError("MCP server URL must not contain credentials")
+        return value
+
+    @property
+    def canonical_prefix(self) -> str:
+        """Return the stable server portion of the canonical tool identity."""
+        return self.alias
+
+
+def canonical_mcp_tool_identity(server_alias: str, provider_tool_name: str) -> tuple[str, str]:
+    """Return the canonical, model-independent identity for an MCP tool."""
+    return (server_alias, provider_tool_name)

--- a/server/app/agent/mcp_config.py
+++ b/server/app/agent/mcp_config.py
@@ -21,7 +21,7 @@ class McpAuthConfig(BaseModel):
     in an Agent definition.
     """
 
-    type: Literal["none", "mcp_oauth", "workload_token_exchange", "static_bearer"] = "none"
+    type: Literal["none", "mcp_oauth", "outbound_auth_provider", "static_bearer"] = "none"
     profile: str | None = Field(default=None, min_length=1, max_length=100)
     env: str | None = Field(default=None, min_length=1, max_length=200)
 
@@ -34,11 +34,11 @@ class McpAuthConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_mode(self) -> McpAuthConfig:
-        if self.type == "workload_token_exchange":
+        if self.type == "outbound_auth_provider":
             if self.profile is None:
-                raise ValueError("workload_token_exchange requires an opaque auth profile")
+                raise ValueError("outbound_auth_provider requires an opaque auth profile")
             if self.env is not None:
-                raise ValueError("workload_token_exchange cannot use an environment token")
+                raise ValueError("outbound_auth_provider cannot use an environment token")
         elif self.type == "static_bearer":
             if self.env is None:
                 raise ValueError("static_bearer requires an environment-variable name")

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -29,12 +29,12 @@ def test_agent_owns_a_streamable_http_mcp_server() -> None:
     assert canonical_mcp_tool_identity("github", "search_issues") == ("github", "search_issues")
 
 
-def test_workload_exchange_uses_an_opaque_profile_not_a_credential() -> None:
-    config = McpAuthConfig(type="workload_token_exchange", profile="runtime-gateway")
+def test_outbound_auth_provider_uses_an_opaque_profile_not_a_credential() -> None:
+    config = McpAuthConfig(type="outbound_auth_provider", profile="runtime-gateway")
     assert config.profile == "runtime-gateway"
 
     with pytest.raises(ValidationError, match="requires an opaque auth profile"):
-        McpAuthConfig(type="workload_token_exchange")
+        McpAuthConfig(type="outbound_auth_provider")
 
 
 @pytest.mark.parametrize(
@@ -56,3 +56,15 @@ def test_static_bearer_never_accepts_a_raw_token() -> None:
 
     with pytest.raises(ValidationError):
         McpAuthConfig(type="static_bearer", env="Bearer secret")
+
+
+def test_agent_rejects_duplicate_mcp_aliases() -> None:
+    with pytest.raises(ValidationError, match="aliases must be unique"):
+        AgentDefinition(
+            name="release-agent",
+            system_prompt="Use configured tools.",
+            mcp_servers=[
+                AgentMcpServer(alias="github", url="https://one.example.test/mcp"),
+                AgentMcpServer(alias="github", url="https://two.example.test/mcp"),
+            ],
+        )

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -1,0 +1,58 @@
+"""Tests for the v0.14 per-agent MCP configuration contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from server.app.agent.definition import AgentDefinition
+from server.app.agent.mcp_config import AgentMcpServer, McpAuthConfig, canonical_mcp_tool_identity
+
+
+def test_agent_owns_a_streamable_http_mcp_server() -> None:
+    agent = AgentDefinition(
+        name="release-agent",
+        system_prompt="Use configured tools.",
+        mcp_servers=[
+            AgentMcpServer(
+                alias="github",
+                url="https://mcp.example.test/github",
+                auth=McpAuthConfig(type="mcp_oauth"),
+            )
+        ],
+    )
+
+    assert agent.mcp_servers[0].alias == "github"
+    assert agent.mcp_servers[0].required
+    assert canonical_mcp_tool_identity("github", "search_issues") == ("github", "search_issues")
+
+
+def test_workload_exchange_uses_an_opaque_profile_not_a_credential() -> None:
+    config = McpAuthConfig(type="workload_token_exchange", profile="runtime-gateway")
+    assert config.profile == "runtime-gateway"
+
+    with pytest.raises(ValidationError, match="requires an opaque auth profile"):
+        McpAuthConfig(type="workload_token_exchange")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"alias": "bad.alias", "url": "https://mcp.example.test"},
+        {"alias": "github", "url": "file:///tmp/mcp"},
+        {"alias": "github", "url": "https://token@example.test/mcp"},
+    ],
+)
+def test_agent_mcp_rejects_untrusted_transport_configuration(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        AgentMcpServer(**kwargs)
+
+
+def test_static_bearer_never_accepts_a_raw_token() -> None:
+    config = McpAuthConfig(type="static_bearer", env="LOCAL_MCP_TOKEN")
+    assert config.env == "LOCAL_MCP_TOKEN"
+
+    with pytest.raises(ValidationError):
+        McpAuthConfig(type="static_bearer", env="Bearer secret")


### PR DESCRIPTION
## Summary
- place streamable HTTP MCP servers inside agent definitions
- support none, direct MCP OAuth, outbound auth provider, and local static bearer modes
- keep profiles opaque and reject duplicate server aliases
- reject credentials in URLs and raw environment token values

## Verification
- uv run pytest tests/unit/test_agent_mcp_config.py -q
- uv run ruff check server/app/agent/mcp_config.py server/app/agent/definition.py tests/unit/test_agent_mcp_config.py
- uv run mypy server/app/agent/mcp_config.py server/app/agent/definition.py