### PR TITLE
feat(mcp): load agent tools through secure transport

### DIFF
--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -33,7 +33,14 @@ from deepagents import create_deep_agent as _create_deep_agent
 
 logger = structlog.get_logger(__name__)
 
-from server.app.agent.mcp_client import McpServerConfig, create_mcp_client  # noqa: E402
+from server.app.agent.mcp_client import (  # noqa: E402
+    McpServerConfig,
+    _build_mcp_callbacks,
+    _build_mcp_interceptors,
+    create_mcp_client,
+    load_agent_mcp_tools,
+)
+from server.app.agent.mcp_config import AgentMcpServer  # noqa: E402
 from server.app.agent.middleware import (  # noqa: E402
     CognitionObservabilityMiddleware,
     CognitionStreamingMiddleware,
@@ -112,6 +119,7 @@ class RuntimeContext:
     system_prompt: str
     memory: tuple[str, ...]
     skills: tuple[str, ...]
+    mcp_server_aliases: tuple[str, ...]
     subagent_count: int
     async_subagents: tuple[tuple[str, str, str, str], ...]
     interrupt_on: tuple[tuple[str, str], ...]
@@ -137,6 +145,7 @@ class RuntimeContext:
         system_prompt: str | None,
         memory: Sequence[str] | None,
         skills: Sequence[str] | None,
+        agent_mcp_servers: Sequence[AgentMcpServer] | None,
         subagents: Sequence[Any] | None,
         async_subagents: Sequence[Any] | None,
         interrupt_on: Mapping[str, Any] | None,
@@ -161,6 +170,7 @@ class RuntimeContext:
             system_prompt=system_prompt or "default",
             memory=tuple(sorted(memory)) if memory else (),
             skills=tuple(sorted(skills)) if skills else (),
+            mcp_server_aliases=tuple(sorted(server.alias for server in (agent_mcp_servers or []))),
             subagent_count=len(subagents) if subagents else 0,
             async_subagents=_async_subagents_cache_key(async_subagents),
             interrupt_on=_mapping_cache_key(interrupt_on),
@@ -320,10 +330,7 @@ def _resolve_filesystem_permissions(permissions: Sequence[Any] | None) -> list[A
 
     from deepagents.middleware.filesystem import FilesystemPermission
 
-    return [
-        FilesystemPermission(**_permission_dict(permission))
-        for permission in permissions
-    ]
+    return [FilesystemPermission(**_permission_dict(permission)) for permission in permissions]
 
 
 def get_cached_agent(ctx: RuntimeContext) -> Any | None:
@@ -389,6 +396,7 @@ class CognitionAgentParams:
     tools: Sequence[Any] | None = None
     settings: Settings | None = None
     mcp_configs: Sequence[McpServerConfig] | None = None
+    agent_mcp_servers: Sequence[AgentMcpServer] | None = None
     scope: dict[str, str] | None = None
     config_store: ConfigStore | None = None
     sandbox_profile: str | None = None
@@ -523,6 +531,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
         system_prompt=params.system_prompt,
         memory=params.memory,
         skills=params.skills,
+        agent_mcp_servers=params.agent_mcp_servers,
         subagents=params.subagents,
         async_subagents=params.async_subagents,
         interrupt_on=params.interrupt_on,
@@ -623,14 +632,16 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                     artifact_store=artifact_store,
                     scope=params.scope,
                 )
-                routes.update({
-                    "/scratch/": artifact_backend,
-                    "/artifacts/": artifact_backend,
-                    "/contracts/": artifact_backend,
-                    "/evals/": artifact_backend,
-                    "/memories/": artifact_backend,
-                    "/policies/": artifact_backend,
-                })
+                routes.update(
+                    {
+                        "/scratch/": artifact_backend,
+                        "/artifacts/": artifact_backend,
+                        "/contracts/": artifact_backend,
+                        "/evals/": artifact_backend,
+                        "/memories/": artifact_backend,
+                        "/policies/": artifact_backend,
+                    }
+                )
             backend = CompositeBackend(
                 default=sandbox_backend,
                 routes=routes,
@@ -661,7 +672,9 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
         agent_permissions = list(params.permissions)
     else:
         defaults = await _defaults()
-        agent_permissions = list(defaults.permissions) if defaults and defaults.permissions else None
+        agent_permissions = (
+            list(defaults.permissions) if defaults and defaults.permissions else None
+        )
 
     if params.interrupt_on is not None:
         agent_interrupt_on = dict(params.interrupt_on)
@@ -709,12 +722,17 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
     agent_tools = list(params.tools) if params.tools else []
     agent_tools.extend(built_in_tools)
 
-    if params.mcp_configs:
-        from server.app.agent.mcp_client import (
-            _build_mcp_callbacks,
-            _build_mcp_interceptors,
+    if params.agent_mcp_servers:
+        mcp_callbacks = _build_mcp_callbacks()
+        mcp_interceptors = _build_mcp_interceptors(params.scope)
+        mcp_tools = await load_agent_mcp_tools(
+            params.agent_mcp_servers,
+            callbacks=mcp_callbacks,
+            tool_interceptors=mcp_interceptors,
         )
-
+        agent_tools.extend(mcp_tools)
+        logger.info("agent_mcp_tools_loaded", count=len(mcp_tools))
+    elif params.mcp_configs:
         enabled_configs = [c for c in params.mcp_configs if c.enabled]
         if enabled_configs:
             try:
@@ -737,9 +755,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                 create_summarization_tool_middleware,
             )
 
-            agent_middleware.append(
-                create_summarization_tool_middleware(params.model, backend)
-            )
+            agent_middleware.append(create_summarization_tool_middleware(params.model, backend))
         except Exception as e:
             logger.warning("Failed to add Deep Agents summarization tool", error=str(e))
 

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -398,6 +398,8 @@ class CognitionAgentParams:
     mcp_configs: Sequence[McpServerConfig] | None = None
     agent_mcp_servers: Sequence[AgentMcpServer] | None = None
     scope: dict[str, str] | None = None
+    agent_identity: str | None = None
+    runtime_snapshot: str | None = None
     config_store: ConfigStore | None = None
     sandbox_profile: str | None = None
     sandbox_execution_role_arn: str | None = None
@@ -724,11 +726,12 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
 
     if params.agent_mcp_servers:
         mcp_callbacks = _build_mcp_callbacks()
-        mcp_interceptors = _build_mcp_interceptors(params.scope)
         mcp_tools = await load_agent_mcp_tools(
             params.agent_mcp_servers,
             callbacks=mcp_callbacks,
-            tool_interceptors=mcp_interceptors,
+            agent_identity=params.agent_identity or "",
+            runtime_snapshot=params.runtime_snapshot or "",
+            trusted_context=params.scope or {},
         )
         agent_tools.extend(mcp_tools)
         logger.info("agent_mcp_tools_loaded", count=len(mcp_tools))

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -10,6 +10,7 @@ Security stance:
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -24,7 +25,18 @@ from langchain_mcp_adapters.sessions import (
 from mcp.types import LoggingMessageNotificationParams
 from pydantic import BaseModel, Field, field_validator
 
+from server.app.agent.mcp_config import AgentMcpServer
+
 logger = structlog.get_logger(__name__)
+
+
+class McpServerUnavailableError(RuntimeError):
+    """A required MCP server could not be discovered without exposing secrets."""
+
+    def __init__(self, alias: str, category: str) -> None:
+        super().__init__(f"Required MCP server '{alias}' is unavailable ({category})")
+        self.alias = alias
+        self.category = category
 
 
 class McpServerConfig(BaseModel):
@@ -84,6 +96,80 @@ def create_mcp_client(
         tool_interceptors=tool_interceptors,
         tool_name_prefix=True,
     )
+
+
+def create_agent_mcp_client(
+    config: AgentMcpServer,
+    *,
+    callbacks: Callbacks | None = None,
+    tool_interceptors: list[ToolCallInterceptor] | None = None,
+) -> MultiServerMCPClient:
+    """Create a client for exactly one validated Agent MCP server.
+
+    Discovery is deliberately isolated per server. The caller applies required
+    versus optional failure semantics without letting one unavailable optional
+    service remove tools from healthy services.
+    """
+    headers: dict[str, str] | None = None
+    if config.auth.type == "static_bearer":
+        assert config.auth.env is not None
+        token = os.environ.get(config.auth.env)
+        if not token:
+            raise McpServerUnavailableError(config.alias, "auth_unavailable")
+        headers = {"Authorization": f"Bearer {token}"}
+    elif config.auth.type in {"mcp_oauth", "workload_token_exchange"}:
+        # These modes require the v0.14 transport-security provider. Do not
+        # downgrade a protected endpoint to anonymous transport while wiring is
+        # incomplete.
+        raise McpServerUnavailableError(config.alias, "auth_provider_unavailable")
+
+    connection: StreamableHttpConnection = {"transport": "streamable_http", "url": config.url}
+    if headers:
+        connection["headers"] = headers
+    return MultiServerMCPClient(
+        connections={config.alias: connection},
+        callbacks=callbacks,
+        tool_interceptors=tool_interceptors,
+        tool_name_prefix=True,
+    )
+
+
+async def load_agent_mcp_tools(
+    configs: Sequence[AgentMcpServer],
+    *,
+    callbacks: Callbacks | None = None,
+    tool_interceptors: list[ToolCallInterceptor] | None = None,
+) -> list[Any]:
+    """Discover agent MCP tools one server at a time with fail-closed semantics."""
+    tools: list[Any] = []
+    identities: set[tuple[str, str]] = set()
+    for config in configs:
+        try:
+            discovered = await create_agent_mcp_client(
+                config,
+                callbacks=callbacks,
+                tool_interceptors=tool_interceptors,
+            ).get_tools()
+            for tool in discovered:
+                provider_name = str(getattr(tool, "name", ""))
+                identity = (config.alias, provider_name)
+                if identity in identities:
+                    raise McpServerUnavailableError(config.alias, "duplicate_tool_identity")
+                identities.add(identity)
+            tools.extend(discovered)
+        except McpServerUnavailableError:
+            if config.required:
+                raise
+            logger.warning("optional_mcp_server_unavailable", server=config.alias)
+        except Exception as exc:
+            if config.required:
+                raise McpServerUnavailableError(config.alias, "discovery_failed") from exc
+            logger.warning(
+                "optional_mcp_server_unavailable",
+                server=config.alias,
+                error_type=type(exc).__name__,
+            )
+    return tools
 
 
 def _build_mcp_callbacks() -> Callbacks:

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any, Literal
 
 import structlog
@@ -26,6 +27,13 @@ from mcp.types import LoggingMessageNotificationParams
 from pydantic import BaseModel, Field, field_validator
 
 from server.app.agent.mcp_config import AgentMcpServer
+from server.app.agent.outbound_auth import (
+    OutboundAuthError,
+    OutboundAuthProviderRegistry,
+    OutboundAuthRequest,
+    OutboundAuthResult,
+    get_outbound_auth_provider_registry,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -103,6 +111,7 @@ def create_agent_mcp_client(
     *,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    outbound_auth: OutboundAuthResult | None = None,
 ) -> MultiServerMCPClient:
     """Create a client for exactly one validated Agent MCP server.
 
@@ -117,7 +126,7 @@ def create_agent_mcp_client(
         if not token:
             raise McpServerUnavailableError(config.alias, "auth_unavailable")
         headers = {"Authorization": f"Bearer {token}"}
-    elif config.auth.type in {"mcp_oauth", "workload_token_exchange"}:
+    elif config.auth.type == "mcp_oauth":
         # These modes require the v0.14 transport-security provider. Do not
         # downgrade a protected endpoint to anonymous transport while wiring is
         # incomplete.
@@ -126,6 +135,11 @@ def create_agent_mcp_client(
     connection: StreamableHttpConnection = {"transport": "streamable_http", "url": config.url}
     if headers:
         connection["headers"] = headers
+    if outbound_auth is not None:
+        if outbound_auth.headers:
+            connection["headers"] = dict(outbound_auth.headers)
+        if outbound_auth.auth is not None:
+            connection["auth"] = outbound_auth.auth
     return MultiServerMCPClient(
         connections={config.alias: connection},
         callbacks=callbacks,
@@ -139,16 +153,31 @@ async def load_agent_mcp_tools(
     *,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    agent_identity: str = "",
+    runtime_snapshot: str = "",
+    trusted_context: dict[str, str] | None = None,
+    deadline: datetime | None = None,
+    auth_providers: OutboundAuthProviderRegistry | None = None,
 ) -> list[Any]:
     """Discover agent MCP tools one server at a time with fail-closed semantics."""
     tools: list[Any] = []
     identities: set[tuple[str, str]] = set()
+    registry = auth_providers or get_outbound_auth_provider_registry()
     for config in configs:
         try:
+            outbound_auth = await _resolve_outbound_auth(
+                config,
+                registry=registry,
+                agent_identity=agent_identity,
+                runtime_snapshot=runtime_snapshot,
+                trusted_context=trusted_context or {},
+                deadline=deadline,
+            )
             discovered = await create_agent_mcp_client(
                 config,
                 callbacks=callbacks,
                 tool_interceptors=tool_interceptors,
+                outbound_auth=outbound_auth,
             ).get_tools()
             for tool in discovered:
                 provider_name = str(getattr(tool, "name", ""))
@@ -170,6 +199,41 @@ async def load_agent_mcp_tools(
                 error_type=type(exc).__name__,
             )
     return tools
+
+
+async def _resolve_outbound_auth(
+    config: AgentMcpServer,
+    *,
+    registry: OutboundAuthProviderRegistry,
+    agent_identity: str,
+    runtime_snapshot: str,
+    trusted_context: dict[str, str],
+    deadline: datetime | None,
+) -> OutboundAuthResult | None:
+    """Resolve and validate one provider result outside model-controlled data."""
+    if config.auth.type != "outbound_auth_provider":
+        return None
+    assert config.auth.profile is not None
+    try:
+        registered = registry.resolve(config.auth.profile)
+        result = await registered.provider.get_auth(
+            OutboundAuthRequest(
+                agent_identity=agent_identity,
+                runtime_snapshot=runtime_snapshot,
+                server_alias=config.alias,
+                trusted_context=trusted_context,
+                deadline=deadline,
+            )
+        )
+    except OutboundAuthError as exc:
+        raise McpServerUnavailableError(config.alias, exc.category) from exc
+    except Exception as exc:
+        raise McpServerUnavailableError(config.alias, "auth_provider_failed") from exc
+
+    disallowed = {header.lower() for header in result.headers} - registered.allowed_headers
+    if disallowed:
+        raise McpServerUnavailableError(config.alias, "auth_header_not_allowlisted")
+    return result
 
 
 def _build_mcp_callbacks() -> Callbacks:

--- a/server/app/agent/outbound_auth.py
+++ b/server/app/agent/outbound_auth.py
@@ -1,0 +1,94 @@
+"""Builder-installed MCP transport authentication boundary.
+
+Cognition owns the call site and validates the returned transport shape. A
+builder owns credential acquisition, identity-provider choices, and any
+short-lived in-memory token cache.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Protocol
+
+import httpx
+
+
+@dataclass(frozen=True)
+class OutboundAuthRequest:
+    """Trusted data supplied to a builder auth provider for one MCP operation."""
+
+    agent_identity: str
+    runtime_snapshot: str
+    server_alias: str
+    trusted_context: Mapping[str, str]
+    deadline: datetime | None
+
+
+@dataclass(frozen=True)
+class OutboundAuthResult:
+    """Bounded transport authentication material for one MCP connection."""
+
+    auth: httpx.Auth | None = None
+    headers: Mapping[str, str] = field(default_factory=dict)
+    expires_at: datetime | None = None
+
+
+class OutboundAuthProvider(Protocol):
+    """Resolve outbound authentication without exposing credentials to Cognition data."""
+
+    async def get_auth(self, request: OutboundAuthRequest) -> OutboundAuthResult:
+        """Return auth material or raise ``OutboundAuthError`` with a redacted category."""
+
+
+class OutboundAuthError(RuntimeError):
+    """A redacted outbound-authentication failure."""
+
+    def __init__(self, category: str) -> None:
+        super().__init__(category)
+        self.category = category
+
+
+@dataclass(frozen=True)
+class RegisteredOutboundAuthProvider:
+    """A provider plus its deployment-controlled header projection allowlist."""
+
+    provider: OutboundAuthProvider
+    allowed_headers: frozenset[str]
+
+
+class OutboundAuthProviderRegistry:
+    """In-memory registry populated by the embedding application at startup."""
+
+    def __init__(self) -> None:
+        self._providers: dict[str, RegisteredOutboundAuthProvider] = {}
+
+    def register(
+        self,
+        profile: str,
+        provider: OutboundAuthProvider,
+        *,
+        allowed_headers: frozenset[str] = frozenset(),
+    ) -> None:
+        """Install a provider for an opaque, deployment-owned profile."""
+        normalized_headers = frozenset(header.lower() for header in allowed_headers)
+        self._providers[profile] = RegisteredOutboundAuthProvider(
+            provider=provider,
+            allowed_headers=normalized_headers,
+        )
+
+    def resolve(self, profile: str) -> RegisteredOutboundAuthProvider:
+        """Return an installed provider or fail closed without revealing configuration."""
+        try:
+            return self._providers[profile]
+        except KeyError as exc:
+            raise OutboundAuthError("auth_provider_unavailable") from exc
+
+
+_default_registry = OutboundAuthProviderRegistry()
+
+
+def get_outbound_auth_provider_registry() -> OutboundAuthProviderRegistry:
+    """Return the process-local registry for embedding-time installation."""
+    return _default_registry

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -509,6 +509,8 @@ class DeepAgentStreamingService:
                     agent_cfg.agent_def.mcp_servers if agent_cfg.agent_def else None
                 ),
                 scope=effective_scope,
+                agent_identity=session.agent_name if session else None,
+                runtime_snapshot=model_cache_key,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
                 sandbox_execution_role_arn=agent_cfg.sandbox_execution_role_arn,
@@ -755,6 +757,8 @@ class DeepAgentStreamingService:
                     agent_cfg.agent_def.mcp_servers if agent_cfg.agent_def else None
                 ),
                 scope=effective_scope,
+                agent_identity=session.agent_name,
+                runtime_snapshot=model_cache_key,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
                 sandbox_execution_role_arn=agent_cfg.sandbox_execution_role_arn,

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -354,9 +354,7 @@ class DeepAgentStreamingService:
         )
         workspace_base = str(self.settings.workspace_path)
         resolved.subagents = [
-            s.to_subagent(base_path=workspace_base)
-            for s in all_defs
-            if s.name != agent_def.name
+            s.to_subagent(base_path=workspace_base) for s in all_defs if s.name != agent_def.name
         ]
 
         if agent_def.async_subagents:
@@ -467,7 +465,6 @@ class DeepAgentStreamingService:
                 metadata=session.metadata if session else None,
             )
 
-            mcp_configs = await self._resolve_mcp_configs(scope=effective_scope)
             context_policy = _effective_context_policy(
                 agent_cfg.context_policy,
                 agent_cfg.tool_token_limit_before_evict,
@@ -508,7 +505,9 @@ class DeepAgentStreamingService:
                 excluded_tools=agent_cfg.excluded_tools,
                 blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
-                mcp_configs=mcp_configs or None,
+                agent_mcp_servers=(
+                    agent_cfg.agent_def.mcp_servers if agent_cfg.agent_def else None
+                ),
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -610,7 +609,9 @@ class DeepAgentStreamingService:
                 yield UsageEvent(
                     input_tokens=acc.input_tokens,
                     output_tokens=acc.output_tokens,
-                    estimated_cost=self._estimate_cost(acc.input_tokens, acc.output_tokens, provider),
+                    estimated_cost=self._estimate_cost(
+                        acc.input_tokens, acc.output_tokens, provider
+                    ),
                     provider=provider,
                     model=model_id,
                 )
@@ -712,7 +713,6 @@ class DeepAgentStreamingService:
                 agent_name=session.agent_name,
                 metadata=session.metadata,
             )
-            mcp_configs = await self._resolve_mcp_configs(scope=effective_scope)
             context_policy = _effective_context_policy(
                 agent_cfg.context_policy,
                 agent_cfg.tool_token_limit_before_evict,
@@ -751,7 +751,9 @@ class DeepAgentStreamingService:
                 excluded_tools=agent_cfg.excluded_tools,
                 blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
-                mcp_configs=mcp_configs or None,
+                agent_mcp_servers=(
+                    agent_cfg.agent_def.mcp_servers if agent_cfg.agent_def else None
+                ),
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -854,9 +856,7 @@ class DeepAgentStreamingService:
         if not isinstance(checkpoint_messages, list):
             return 0
         if not checkpoint_messages:
-            existing_messages = await self.storage_backend.list_messages_for_session(
-                session_id
-            )
+            existing_messages = await self.storage_backend.list_messages_for_session(session_id)
             return len(existing_messages)
 
         rebuilt_count = await self.storage_backend.rebuild_message_projection(
@@ -1318,9 +1318,7 @@ class SessionAgentManager:
                 metadata=self._sandbox_runtime_metadata(backend, session_id=session_id),
             ),
         )
-        self._sandbox_emitted_lifecycle_phases.setdefault(session_id, set()).add(
-            "teardown_started"
-        )
+        self._sandbox_emitted_lifecycle_phases.setdefault(session_id, set()).add("teardown_started")
         if hasattr(backend, "terminate"):
             try:
                 backend.terminate()

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -11,6 +11,11 @@ from pydantic import ValidationError
 from server.app.agent.definition import AgentDefinition
 from server.app.agent.mcp_client import McpServerUnavailableError, load_agent_mcp_tools
 from server.app.agent.mcp_config import AgentMcpServer, McpAuthConfig, canonical_mcp_tool_identity
+from server.app.agent.outbound_auth import (
+    OutboundAuthProviderRegistry,
+    OutboundAuthRequest,
+    OutboundAuthResult,
+)
 
 
 def test_agent_owns_a_streamable_http_mcp_server() -> None:
@@ -31,12 +36,12 @@ def test_agent_owns_a_streamable_http_mcp_server() -> None:
     assert canonical_mcp_tool_identity("github", "search_issues") == ("github", "search_issues")
 
 
-def test_workload_exchange_uses_an_opaque_profile_not_a_credential() -> None:
-    config = McpAuthConfig(type="workload_token_exchange", profile="runtime-gateway")
+def test_outbound_auth_provider_uses_an_opaque_profile_not_a_credential() -> None:
+    config = McpAuthConfig(type="outbound_auth_provider", profile="runtime-gateway")
     assert config.profile == "runtime-gateway"
 
     with pytest.raises(ValidationError, match="requires an opaque auth profile"):
-        McpAuthConfig(type="workload_token_exchange")
+        McpAuthConfig(type="outbound_auth_provider")
 
 
 @pytest.mark.parametrize(
@@ -58,6 +63,69 @@ def test_static_bearer_never_accepts_a_raw_token() -> None:
 
     with pytest.raises(ValidationError):
         McpAuthConfig(type="static_bearer", env="Bearer secret")
+
+
+def test_agent_rejects_duplicate_mcp_aliases() -> None:
+    with pytest.raises(ValidationError, match="aliases must be unique"):
+        AgentDefinition(
+            name="release-agent",
+            system_prompt="Use configured tools.",
+            mcp_servers=[
+                AgentMcpServer(alias="github", url="https://one.example.test/mcp"),
+                AgentMcpServer(alias="github", url="https://two.example.test/mcp"),
+            ],
+        )
+
+
+class _AllowlistedProvider:
+    async def get_auth(self, request: OutboundAuthRequest) -> OutboundAuthResult:
+        assert request.agent_identity == "agent-1"
+        assert request.trusted_context == {"tenant": "acme"}
+        return OutboundAuthResult(headers={"X-Builder-Route": "github"})
+
+
+class _UnrestrictedHeaderProvider:
+    async def get_auth(self, request: OutboundAuthRequest) -> OutboundAuthResult:
+        del request
+        return OutboundAuthResult(headers={"X-Builder-Route": "github"})
+
+
+@pytest.mark.asyncio
+async def test_outbound_auth_provider_uses_only_allowlisted_headers() -> None:
+    server = AgentMcpServer(
+        alias="github",
+        url="https://mcp.example.test/github",
+        auth=McpAuthConfig(type="outbound_auth_provider", profile="gateway"),
+    )
+    registry = OutboundAuthProviderRegistry()
+    registry.register("gateway", _AllowlistedProvider(), allowed_headers=frozenset({"X-Builder-Route"}))
+    client = MagicMock()
+    client.get_tools = AsyncMock(return_value=[])
+
+    with patch("server.app.agent.mcp_client.create_agent_mcp_client", return_value=client) as factory:
+        await load_agent_mcp_tools(
+            [server],
+            agent_identity="agent-1",
+            runtime_snapshot="snapshot-1",
+            trusted_context={"tenant": "acme"},
+            auth_providers=registry,
+        )
+
+    assert factory.call_args.kwargs["outbound_auth"].headers == {"X-Builder-Route": "github"}
+
+
+@pytest.mark.asyncio
+async def test_outbound_auth_provider_rejects_non_allowlisted_headers() -> None:
+    server = AgentMcpServer(
+        alias="github",
+        url="https://mcp.example.test/github",
+        auth=McpAuthConfig(type="outbound_auth_provider", profile="gateway"),
+    )
+    registry = OutboundAuthProviderRegistry()
+    registry.register("gateway", _UnrestrictedHeaderProvider())
+
+    with pytest.raises(McpServerUnavailableError, match="auth_header_not_allowlisted"):
+        await load_agent_mcp_tools([server], auth_providers=registry)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
 from server.app.agent.definition import AgentDefinition
+from server.app.agent.mcp_client import McpServerUnavailableError, load_agent_mcp_tools
 from server.app.agent.mcp_config import AgentMcpServer, McpAuthConfig, canonical_mcp_tool_identity
 
 
@@ -29,12 +31,12 @@ def test_agent_owns_a_streamable_http_mcp_server() -> None:
     assert canonical_mcp_tool_identity("github", "search_issues") == ("github", "search_issues")
 
 
-def test_outbound_auth_provider_uses_an_opaque_profile_not_a_credential() -> None:
-    config = McpAuthConfig(type="outbound_auth_provider", profile="runtime-gateway")
+def test_workload_exchange_uses_an_opaque_profile_not_a_credential() -> None:
+    config = McpAuthConfig(type="workload_token_exchange", profile="runtime-gateway")
     assert config.profile == "runtime-gateway"
 
     with pytest.raises(ValidationError, match="requires an opaque auth profile"):
-        McpAuthConfig(type="outbound_auth_provider")
+        McpAuthConfig(type="workload_token_exchange")
 
 
 @pytest.mark.parametrize(
@@ -58,13 +60,31 @@ def test_static_bearer_never_accepts_a_raw_token() -> None:
         McpAuthConfig(type="static_bearer", env="Bearer secret")
 
 
-def test_agent_rejects_duplicate_mcp_aliases() -> None:
-    with pytest.raises(ValidationError, match="aliases must be unique"):
-        AgentDefinition(
-            name="release-agent",
-            system_prompt="Use configured tools.",
-            mcp_servers=[
-                AgentMcpServer(alias="github", url="https://one.example.test/mcp"),
-                AgentMcpServer(alias="github", url="https://two.example.test/mcp"),
-            ],
-        )
+@pytest.mark.asyncio
+async def test_optional_server_failure_preserves_healthy_tools() -> None:
+    healthy = AgentMcpServer(alias="healthy", url="https://healthy.example.test")
+    optional = AgentMcpServer(alias="optional", url="https://optional.example.test", required=False)
+    healthy_client = MagicMock()
+    healthy_client.get_tools = AsyncMock(return_value=[MagicMock(name="search")])
+
+    with patch(
+        "server.app.agent.mcp_client.create_agent_mcp_client",
+        side_effect=[healthy_client, McpServerUnavailableError("optional", "discovery_failed")],
+    ):
+        tools = await load_agent_mcp_tools([healthy, optional])
+
+    assert len(tools) == 1
+
+
+@pytest.mark.asyncio
+async def test_required_server_failure_stops_before_model_execution() -> None:
+    required = AgentMcpServer(alias="required", url="https://required.example.test")
+
+    with (
+        patch(
+            "server.app.agent.mcp_client.create_agent_mcp_client",
+            side_effect=McpServerUnavailableError("required", "discovery_failed"),
+        ),
+        pytest.raises(McpServerUnavailableError, match="required"),
+    ):
+        await load_agent_mcp_tools([required])


### PR DESCRIPTION
## Summary
- discover MCP servers independently per agent
- preserve healthy optional tools and fail required servers closed
- add builder-installed OutboundAuthProvider registry
- restrict provider headers to deployment allowlists
- pass trusted runtime context without injecting scope into model tool arguments

## Verification
- uv run pytest tests/unit/test_agent_mcp_config.py tests/unit/test_composite_backend_skill_routing.py -q
- uv run ruff check server/app/agent/cognition_agent.py server/app/agent/mcp_client.py server/app/agent/outbound_auth.py server/app/llm/deep_agent_service.py tests/unit/test_agent_mcp_config.py
- uv run mypy server/app/agent/cognition_agent.py server/app/agent/mcp_client.py server/app/agent/outbound_auth.py server/app/llm/deep_agent_service.py