### PR TITLE
feat(skills): support Deep Agents skill bundles

### DIFF
--- a/server/app/agent/skills_backend.py
+++ b/server/app/agent/skills_backend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import structlog
 from deepagents.backends.protocol import (
@@ -79,7 +79,7 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         return file_infos
 
     async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        """Download SKILL.md file content for SkillsMiddleware.
+        """Download bundle file content for SkillsMiddleware and file tools.
 
         SkillsMiddleware calls this to get the actual skill content for parsing
         YAML frontmatter.
@@ -93,21 +93,21 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         responses: list[FileDownloadResponse] = []
 
         for file_path in paths:
-            # Extract skill name from path like "/web-research/SKILL.md"
-            # (CompositeBackend has already stripped the /skills/api/ prefix)
-            if not file_path.startswith("/") or not file_path.endswith("/SKILL.md"):
+            parsed = _parse_bundle_path(file_path)
+            if parsed is None:
                 responses.append(FileDownloadResponse(path=file_path, error="invalid_path"))
                 continue
-
-            # Remove leading slash and /SKILL.md suffix to get skill name
-            skill_name = file_path[1 : -len("/SKILL.md")]
+            skill_name, relative_path = parsed
 
             try:
                 skill = await self._registry.get_skill(skill_name, scope=self._scope)
                 if skill is None or not skill.enabled:
                     responses.append(FileDownloadResponse(path=file_path, error="file_not_found"))
                 else:
-                    content = skill.content or ""
+                    content = _bundle_content(skill, relative_path)
+                    if content is None:
+                        responses.append(FileDownloadResponse(path=file_path, error="file_not_found"))
+                        continue
                     responses.append(
                         FileDownloadResponse(
                             path=file_path,
@@ -150,18 +150,19 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         Returns:
             Formatted file content with line numbers, or an error result.
         """
-        # Reuse the same logic as adownload_files but return formatted string
-        if not file_path.startswith("/") or not file_path.endswith("/SKILL.md"):
+        parsed = _parse_bundle_path(file_path)
+        if parsed is None:
             return ReadResult(error=f"Invalid path {file_path}")
-
-        skill_name = file_path[1 : -len("/SKILL.md")]
+        skill_name, relative_path = parsed
 
         try:
             skill = await self._registry.get_skill(skill_name, scope=self._scope)
             if skill is None or not skill.enabled:
                 return ReadResult(error=f"Skill not found: {skill_name}")
 
-            content = skill.content or ""
+            content = _bundle_content(skill, relative_path)
+            if content is None:
+                return ReadResult(error=f"Skill bundle file not found: {relative_path}")
             lines = content.splitlines()
 
             # Apply offset and limit
@@ -214,3 +215,20 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
     # are intentionally not implemented. SkillsMiddleware only needs als_info,
     # adownload_files, and aread. All other paths are handled by the default
     # sandbox backend via CompositeBackend routing.
+
+
+def _parse_bundle_path(path: str) -> tuple[str, str] | None:
+    """Parse a route-relative skill bundle path without allowing traversal."""
+    if not path.startswith("/"):
+        return None
+    parts = path.lstrip("/").split("/")
+    if len(parts) < 2 or any(part in {"", ".", ".."} for part in parts):
+        return None
+    return parts[0], "/".join(parts[1:])
+
+
+def _bundle_content(skill: Any, relative_path: str) -> str | None:
+    """Return the primary document or a declared supporting bundle file."""
+    if relative_path == "SKILL.md":
+        return skill.content or ""
+    return cast(dict[str, str], skill.files).get(relative_path)

--- a/server/app/bootstrap.py
+++ b/server/app/bootstrap.py
@@ -250,6 +250,15 @@ async def seed_skills_from_sources(
                 continue
 
             content = skill_md.read_text(encoding="utf-8")
+            files: dict[str, str] = {}
+            for candidate in skill_dir.rglob("*"):
+                if not candidate.is_file() or candidate == skill_md:
+                    continue
+                relative_path = candidate.relative_to(skill_dir).as_posix()
+                try:
+                    files[relative_path] = candidate.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    logger.warning("Skipping non-text skill bundle file", path=str(candidate))
             name = skill_dir.name
             description: str | None = None
             try:
@@ -270,6 +279,7 @@ async def seed_skills_from_sources(
                 enabled=True,
                 description=description,
                 content=content,
+                files=files,
                 scope={},
                 source="file",
             )

--- a/server/app/storage/config_models.py
+++ b/server/app/storage/config_models.py
@@ -213,6 +213,10 @@ class SkillDefinition(BaseModel):
     enabled: bool = Field(default=True)
     description: str | None = Field(default=None)
     content: str | None = Field(default=None)
+    files: dict[str, str] = Field(
+        default_factory=dict,
+        description="Supporting bundle files keyed by safe, relative POSIX paths.",
+    )
     scope: dict[str, str] = Field(default_factory=dict)
     source: Literal["file", "api"] = Field(default="file")
 
@@ -223,6 +227,18 @@ class SkillDefinition(BaseModel):
         if not v.replace("-", "").replace("_", "").isalnum():
             raise ValueError(f"Skill name must be alphanumeric with hyphens/underscores only: {v}")
         return v
+
+    @field_validator("files")
+    @classmethod
+    def validate_bundle_files(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject absolute, traversal, and non-text bundle entries."""
+        for path, content in value.items():
+            parts = path.split("/")
+            if not path or path.startswith("/") or any(part in {"", ".", ".."} for part in parts):
+                raise ValueError("Skill bundle file paths must be safe relative POSIX paths")
+            if not isinstance(content, str):
+                raise ValueError("Skill bundle file contents must be text")
+        return value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -198,6 +198,8 @@ class TestSeedSkillsFromSources:
             "---\nname: clean-code\ndescription: Use this skill for clean code.\n---\n\n# Clean Code\n",
             encoding="utf-8",
         )
+        (source_dir / "references").mkdir()
+        (source_dir / "references" / "guide.md").write_text("Supporting guide", encoding="utf-8")
 
         store = DefaultConfigStore(MemoryConfigRegistry(), workspace_path=tmp_path)
         inserted = await seed_skills_from_sources(
@@ -211,6 +213,7 @@ class TestSeedSkillsFromSources:
         assert skill is not None
         assert skill.source == "file"
         assert skill.description == "Use this skill for clean code."
+        assert skill.files == {"references/guide.md": "Supporting guide"}
 
     @pytest.mark.asyncio
     async def test_does_not_override_api_skill(self, tmp_path: Path) -> None:

--- a/tests/unit/test_skills_backend.py
+++ b/tests/unit/test_skills_backend.py
@@ -149,8 +149,8 @@ class TestAdownloadFiles:
         assert result[0].error == "file_not_found"
 
     async def test_returns_invalid_path_for_malformed_paths(self, backend):
-        """Should return invalid_path for non-SKILL.md paths."""
-        result = await backend.adownload_files(["/some/other/file.txt"])
+        """Should return invalid_path for paths outside a skill bundle."""
+        result = await backend.adownload_files(["/../file.txt"])
         assert result[0].error == "invalid_path"
 
     async def test_handles_empty_content(self, registry, backend):
@@ -189,6 +189,19 @@ class TestAdownloadFiles:
         assert result[0].content == b"# skill-a"
         assert result[1].content == b"# skill-b"
         assert result[2].error == "file_not_found"
+
+    async def test_downloads_skill_supporting_file(self, registry, backend):
+        await registry.upsert_skill(
+            SkillDefinition(
+                name="bundle-skill",
+                path="/skills/api/bundle-skill/SKILL.md",
+                content="# Bundle",
+                files={"references/guide.md": "Supporting guidance"},
+            )
+        )
+
+        result = await backend.adownload_files(["/bundle-skill/references/guide.md"])
+        assert result[0].content == b"Supporting guidance"
 
 
 class TestAread:
@@ -242,6 +255,19 @@ class TestAread:
         assert lines[0].startswith("     2")
         assert lines[1].startswith("     3")
 
+    async def test_reads_supporting_file(self, registry, backend):
+        await registry.upsert_skill(
+            SkillDefinition(
+                name="bundle-skill",
+                path="/skills/api/bundle-skill/SKILL.md",
+                content="# Bundle",
+                files={"examples/example.txt": "one\ntwo"},
+            )
+        )
+
+        result = await backend.aread("/bundle-skill/examples/example.txt")
+        assert "one" in self._content(result)
+
     async def test_returns_error_for_missing_skill(self, backend):
         """Should return error for non-existent skill."""
         result = await backend.aread("/missing/SKILL.md")
@@ -264,7 +290,7 @@ class TestAread:
 
     async def test_returns_error_for_invalid_path(self, backend):
         """Should return error for malformed path."""
-        result = await backend.aread("/invalid/path.txt")
+        result = await backend.aread("/invalid/../path.txt")
         assert result.error is not None
         assert "Invalid path" in result.error
 


### PR DESCRIPTION
## Summary
- persist safe supporting text files alongside each SKILL.md registry record
- seed nested bundle files from configured skill sources
- expose supporting files through the scoped Deep Agents backend route
- reject traversal paths in stored and requested bundle paths

## Verification
- uv run pytest tests/unit/test_skills_backend.py tests/unit/test_config_registry.py tests/unit/test_bootstrap.py -q
- uv run ruff check server/app/agent/skills_backend.py server/app/bootstrap.py server/app/storage/config_models.py tests/unit/test_skills_backend.py tests/unit/test_bootstrap.py
- uv run mypy server/app/agent/skills_backend.py server/app/bootstrap.py server/app/storage/config_models.py