### PR TITLE
refactor(mcp): remove legacy global persistence

### DIFF
--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -684,7 +684,6 @@ class GlobalAgentDefaultsResponse(BaseModel):
     tool_token_limit_before_evict: int | None = None
     context_policy: ContextPolicy | None = None
     recursion_limit: int
-    mcp_servers: dict[str, Any] = Field(default_factory=dict)
 
 
 class GlobalAgentDefaultsUpdate(BaseModel):
@@ -700,7 +699,6 @@ class GlobalAgentDefaultsUpdate(BaseModel):
     tool_token_limit_before_evict: int | None = None
     context_policy: ContextPolicy | None = None
     recursion_limit: int | None = None
-    mcp_servers: dict[str, Any] | None = None
 
 
 class McpServerCreate(BaseModel):

--- a/server/app/api/routes/config.py
+++ b/server/app/api/routes/config.py
@@ -136,7 +136,6 @@ def _agent_defaults_response(defaults: Any) -> GlobalAgentDefaultsResponse:
         tool_token_limit_before_evict=defaults.tool_token_limit_before_evict,
         context_policy=defaults.context_policy,
         recursion_limit=defaults.recursion_limit,
-        mcp_servers=dict(defaults.mcp_servers),
     )
 
 

--- a/server/app/storage/config_models.py
+++ b/server/app/storage/config_models.py
@@ -242,41 +242,6 @@ class SkillDefinition(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# MCP Server
-# ---------------------------------------------------------------------------
-
-
-class McpServerRegistration(BaseModel):
-    """An MCP (Model Context Protocol) server registered in the config registry.
-
-    Attributes:
-        name: Server identifier.
-        url: HTTP/HTTPS URL for the MCP server.
-        headers: Optional request headers (e.g. auth tokens).
-        enabled: Whether this server is active.
-        scope: Scope this entry applies to.
-        source: "file" or "api".
-        transport: Transport protocol ("sse" or "streamable_http").
-    """
-
-    name: str = Field(..., min_length=1, max_length=100)
-    url: str = Field(..., min_length=1)
-    headers: dict[str, str] = Field(default_factory=dict)
-    enabled: bool = Field(default=True)
-    scope: dict[str, str] = Field(default_factory=dict)
-    source: Literal["file", "api"] = Field(default="file")
-    transport: Literal["sse", "streamable_http"] = Field(default="sse")
-
-    @field_validator("url")
-    @classmethod
-    def validate_url(cls, v: str) -> str:
-        """Ensure URL uses HTTP/HTTPS only."""
-        if not v.startswith(("http://", "https://")):
-            raise ValueError(f"MCP server URL must start with http:// or https://, got: {v!r}")
-        return v
-
-
-# ---------------------------------------------------------------------------
 # Sandbox Profile
 # ---------------------------------------------------------------------------
 
@@ -585,7 +550,6 @@ class GlobalAgentDefaults(BaseModel):
         interrupt_on: Tool-name -> bool or rich human-in-the-loop config.
         permissions: Deep Agents filesystem permission rules.
         recursion_limit: Max ReAct recursion depth.
-        mcp_servers: MCP server config dicts keyed by name.
     """
 
     memory: list[str] = Field(default_factory=lambda: ["AGENTS.md"])
@@ -598,7 +562,6 @@ class GlobalAgentDefaults(BaseModel):
     tool_token_limit_before_evict: int | None = Field(default=None, gt=0)
     context_policy: ContextPolicy | None = Field(default=None)
     recursion_limit: int = Field(default=1000, gt=0)
-    mcp_servers: dict[str, Any] = Field(default_factory=dict)
 
 
 __all__ = [
@@ -610,7 +573,6 @@ __all__ = [
     "GlobalAgentDefaults",
     "GlobalProviderDefaults",
     "LambdaMicroVmCloudWatchLogging",
-    "McpServerRegistration",
     "OperationType",
     "ProviderConfig",
     "LambdaMicroVmIdlePolicy",

--- a/server/app/storage/config_registry.py
+++ b/server/app/storage/config_registry.py
@@ -42,7 +42,6 @@ from server.app.storage.config_models import (
     EntityType,
     GlobalAgentDefaults,
     GlobalProviderDefaults,
-    McpServerRegistration,
     ProviderConfig,
     SandboxProfile,
     SkillDefinition,
@@ -163,24 +162,6 @@ class ConfigRegistry(Protocol):
 
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
         """Delete an agent definition row. Returns True if row existed."""
-        ...
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        """List all MCP server registrations visible in the given scope."""
-        ...
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        """Create or replace an MCP server registration."""
-        ...
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        """Delete an MCP server registration. Returns True if row existed."""
         ...
 
     # ------------------------------------------------------------------
@@ -657,23 +638,6 @@ class SqliteConfigRegistry:
         return await self._delete_entity("agent", name, scope)
 
     # ------------------------------------------------------------------
-    # MCP server CRUD (SqliteConfigRegistry)
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        rows = await self._list_entities("mcp_server", scope)
-        return [McpServerRegistration.model_validate(r) for r in rows]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        data = server.model_dump()
-        await self._upsert_entity("mcp_server", server.name, server.scope, data, server.source)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return await self._delete_entity("mcp_server", name, scope)
-
-    # ------------------------------------------------------------------
     # Sandbox profile CRUD (SqliteConfigRegistry)
     # ------------------------------------------------------------------
 
@@ -1128,24 +1092,6 @@ class PostgresConfigRegistry:
         return await self._delete_entity("agent", name, scope)
 
     # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        rows = await self._list_entities("mcp_server", scope)
-        return [McpServerRegistration.model_validate(r) for r in rows]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        await self._upsert_entity(
-            "mcp_server", server.name, server.scope, server.model_dump(), server.source
-        )
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return await self._delete_entity("mcp_server", name, scope)
-
-    # ------------------------------------------------------------------
     # Sandbox profile CRUD
     # ------------------------------------------------------------------
 
@@ -1455,21 +1401,6 @@ class MemoryConfigRegistry:
 
     async def delete_agent(self, name: str, scope: dict[str, str] | None = None) -> bool:
         return self._delete("agent", name, scope)
-
-    # MCP
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        return [
-            McpServerRegistration.model_validate(r)
-            for r in self._list_entities("mcp_server", scope)
-        ]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        self._upsert("mcp_server", server.name, server.scope, server.model_dump(), server.source)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return self._delete("mcp_server", name, scope)
 
     # Sandbox profile
     async def get_sandbox_profile(

--- a/server/app/storage/config_store.py
+++ b/server/app/storage/config_store.py
@@ -38,7 +38,6 @@ from server.app.storage.config_models import (
     EntityType,
     GlobalAgentDefaults,
     GlobalProviderDefaults,
-    McpServerRegistration,
     ProviderConfig,
     SandboxProfile,
     SkillDefinition,
@@ -169,18 +168,6 @@ class ConfigStore(Protocol):
     async def is_valid_primary(self, name: str, scope: dict[str, str] | None = None) -> bool:
         """Check if an agent name is a valid primary agent."""
         ...
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]: ...
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None: ...
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool: ...
 
     # ------------------------------------------------------------------
     # Sandbox profile CRUD
@@ -547,23 +534,6 @@ Attempt the exact protected tool call immediately so that human-in-the-loop appr
         if agent is None or agent.hidden:
             return False
         return agent.mode in ("primary", "all")
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        return cast(
-            list[McpServerRegistration], await self._config_registry.list_mcp_servers(scope)
-        )
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        await self._config_registry.upsert_mcp_server(server)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return bool(await self._config_registry.delete_mcp_server(name, scope))
 
     # ------------------------------------------------------------------
     # Sandbox profile CRUD


### PR DESCRIPTION
## Summary
- remove global MCP registration models and ConfigRegistry/ConfigStore CRUD
- remove global agent-default MCP fields from the API contract
- retain only agent-owned MCP declarations

## Verification
- uv run pytest tests/unit/test_config_registry.py tests/unit/test_agent_def_field_wiring.py -q
- uv run ruff check server/app/storage/config_models.py server/app/storage/config_registry.py server/app/storage/config_store.py server/app/api/models.py server/app/api/routes/config.py
- uv run mypy server/app/storage/config_models.py server/app/storage/config_registry.py server/app/storage/config_store.py server/app/api/models.py server/app/api/routes/config.py