### PR TITLE
feat: add encrypted MCP OAuth token storage

### DIFF
--- a/server/app/agent/mcp_oauth.py
+++ b/server/app/agent/mcp_oauth.py
@@ -1,0 +1,227 @@
+"""Encrypted persistence for direct MCP OAuth client state.
+
+This module deliberately stores MCP OAuth tokens outside Agent definitions,
+runtime projections, and object storage.  The database row is keyed by an
+HMAC-derived partition so tenant scope and canonical provider URL are not
+recoverable from normal database inspection.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import aiosqlite
+from cryptography.fernet import Fernet, InvalidToken
+from mcp.client.auth import TokenStorage
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+
+class McpOAuthStorageError(RuntimeError):
+    """A redacted failure in durable direct-MCP OAuth storage."""
+
+
+@dataclass(frozen=True)
+class McpOAuthPartition:
+    """Trusted dimensions that isolate one direct-MCP OAuth authorization."""
+
+    agent_identity: str
+    runtime_snapshot: str
+    effective_scope: dict[str, str]
+    server_url: str
+
+
+def canonicalize_mcp_server_url(url: str) -> str:
+    """Return a stable remote-MCP URL identity without credentials or fragments."""
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+    port = parsed.port
+    if (parsed.scheme == "https" and port == 443) or (parsed.scheme == "http" and port == 80):
+        port = None
+    netloc = hostname if port is None else f"{hostname}:{port}"
+    path = parsed.path.rstrip("/") or "/"
+    return urlunparse((parsed.scheme.lower(), netloc, path, "", parsed.query, ""))
+
+
+class EncryptedMcpOAuthTokenStorage(TokenStorage):
+    """MCP SDK ``TokenStorage`` backed by SQLite or PostgreSQL-compatible DBs.
+
+    It uses a deployment supplied Fernet key for ciphertext and derives the
+    opaque partition identifier with a separate HMAC domain.  Only ciphertext,
+    timestamps, and non-reversible partition identifiers reach the database.
+    """
+
+    def __init__(
+        self,
+        *,
+        persistence_backend: str,
+        persistence_uri: str,
+        encryption_key: str,
+        partition: McpOAuthPartition,
+        workspace_path: Path | None = None,
+    ) -> None:
+        if persistence_backend not in {"sqlite", "postgres"}:
+            raise McpOAuthStorageError("oauth_storage_unavailable")
+        try:
+            self._fernet = Fernet(encryption_key.encode())
+            key_material = base64.urlsafe_b64decode(encryption_key.encode())
+        except Exception as exc:
+            raise McpOAuthStorageError("oauth_storage_unavailable") from exc
+        payload = json.dumps(
+            {
+                "agent_identity": partition.agent_identity,
+                "runtime_snapshot": partition.runtime_snapshot,
+                "effective_scope": partition.effective_scope,
+                "server_url": canonicalize_mcp_server_url(partition.server_url),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        self._partition_id = hmac.new(key_material, b"cognition-mcp-oauth-v1\0" + payload, hashlib.sha256).hexdigest()
+        self._backend = persistence_backend
+        self._uri = self._resolve_uri(persistence_uri, workspace_path)
+
+    @staticmethod
+    def _resolve_uri(uri: str, workspace_path: Path | None) -> str:
+        if uri.startswith("sqlite:///"):
+            uri = uri.removeprefix("sqlite:///")
+        if uri.startswith("postgresql+asyncpg://"):
+            return uri.replace("postgresql+asyncpg://", "postgresql://", 1)
+        path = Path(uri)
+        if not path.is_absolute() and workspace_path is not None:
+            path = workspace_path / path
+        return str(path)
+
+    async def _sqlite_connect(self) -> aiosqlite.Connection:
+        db = await aiosqlite.connect(self._uri)
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mcp_oauth_credentials (
+                partition_id TEXT PRIMARY KEY,
+                token_ciphertext TEXT,
+                client_ciphertext TEXT,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await db.commit()
+        return db
+
+    def _encrypt(self, value: str) -> str:
+        return self._fernet.encrypt(value.encode()).decode()
+
+    def _decrypt(self, value: str) -> str:
+        try:
+            return self._fernet.decrypt(value.encode()).decode()
+        except (InvalidToken, UnicodeDecodeError) as exc:
+            raise McpOAuthStorageError("oauth_storage_unavailable") from exc
+
+    async def _get_sqlite(self, column: str) -> str | None:
+        db = await self._sqlite_connect()
+        try:
+            cursor = await db.execute(
+                f"SELECT {column} FROM mcp_oauth_credentials WHERE partition_id = ?",
+                (self._partition_id,),
+            )
+            row = await cursor.fetchone()
+            return str(row[0]) if row and row[0] is not None else None
+        finally:
+            await db.close()
+
+    async def _set_sqlite(self, column: str, value: str) -> None:
+        db = await self._sqlite_connect()
+        try:
+            await db.execute(
+                f"""
+                INSERT INTO mcp_oauth_credentials (partition_id, {column}) VALUES (?, ?)
+                ON CONFLICT(partition_id) DO UPDATE SET {column} = excluded.{column},
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (self._partition_id, value),
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+    async def _get_postgres(self, column: str) -> str | None:
+        import psycopg
+
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_oauth_credentials (
+                    partition_id TEXT PRIMARY KEY,
+                    token_ciphertext TEXT,
+                    client_ciphertext TEXT,
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    f"SELECT {column} FROM mcp_oauth_credentials WHERE partition_id = %s",
+                    (self._partition_id,),
+                )
+                row = await cursor.fetchone()
+                return str(row[0]) if row and row[0] is not None else None
+
+    async def _set_postgres(self, column: str, value: str) -> None:
+        import psycopg
+
+        async with await psycopg.AsyncConnection.connect(self._uri) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_oauth_credentials (
+                    partition_id TEXT PRIMARY KEY,
+                    token_ciphertext TEXT,
+                    client_ciphertext TEXT,
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            await conn.execute(
+                f"""
+                INSERT INTO mcp_oauth_credentials (partition_id, {column}) VALUES (%s, %s)
+                ON CONFLICT(partition_id) DO UPDATE SET {column} = EXCLUDED.{column},
+                    updated_at = NOW()
+                """,
+                (self._partition_id, value),
+            )
+
+    async def _get(self, column: str) -> str | None:
+        if self._backend == "sqlite":
+            return await self._get_sqlite(column)
+        return await self._get_postgres(column)
+
+    async def _set(self, column: str, value: str) -> None:
+        if self._backend == "sqlite":
+            await self._set_sqlite(column, value)
+            return
+        await self._set_postgres(column, value)
+
+    async def get_tokens(self) -> OAuthToken | None:
+        """Return the decrypted OAuth access/refresh-token bundle, if present."""
+        ciphertext = await self._get("token_ciphertext")
+        return OAuthToken.model_validate_json(self._decrypt(ciphertext)) if ciphertext else None
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        """Encrypt and save an OAuth token bundle."""
+        await self._set("token_ciphertext", self._encrypt(tokens.model_dump_json()))
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        """Return registered OAuth client information, if present."""
+        ciphertext = await self._get("client_ciphertext")
+        return (
+            OAuthClientInformationFull.model_validate_json(self._decrypt(ciphertext))
+            if ciphertext
+            else None
+        )
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        """Encrypt and save dynamic client-registration metadata."""
+        await self._set("client_ciphertext", self._encrypt(client_info.model_dump_json()))

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -162,6 +162,19 @@ class Settings(BaseSettings):
             "It is never persisted or exposed to agent runtime data."
         ),
     )
+    mcp_oauth_encryption_key: SecretStr | None = Field(
+        default=None,
+        alias="COGNITION_MCP_OAUTH_ENCRYPTION_KEY",
+        description=(
+            "Fernet key used only to encrypt direct MCP OAuth tokens and dynamic "
+            "client registrations in the configured database."
+        ),
+    )
+    mcp_oauth_callback_url: str | None = Field(
+        default=None,
+        alias="COGNITION_MCP_OAUTH_CALLBACK_URL",
+        description="Public HTTPS callback URL for Cognition direct MCP OAuth authorization.",
+    )
 
     # Sandbox / Execution backend settings
     sandbox_backend: Literal["local", "docker", "kubernetes", "aws_lambda_microvm"] = Field(

--- a/tests/unit/test_mcp_oauth.py
+++ b/tests/unit/test_mcp_oauth.py
@@ -1,0 +1,66 @@
+"""Tests for encrypted direct-MCP OAuth persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from cryptography.fernet import Fernet
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+
+from server.app.agent.mcp_oauth import EncryptedMcpOAuthTokenStorage, McpOAuthPartition
+
+
+def _store(tmp_path, *, scope: dict[str, str]) -> EncryptedMcpOAuthTokenStorage:
+    return EncryptedMcpOAuthTokenStorage(
+        persistence_backend="sqlite",
+        persistence_uri="oauth.db",
+        encryption_key=Fernet.generate_key().decode(),
+        partition=McpOAuthPartition(
+            agent_identity="support-agent",
+            runtime_snapshot="revision-1",
+            effective_scope=scope,
+            server_url="https://mcp.example.test/github/",
+        ),
+        workspace_path=tmp_path,
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_storage_encrypts_tokens_and_dynamic_client_data(tmp_path) -> None:
+    storage = _store(tmp_path, scope={"tenant": "acme"})
+    token = OAuthToken(access_token="access-secret", refresh_token="refresh-secret")
+    client = OAuthClientInformationFull(
+        redirect_uris=[AnyUrl("https://cognition.example.test/mcp/oauth/callback")],
+        client_id="registered-client",
+        client_secret="client-secret",
+    )
+
+    await storage.set_tokens(token)
+    await storage.set_client_info(client)
+
+    assert await storage.get_tokens() == token
+    assert await storage.get_client_info() == client
+    raw = sqlite3.connect(tmp_path / "oauth.db").execute(
+        "SELECT partition_id, token_ciphertext, client_ciphertext FROM mcp_oauth_credentials"
+    ).fetchone()
+    assert raw is not None
+    assert all(secret not in " ".join(str(value) for value in raw) for secret in [
+        "access-secret",
+        "refresh-secret",
+        "registered-client",
+        "client-secret",
+        "acme",
+    ])
+
+
+@pytest.mark.asyncio
+async def test_token_storage_does_not_cross_exact_effective_scope(tmp_path) -> None:
+    acme = _store(tmp_path, scope={"tenant": "acme"})
+    globex = _store(tmp_path, scope={"tenant": "globex"})
+
+    await acme.set_tokens(OAuthToken(access_token="acme-token"))
+
+    assert (await acme.get_tokens()).access_token == "acme-token"  # type: ignore[union-attr]
+    assert await globex.get_tokens() is None


### PR DESCRIPTION
## Summary
- add scope-, revision-, agent-, and server-partitioned encrypted storage for direct MCP OAuth tokens and dynamic client registration
- support SQLite locally and PostgreSQL-compatible databases in production
- add deployment settings for a Fernet encryption key and OAuth callback URL

## Security
- no token, client secret, raw scope, or provider URL is stored in plaintext
- the storage layer never uses S3, Agent definitions, or runtime projections

## Validation
- uv run pytest tests/unit/test_mcp_oauth.py -q
- uv run ruff check server/app/agent/mcp_oauth.py server/app/settings.py tests/unit/test_mcp_oauth.py
- uv run mypy server/app/agent/mcp_oauth.py tests/unit/test_mcp_oauth.py