### PR TITLE
feat: wire direct MCP OAuth into runtime

### DIFF
--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -728,6 +728,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
             agent_identity=params.agent_identity or "",
             runtime_snapshot=params.runtime_snapshot or "",
             trusted_context=params.scope or {},
+            settings=settings,
         )
         agent_tools.extend(mcp_tools)
         logger.info("agent_mcp_tools_loaded", count=len(mcp_tools))

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -20,9 +20,16 @@ from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
+from mcp.client.auth import OAuthClientProvider
+from mcp.shared.auth import OAuthClientMetadata
 from mcp.types import LoggingMessageNotificationParams
 
 from server.app.agent.mcp_config import AgentMcpServer
+from server.app.agent.mcp_oauth import (
+    EncryptedMcpOAuthTokenStorage,
+    McpOAuthPartition,
+    McpOAuthStorageError,
+)
 from server.app.agent.outbound_auth import (
     OutboundAuthError,
     OutboundAuthProviderRegistry,
@@ -30,6 +37,7 @@ from server.app.agent.outbound_auth import (
     OutboundAuthResult,
     get_outbound_auth_provider_registry,
 )
+from server.app.settings import Settings, get_settings
 
 logger = structlog.get_logger(__name__)
 
@@ -49,6 +57,10 @@ def create_agent_mcp_client(
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
     outbound_auth: OutboundAuthResult | None = None,
+    agent_identity: str = "",
+    runtime_snapshot: str = "",
+    trusted_context: dict[str, str] | None = None,
+    settings: Settings | None = None,
 ) -> MultiServerMCPClient:
     """Create a client for exactly one validated Agent MCP server.
 
@@ -64,14 +76,35 @@ def create_agent_mcp_client(
             raise McpServerUnavailableError(config.alias, "auth_unavailable")
         headers = {"Authorization": f"Bearer {token}"}
     elif config.auth.type == "mcp_oauth":
-        # These modes require the v0.14 transport-security provider. Do not
-        # downgrade a protected endpoint to anonymous transport while wiring is
-        # incomplete.
-        raise McpServerUnavailableError(config.alias, "auth_provider_unavailable")
+        resolved_settings = settings or get_settings()
+        if resolved_settings.mcp_oauth_encryption_key is None:
+            raise McpServerUnavailableError(config.alias, "oauth_storage_unavailable")
+        try:
+            storage = EncryptedMcpOAuthTokenStorage(
+                persistence_backend=resolved_settings.persistence_backend,
+                persistence_uri=resolved_settings.persistence_uri,
+                encryption_key=resolved_settings.mcp_oauth_encryption_key.get_secret_value(),
+                partition=McpOAuthPartition(
+                    agent_identity=agent_identity,
+                    runtime_snapshot=runtime_snapshot,
+                    effective_scope=trusted_context or {},
+                    server_url=config.url,
+                ),
+                workspace_path=resolved_settings.workspace_path,
+            )
+            oauth_auth = OAuthClientProvider(
+                server_url=config.url,
+                client_metadata=OAuthClientMetadata(redirect_uris=None),
+                storage=storage,
+            )
+        except McpOAuthStorageError as exc:
+            raise McpServerUnavailableError(config.alias, "oauth_storage_unavailable") from exc
 
     connection: StreamableHttpConnection = {"transport": "streamable_http", "url": config.url}
     if headers:
         connection["headers"] = headers
+    if config.auth.type == "mcp_oauth":
+        connection["auth"] = oauth_auth
     if outbound_auth is not None:
         if outbound_auth.headers:
             connection["headers"] = dict(outbound_auth.headers)
@@ -95,6 +128,7 @@ async def load_agent_mcp_tools(
     trusted_context: dict[str, str] | None = None,
     deadline: datetime | None = None,
     auth_providers: OutboundAuthProviderRegistry | None = None,
+    settings: Settings | None = None,
 ) -> list[Any]:
     """Discover agent MCP tools one server at a time with fail-closed semantics."""
     tools: list[Any] = []
@@ -115,6 +149,10 @@ async def load_agent_mcp_tools(
                 callbacks=callbacks,
                 tool_interceptors=tool_interceptors,
                 outbound_auth=outbound_auth,
+                agent_identity=agent_identity,
+                runtime_snapshot=runtime_snapshot,
+                trusted_context=trusted_context,
+                settings=settings,
             ).get_tools()
             for tool in discovered:
                 provider_name = str(getattr(tool, "name", ""))

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -6,16 +6,22 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography.fernet import Fernet
 from pydantic import ValidationError
 
 from server.app.agent.definition import AgentDefinition
-from server.app.agent.mcp_client import McpServerUnavailableError, load_agent_mcp_tools
+from server.app.agent.mcp_client import (
+    McpServerUnavailableError,
+    create_agent_mcp_client,
+    load_agent_mcp_tools,
+)
 from server.app.agent.mcp_config import AgentMcpServer, McpAuthConfig, canonical_mcp_tool_identity
 from server.app.agent.outbound_auth import (
     OutboundAuthProviderRegistry,
     OutboundAuthRequest,
     OutboundAuthResult,
 )
+from server.app.settings import Settings
 
 
 def test_agent_owns_a_streamable_http_mcp_server() -> None:
@@ -63,6 +69,36 @@ def test_static_bearer_never_accepts_a_raw_token() -> None:
 
     with pytest.raises(ValidationError):
         McpAuthConfig(type="static_bearer", env="Bearer secret")
+
+
+def test_mcp_oauth_uses_the_mcp_sdk_with_encrypted_database_storage(tmp_path) -> None:
+    server = AgentMcpServer(
+        alias="github",
+        url="https://mcp.example.test/github",
+        auth=McpAuthConfig(type="mcp_oauth"),
+    )
+    settings = Settings.model_validate(
+        {
+            "persistence_backend": "sqlite",
+            "persistence_uri": "oauth.db",
+            "workspace_root": tmp_path,
+            "mcp_oauth_encryption_key": Fernet.generate_key().decode(),
+        }
+    )
+
+    with patch("server.app.agent.mcp_client.MultiServerMCPClient") as client_type:
+        create_agent_mcp_client(
+            server,
+            agent_identity="agent-1",
+            runtime_snapshot="snapshot-1",
+            trusted_context={"tenant": "acme"},
+            settings=settings,
+        )
+
+    connection = client_type.call_args.kwargs["connections"]["github"]
+    assert connection["transport"] == "streamable_http"
+    assert connection["auth"].__class__.__name__ == "OAuthClientProvider"
+    assert "headers" not in connection
 
 
 def test_agent_rejects_duplicate_mcp_aliases() -> None:


### PR DESCRIPTION
## Summary
- construct the official MCP SDK OAuth client for direct MCP OAuth server declarations
- partition tokens by immutable agent identity, runtime snapshot, exact scope, and canonical server URL
- fail closed when encrypted OAuth storage is not configured

## Validation
- uv run pytest tests/unit/test_agent_mcp_config.py tests/unit/test_mcp_oauth.py -q
- uv run ruff check server/app/agent/mcp_client.py server/app/agent/cognition_agent.py tests/unit/test_agent_mcp_config.py
- uv run mypy server/app/agent/mcp_client.py server/app/agent/cognition_agent.py tests/unit/test_agent_mcp_config.py