### PR TITLE
test: enforce MCP OAuth secure storage

### DIFF
--- a/server/app/agent/mcp_oauth.py
+++ b/server/app/agent/mcp_oauth.py
@@ -225,3 +225,8 @@ class EncryptedMcpOAuthTokenStorage(TokenStorage):
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         """Encrypt and save dynamic client-registration metadata."""
         await self._set("client_ciphertext", self._encrypt(client_info.model_dump_json()))
+
+    @property
+    def partition_id(self) -> str:
+        """Return the opaque durable partition identifier for trusted callers."""
+        return self._partition_id

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -101,6 +101,18 @@ def test_mcp_oauth_uses_the_mcp_sdk_with_encrypted_database_storage(tmp_path) ->
     assert "headers" not in connection
 
 
+def test_mcp_oauth_fails_closed_without_encrypted_storage() -> None:
+    server = AgentMcpServer(
+        alias="github",
+        url="https://mcp.example.test/github",
+        auth=McpAuthConfig(type="mcp_oauth"),
+    )
+    settings = Settings.model_validate({"persistence_backend": "sqlite"})
+
+    with pytest.raises(McpServerUnavailableError, match="oauth_storage_unavailable"):
+        create_agent_mcp_client(server, settings=settings)
+
+
 def test_agent_rejects_duplicate_mcp_aliases() -> None:
     with pytest.raises(ValidationError, match="aliases must be unique"):
         AgentDefinition(


### PR DESCRIPTION
## Summary
- verify direct MCP OAuth fails closed when encrypted token storage is absent
- expose the opaque storage partition only to trusted OAuth-connect runtime code

## Validation
- uv run pytest tests/unit/test_agent_mcp_config.py tests/unit/test_mcp_oauth.py -q
- uv run ruff check server/app/agent/mcp_oauth.py tests/unit/test_agent_mcp_config.py
- uv run mypy server/app/agent/mcp_oauth.py tests/unit/test_agent_mcp_config.py