### PR TITLE
feat: align Deep Agents 0.7 and add S3-compatible backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ k8s = [
     "langchain-k8s-sandbox[k8s]",
 ]
 
+# Documentation site
+docs = [
+    "mkdocs-material>=9.6.0",
+]
+
 # AWS Lambda MicroVM sandbox backend
 aws-lambda-microvms = [
     "langchain-aws-lambda-microvms[aws]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     # Core framework
-    "deepagents>=0.6.2",
+    "deepagents>=0.7.1",
     "langchain>=1.3.0",
     "langgraph>=0.2.0",
     "langchain-core>=1.4.0",
@@ -55,7 +55,7 @@ dependencies = [
     "langsmith[otel]>=0.4.25",
     "langgraph-checkpoint-sqlite>=1.0.0",
     # MCP (Model Context Protocol) - Remote-only support via langchain-mcp-adapters
-    "langchain-mcp-adapters>=0.2.0",
+    "langchain-mcp-adapters>=0.3.1",
     # A2A (Agent-to-Agent Protocol) - Inbound server adapter
     "a2a-sdk>=1.0.3",
     # AWS Lambda MicroVM sandbox adapter (boto3 is optional/lazy)
@@ -66,6 +66,9 @@ dependencies = [
 # LLM providers (install as needed)
 openai = ["langchain-openai>=0.2.0", "openai>=1.52.0"]
 bedrock = ["langchain-aws>=0.2.0", "boto3>=1.35.0"]
+
+# S3-compatible durable file backend (AWS S3, Garage, and other S3 APIs)
+s3 = ["boto3>=1.35.0"]
 
 # Testing
 test = [
@@ -98,11 +101,6 @@ k8s = [
     "langchain-k8s-sandbox[k8s]",
 ]
 
-# Documentation site
-docs = [
-    "mkdocs-material>=9.6.0",
-]
-
 # AWS Lambda MicroVM sandbox backend
 aws-lambda-microvms = [
     "langchain-aws-lambda-microvms[aws]",
@@ -110,7 +108,7 @@ aws-lambda-microvms = [
 
 # All extras
 all = [
-    "cognition[openai,bedrock,test,deploy,k8s,aws-lambda-microvms]",
+    "cognition[openai,bedrock,s3,test,deploy,k8s,aws-lambda-microvms]",
 ]
 
 [project.scripts]

--- a/server/app/agent/artifacts_backend.py
+++ b/server/app/agent/artifacts_backend.py
@@ -160,13 +160,15 @@ class ArtifactBackend(BackendProtocol):
                 scope=self._scope,
                 artifact_type=artifact_type,
             )
-            return LsResult(entries=[
-                FileInfo(
-                    path=f"/{artifact_type}/{a.id}",
-                    size=len(a.content.encode("utf-8")),
-                )
-                for a in artifacts
-            ])
+            return LsResult(
+                entries=[
+                    FileInfo(
+                        path=f"/{artifact_type}/{a.id}",
+                        size=len(a.content.encode("utf-8")),
+                    )
+                    for a in artifacts
+                ]
+            )
 
         return LsResult(entries=[])
 
@@ -200,13 +202,25 @@ class ArtifactBackend(BackendProtocol):
         return []
 
     async def agrep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
+        del pattern, path, glob, max_count
         return GrepResult(matches=[])
 
     def grep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
+        del pattern, path, glob, max_count
         return GrepResult(matches=[])
 
     async def agrep_raw(
@@ -307,9 +321,7 @@ class ArtifactBackend(BackendProtocol):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return EditResult(error="ArtifactBackend requires an async event loop")
-        return loop.run_until_complete(
-            self.aedit(file_path, old_string, new_string, replace_all)
-        )
+        return loop.run_until_complete(self.aedit(file_path, old_string, new_string, replace_all))
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> Any:
         return None

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -621,34 +621,6 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
         except RuntimeError:
             config_store = None
 
-    runtime_ctx = RuntimeContext.from_params(
-        project_path=project_path,
-        model=getattr(params.model, "model_name", None)
-        or getattr(params.model, "model_id", None)
-        or getattr(params.model, "model", None)
-        or str(params.model),
-        store=params.store,
-        system_prompt=params.system_prompt,
-        memory=params.memory,
-        skills=params.skills,
-        subagents=params.subagents,
-        async_subagents=params.async_subagents,
-        interrupt_on=params.interrupt_on,
-        permissions=params.permissions,
-        response_format=params.response_format,
-        tool_token_limit_before_evict=params.tool_token_limit_before_evict,
-        context_policy=params.context_policy,
-        excluded_tools=params.excluded_tools,
-        blocked_tools=params.blocked_tools,
-        middleware=params.middleware,
-        tools=params.tools,
-        settings=settings,
-        scope=params.scope,
-        sandbox_profile=params.sandbox_profile,
-        sandbox_execution_role_arn=params.sandbox_execution_role_arn,
-        model_cache_key=params.model_cache_key,
-        manifest_digest=params.manifest_digest,
-    )
     resolved_sandbox_profile = params.sandbox_profile or settings.aws_lambda_microvm_default_profile
     sandbox_profile_config = params.pinned_sandbox_profile_config
     if sandbox_profile_config is None:
@@ -658,19 +630,6 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
             profile_name=resolved_sandbox_profile,
             scope=params.scope,
         )
-
-    cached_agent = get_cached_agent(runtime_ctx)
-    if cached_agent is not None:
-        sandbox_backend = _create_sandbox(
-            project_path,
-            sandbox_id,
-            settings,
-            k8s_labels,
-            sandbox_profile=resolved_sandbox_profile,
-            sandbox_execution_role_arn=params.sandbox_execution_role_arn,
-            sandbox_profile_config=sandbox_profile_config,
-        )
-        return CognitionAgentResult(agent=cached_agent, sandbox_backend=sandbox_backend)
 
     sandbox_backend = _create_sandbox(
         project_path,
@@ -742,23 +701,16 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                     }
                 )
 
-    def runtime_backend(tool_runtime: Any) -> Any:
-        """Resolve only the current invocation's assigned sandbox."""
-        context = getattr(tool_runtime, "context", None)
-        selected = getattr(context, "sandbox_backend", None)
-        if selected is None:
-            STRICT_EXECUTION_REJECTIONS_TOTAL.labels(reason="missing_sandbox").inc()
-            raise RuntimeError(
-                "The current run has no assigned sandbox backend; refusing "
-                "host or stale-sandbox fallback"
-            )
-        if routes:
-            from deepagents.backends.composite import CompositeBackend
+    # Deep Agents 0.7 deliberately accepts only initialized backend instances,
+    # not runtime factories. A compiled graph therefore captures its sandbox;
+    # caching that graph would cross a session's execution boundary. Build each
+    # run with its assigned sandbox instead of retaining a stale graph.
+    if routes:
+        from deepagents.backends.composite import CompositeBackend
 
-            return CompositeBackend(default=selected, routes=routes)
-        return selected
-
-    backend = runtime_backend
+        backend = CompositeBackend(default=sandbox_backend, routes=routes)
+    else:
+        backend = sandbox_backend
 
     if params.subagents is not None:
         raw_subagents = list(params.subagents)
@@ -949,7 +901,6 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
     agent = cast(Any, create_deep_agent)(**create_kwargs)
 
     result = CognitionAgentResult(agent=agent, sandbox_backend=sandbox_backend)
-    cache_agent(runtime_ctx, agent)
 
     return result
 

--- a/server/app/agent/s3_backend.py
+++ b/server/app/agent/s3_backend.py
@@ -1,0 +1,222 @@
+"""S3-compatible Deep Agents backend.
+
+The backend intentionally targets the S3 API rather than an AWS-specific
+service.  It supports AWS S3 through the normal boto3 credential chain and
+S3-compatible deployments such as Garage through an explicit endpoint URL.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import posixpath
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import Any
+
+from deepagents.backends.protocol import (
+    BackendProtocol,
+    DeleteResult,
+    EditResult,
+    FileData,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GlobResult,
+    GrepMatch,
+    GrepResult,
+    LsResult,
+    ReadResult,
+    WriteResult,
+)
+
+
+class S3CompatibleBackend(BackendProtocol):
+    """Expose one S3 prefix as a safe, virtual Deep Agents filesystem.
+
+    ``prefix`` is controlled by the runtime, not model input.  File paths are
+    normalized and must remain below that prefix, preventing path traversal
+    from escaping the effective-scope namespace.
+    """
+
+    def __init__(self, client: Any, bucket: str, prefix: str = "") -> None:
+        self._client = client
+        self._bucket = bucket
+        self._prefix = prefix.strip("/")
+
+    def _key(self, path: str) -> str:
+        normalized = posixpath.normpath("/" + path.lstrip("/"))
+        if normalized == "/.." or normalized.startswith("/../"):
+            raise ValueError("path escapes the configured storage prefix")
+        relative = normalized.lstrip("/")
+        return "/".join(part for part in (self._prefix, relative) if part)
+
+    def _path(self, key: str) -> str:
+        if self._prefix:
+            if not key.startswith(f"{self._prefix}/"):
+                raise ValueError("object is outside the configured storage prefix")
+            key = key[len(self._prefix) + 1 :]
+        return f"/{key}"
+
+    def _iter_objects(self, path: str = "/") -> Iterable[dict[str, Any]]:
+        prefix = self._key(path).rstrip("/")
+        if prefix:
+            prefix += "/"
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+            yield from page.get("Contents", [])
+
+    @staticmethod
+    def _timestamp(value: datetime | None) -> str:
+        if value is None:
+            return ""
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+
+    @staticmethod
+    def _not_found(error: Exception) -> bool:
+        response = getattr(error, "response", {})
+        code = str(response.get("Error", {}).get("Code", ""))
+        return code in {"404", "NoSuchKey", "NoSuchBucket"}
+
+    def ls(self, path: str) -> LsResult:
+        try:
+            entries: dict[str, FileInfo] = {}
+            root = self._key(path).rstrip("/")
+            prefix = f"{root}/" if root else ""
+            for obj in self._iter_objects(path):
+                key = str(obj["Key"])
+                remainder = key[len(prefix) :] if prefix else key
+                first, _, tail = remainder.partition("/")
+                entry_path = f"{path.rstrip('/')}/{first}" if path != "/" else f"/{first}"
+                if tail:
+                    entries.setdefault(entry_path, {"path": entry_path, "is_dir": True})
+                else:
+                    entries[entry_path] = {
+                        "path": entry_path,
+                        "is_dir": False,
+                        "size": int(obj.get("Size", 0)),
+                        "modified_at": self._timestamp(obj.get("LastModified")),
+                    }
+            return LsResult(entries=[entries[key] for key in sorted(entries)])
+        except Exception as exc:
+            return LsResult(error=f"S3 list failed: {type(exc).__name__}")
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        try:
+            response = self._client.get_object(Bucket=self._bucket, Key=self._key(file_path))
+            content = response["Body"].read().decode("utf-8")
+        except Exception as exc:
+            if self._not_found(exc):
+                return ReadResult(error=f"Error: File '{file_path}' not found")
+            return ReadResult(error=f"S3 read failed: {type(exc).__name__}")
+
+        lines = content.splitlines()
+        if limit <= 0:
+            return ReadResult(total_lines=len(lines), no_lines_requested=True)
+        selected = lines[offset : offset + limit]
+        return ReadResult(
+            file_data=FileData(content="\n".join(selected), encoding="utf-8"),
+            total_lines=len(lines),
+            start_line=offset + 1 if selected else None,
+            end_line=offset + len(selected) if selected else None,
+            next_offset=offset + len(selected) if offset + len(selected) < len(lines) else None,
+        )
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        try:
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=self._key(file_path),
+                Body=content.encode("utf-8"),
+                ContentType="text/plain; charset=utf-8",
+            )
+            return WriteResult(path=file_path)
+        except Exception as exc:
+            return WriteResult(error=f"S3 write failed: {type(exc).__name__}")
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        result = self.read(file_path, limit=2**31 - 1)
+        if result.error or result.file_data is None:
+            return EditResult(error=result.error or f"Cannot read {file_path}")
+        content = result.file_data["content"]
+        occurrences = content.count(old_string)
+        if occurrences == 0:
+            return EditResult(error=f"String not found in {file_path}")
+        if not replace_all:
+            occurrences = 1
+        updated = content.replace(old_string, new_string, occurrences)
+        write = self.write(file_path, updated)
+        return EditResult(
+            error=write.error, path=file_path if not write.error else None, occurrences=occurrences
+        )
+
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
+        try:
+            matches: list[FileInfo] = [
+                {
+                    "path": self._path(str(obj["Key"])),
+                    "is_dir": False,
+                    "size": int(obj.get("Size", 0)),
+                    "modified_at": self._timestamp(obj.get("LastModified")),
+                }
+                for obj in self._iter_objects(path or "/")
+                if fnmatch.fnmatch(self._path(str(obj["Key"])).lstrip("/"), pattern)
+            ]
+            return GlobResult(matches=sorted(matches, key=lambda item: item["path"]))
+        except Exception as exc:
+            return GlobResult(error=f"S3 glob failed: {type(exc).__name__}")
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
+    ) -> GrepResult:
+        matches: list[GrepMatch] = []
+        for info in self.glob(glob or "**", path).matches or []:
+            read = self.read(info["path"], limit=2**31 - 1)
+            if read.error or read.file_data is None:
+                continue
+            for line_number, line in enumerate(read.file_data["content"].splitlines(), start=1):
+                if pattern in line:
+                    matches.append({"path": info["path"], "line": line_number, "text": line})
+                    if max_count is not None and len(matches) >= max_count:
+                        return GrepResult(matches=matches, truncated=True)
+        return GrepResult(matches=matches)
+
+    def delete(self, file_path: str) -> DeleteResult:
+        try:
+            self._client.delete_object(Bucket=self._bucket, Key=self._key(file_path))
+            return DeleteResult(path=file_path)
+        except Exception as exc:
+            return DeleteResult(error=f"S3 delete failed: {type(exc).__name__}")
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        responses: list[FileDownloadResponse] = []
+        for path in paths:
+            try:
+                response = self._client.get_object(Bucket=self._bucket, Key=self._key(path))
+                responses.append(FileDownloadResponse(path=path, content=response["Body"].read()))
+            except Exception as exc:
+                error = "file_not_found" if self._not_found(exc) else "invalid_path"
+                responses.append(FileDownloadResponse(path=path, error=error))
+        return responses
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        results: list[FileUploadResponse] = []
+        for path, content in files:
+            try:
+                self._client.put_object(Bucket=self._bucket, Key=self._key(path), Body=content)
+                results.append(FileUploadResponse(path=path))
+            except Exception:
+                results.append(FileUploadResponse(path=path, error="invalid_path"))
+        return results

--- a/server/app/agent/s3_backend.py
+++ b/server/app/agent/s3_backend.py
@@ -43,6 +43,35 @@ class S3CompatibleBackend(BackendProtocol):
         self._bucket = bucket
         self._prefix = prefix.strip("/")
 
+    @classmethod
+    def from_boto3(
+        cls,
+        *,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: str | None = None,
+        region_name: str | None = None,
+        force_path_style: bool = False,
+    ) -> S3CompatibleBackend:
+        """Build a backend from boto3's standard AWS/S3-compatible client.
+
+        ``force_path_style`` is useful for Garage and other local object stores;
+        AWS S3 deployments can leave it disabled and use virtual-host addressing.
+        Credentials deliberately come from boto3's standard provider chain.
+        """
+        try:
+            import boto3
+            from botocore.config import Config
+        except ImportError as exc:  # pragma: no cover - guarded by the s3 extra
+            raise RuntimeError("Install Cognition with the 's3' extra to use S3 storage") from exc
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            config=Config(s3={"addressing_style": "path" if force_path_style else "virtual"}),
+        )
+        return cls(client, bucket=bucket, prefix=prefix)
+
     def _key(self, path: str) -> str:
         normalized = posixpath.normpath("/" + path.lstrip("/"))
         if normalized == "/.." or normalized.startswith("/../"):

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -767,7 +767,10 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files in the AWS Lambda MicroVM sandbox."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def glob(self, pattern: str, path: str | None = "/") -> GlobResult:
@@ -1081,7 +1084,10 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
     ) -> GrepResult:
         """Search files using Deep Agents' current result API."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
+        kwargs: dict[str, Any] = {"path": path, "glob": glob}
+        if max_count is not None:
+            kwargs["max_count"] = max_count
+        result: GrepResult = backend.grep(pattern, **kwargs)
         return result
 
     def grep_raw(

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -762,10 +762,12 @@ class CognitionAwsLambdaMicroVmSandboxBackend(SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search files in the AWS Lambda MicroVM sandbox."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob)
+        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
         return result
 
     def glob(self, pattern: str, path: str | None = "/") -> GlobResult:
@@ -937,12 +939,16 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
 
         # Check workspace root
         expected_root = str(self._root_dir)
-        result = self._backend.execute(f'test -d {shlex.quote(expected_root)} && echo "ok" || echo "missing"')
+        result = self._backend.execute(
+            f'test -d {shlex.quote(expected_root)} && echo "ok" || echo "missing"'
+        )
         workspace_ok = result.exit_code == 0
         checks.append(("workspace_root", f"Expected {expected_root}", workspace_ok))
 
         # Check writable workspace
-        result = self._backend.execute(f'test -w {shlex.quote(expected_root)} && echo "ok" || echo "ro"')
+        result = self._backend.execute(
+            f'test -w {shlex.quote(expected_root)} && echo "ok" || echo "ro"'
+        )
         writable_ok = result.exit_code == 0
         checks.append(("workspace_writable", expected_root, writable_ok))
 
@@ -953,7 +959,11 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
 
         # Check env vars
         result = self._backend.execute("env | grep -c COGNITION_WORKSPACE_ROOT")
-        env_ok = result.exit_code == 0 and result.output.strip().isdigit() and int(result.output.strip()) > 0
+        env_ok = (
+            result.exit_code == 0
+            and result.output.strip().isdigit()
+            and int(result.output.strip()) > 0
+        )
         checks.append(("env_var", "COGNITION_WORKSPACE_ROOT", env_ok))
 
         # Check GitHub auth if token is expected
@@ -1066,10 +1076,12 @@ class CognitionKubernetesSandboxBackend(SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search files using Deep Agents' current result API."""
         backend = self._get_backend()
-        result: GrepResult = backend.grep(pattern, path=path, glob=glob)
+        result: GrepResult = backend.grep(pattern, path=path, glob=glob, max_count=max_count)
         return result
 
     def grep_raw(
@@ -1198,7 +1210,9 @@ def create_sandbox_backend(
     aws_lambda_microvm_profile: str = "default",
     aws_lambda_microvm_execution_role_arn: str | None = None,
     aws_lambda_microvm_profile_config: SandboxProfile | None = None,
-) -> FilesystemBackend | CognitionKubernetesSandboxBackend | CognitionAwsLambdaMicroVmSandboxBackend:
+) -> (
+    FilesystemBackend | CognitionKubernetesSandboxBackend | CognitionAwsLambdaMicroVmSandboxBackend
+):
     """Factory for creating sandbox backends from settings.
 
     Args:

--- a/server/app/agent/sandbox_backend.py
+++ b/server/app/agent/sandbox_backend.py
@@ -363,14 +363,20 @@ class CognitionDockerSandboxBackend(FilesystemBackend, SandboxBackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        max_count: int | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search text only through the assigned Docker sandbox."""
+        del context_lines  # Docker's adapter does not expose surrounding-line search.
         try:
             matches = self._get_docker_backend().grep_files(
                 pattern,
                 self._relative_path(path),
                 glob,
             )
+            if max_count is not None:
+                matches = matches[:max_count]
             return GrepResult(matches=cast(list[Any], matches))
         except Exception as exc:
             return GrepResult(error=f"Error searching sandbox: {exc}", matches=[])

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -205,6 +205,23 @@ class Settings(BaseSettings):
         alias="COGNITION_PERSISTENCE_URI",
     )
 
+    # Durable Deep Agents file backend. SQLite/in-memory/local remain supported
+    # only for local and development profiles; production uses S3-compatible
+    # object storage for durable file-shaped runtime data.
+    durable_file_backend: Literal["local", "s3"] = Field(
+        default="local",
+        alias="COGNITION_DURABLE_FILE_BACKEND",
+    )
+    s3_bucket: str | None = Field(default=None, alias="COGNITION_S3_BUCKET")
+    s3_prefix: str = Field(default="cognition", alias="COGNITION_S3_PREFIX")
+    s3_endpoint_url: str | None = Field(default=None, alias="COGNITION_S3_ENDPOINT_URL")
+    s3_region: str | None = Field(default=None, alias="COGNITION_S3_REGION")
+    s3_force_path_style: bool = Field(
+        default=False,
+        alias="COGNITION_S3_FORCE_PATH_STYLE",
+        description="Use path-style S3 requests for Garage and similar compatible stores.",
+    )
+
     # Sandbox / Execution backend settings
     sandbox_backend: Literal["local", "docker", "kubernetes", "aws_lambda_microvm"] = Field(
         default="local",
@@ -463,6 +480,11 @@ class Settings(BaseSettings):
         if not 1 <= v <= 65535:
             raise ValueError(f"Port must be between 1 and 65535, got {v}")
         return v
+
+    @property
+    def s3_enabled(self) -> bool:
+        """Return whether durable file data is configured for S3-compatible storage."""
+        return self.durable_file_backend == "s3"
 
 
 # Global settings instance

--- a/tests/e2e/test_s3_garage_e2e.py
+++ b/tests/e2e/test_s3_garage_e2e.py
@@ -1,0 +1,112 @@
+"""End-to-end coverage for the S3 backend against a real Garage node."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import boto3
+import pytest
+from botocore.config import Config
+
+from server.app.agent.s3_backend import S3CompatibleBackend
+
+pytestmark = pytest.mark.e2e
+
+_ACCESS_KEY = "cognition-test-access"
+_SECRET_KEY = "cognition-test-secret"
+_BUCKET = "cognition-test"
+
+
+@pytest.fixture(scope="module")
+def garage_endpoint(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Start an ephemeral single-node Garage S3 service for this test module."""
+    docker = pytest.importorskip("docker")
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception as exc:  # pragma: no cover - local environment condition
+        pytest.skip(f"Docker is unavailable for Garage E2E: {type(exc).__name__}")
+
+    config_path = Path(tmp_path_factory.mktemp("garage")) / "garage.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'metadata_dir = "/tmp/meta"',
+                'data_dir = "/tmp/data"',
+                'db_engine = "sqlite"',
+                "replication_factor = 1",
+                'rpc_bind_addr = "[::]:3901"',
+                'rpc_public_addr = "127.0.0.1:3901"',
+                'rpc_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"',
+                "[s3_api]",
+                's3_region = "garage"',
+                'api_bind_addr = "[::]:3900"',
+                'root_domain = ".s3.garage.localhost"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    container = client.containers.run(
+        "dxflrs/garage:v2.3.0",
+        "/garage server --single-node --default-bucket",
+        detach=True,
+        remove=True,
+        ports={"3900/tcp": None},
+        environment={
+            "GARAGE_DEFAULT_ACCESS_KEY": _ACCESS_KEY,
+            "GARAGE_DEFAULT_SECRET_KEY": _SECRET_KEY,
+            "GARAGE_DEFAULT_BUCKET": _BUCKET,
+        },
+        volumes={str(config_path): {"bind": "/etc/garage.toml", "mode": "ro"}},
+    )
+    try:
+        container.reload()
+        port = container.attrs["NetworkSettings"]["Ports"]["3900/tcp"][0]["HostPort"]
+        endpoint = f"http://127.0.0.1:{port}"
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            region_name="garage",
+            aws_access_key_id=_ACCESS_KEY,
+            aws_secret_access_key=_SECRET_KEY,
+            config=Config(s3={"addressing_style": "path"}),
+        )
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                s3.list_objects_v2(Bucket=_BUCKET)
+                break
+            except Exception:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.5)
+        yield endpoint
+    finally:
+        try:
+            container.stop(timeout=5)
+        except Exception:
+            pass
+
+
+def test_s3_backend_against_garage(
+    garage_endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Garage behaves as an S3-compatible durable filesystem backend."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _ACCESS_KEY)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _SECRET_KEY)
+    backend = S3CompatibleBackend.from_boto3(
+        bucket=_BUCKET,
+        prefix="scope/a0b1c2",
+        endpoint_url=garage_endpoint,
+        region_name="garage",
+        force_path_style=True,
+    )
+
+    assert backend.write("/skills/release/SKILL.md", "garage e2e").error is None
+    assert backend.read("/skills/release/SKILL.md").file_data == {
+        "content": "garage e2e",
+        "encoding": "utf-8",
+    }
+    assert backend.download_files(["/skills/release/SKILL.md"])[0].content == b"garage e2e"

--- a/tests/unit/test_composite_backend_skill_routing.py
+++ b/tests/unit/test_composite_backend_skill_routing.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.protocol import LsResult
 
 from server.app.agent.sandbox_backend import CognitionLocalSandboxBackend
 
 
 class StubSkillBackend:
     def ls(self, path: str):
-        return [{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}]
-
-    def ls_info(self, path: str):
-        return [{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}]
-
-    def glob_info(self, pattern: str, path: str = "/"):
-        return []
-
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000):
-        return "stub"
-
-    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
-        return []
+        return LsResult(entries=[{"path": "/demo/", "is_dir": True, "size": 0, "modified_at": ""}])
 
 
 def test_composite_backend_routes_only_skill_paths(tmp_path):
@@ -31,13 +20,14 @@ def test_composite_backend_routes_only_skill_paths(tmp_path):
     sandbox = CognitionLocalSandboxBackend(root_dir=repo_root)
     backend = CompositeBackend(default=sandbox, routes={"/skills/api/": StubSkillBackend()})
 
-    repo_entries = backend.ls_info(str(repo_root / "Cognition-Gateway"))
+    repo_listing = backend.ls(str(repo_root / "Cognition-Gateway"))
+    assert repo_listing.entries is not None
     assert any(
         entry["path"] == str(repo_root / "Cognition-Gateway" / "README.md")
-        for entry in repo_entries
+        for entry in repo_listing.entries
     )
 
-    skill_entries = backend.ls_info("/skills/api/")
-    assert skill_entries == [
+    skill_listing = backend.ls("/skills/api/")
+    assert skill_listing.entries == [
         {"path": "/skills/api/demo/", "is_dir": True, "size": 0, "modified_at": ""}
     ]

--- a/tests/unit/test_s3_backend.py
+++ b/tests/unit/test_s3_backend.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from server.app.agent.s3_backend import S3CompatibleBackend
+
+
+class FakePaginator:
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self._objects = objects
+
+    def paginate(self, *, Bucket: str, Prefix: str):  # noqa: N803
+        del Bucket
+        return [
+            {
+                "Contents": [
+                    {"Key": key, "Size": len(value)}
+                    for key, value in self._objects.items()
+                    if key.startswith(Prefix)
+                ]
+            }
+        ]
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def get_paginator(self, operation_name: str) -> FakePaginator:
+        assert operation_name == "list_objects_v2"
+        return FakePaginator(self.objects)
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **kwargs: object) -> None:  # noqa: N803
+        del Bucket, kwargs
+        self.objects[Key] = Body
+
+    def get_object(self, *, Bucket: str, Key: str):  # noqa: N803
+        del Bucket
+        if Key not in self.objects:
+            error = RuntimeError("missing")
+            error.response = {"Error": {"Code": "NoSuchKey"}}  # type: ignore[attr-defined]
+            raise error
+        return {"Body": BytesIO(self.objects[Key])}
+
+    def delete_object(self, *, Bucket: str, Key: str) -> None:  # noqa: N803
+        del Bucket
+        self.objects.pop(Key, None)
+
+
+def test_s3_backend_isolates_prefix_and_supports_file_operations() -> None:
+    client = FakeS3Client()
+    backend = S3CompatibleBackend(client, bucket="test", prefix="scopes/opaque")
+
+    assert backend.write("/skills/demo/SKILL.md", "one\ntwo").error is None
+    assert client.objects == {"scopes/opaque/skills/demo/SKILL.md": b"one\ntwo"}
+
+    listing = backend.ls("/skills/")
+    assert listing.entries == [{"path": "/skills/demo", "is_dir": True}]
+
+    read = backend.read("/skills/demo/SKILL.md", offset=1, limit=1)
+    assert read.file_data == {"content": "two", "encoding": "utf-8"}
+    assert backend.glob("skills/**/*.md").matches == [
+        {"path": "/skills/demo/SKILL.md", "is_dir": False, "size": 7, "modified_at": ""}
+    ]
+
+    edit = backend.edit("/skills/demo/SKILL.md", "two", "three")
+    assert edit.error is None
+    assert backend.read("/skills/demo/SKILL.md").file_data == {
+        "content": "one\nthree",
+        "encoding": "utf-8",
+    }
+
+    assert backend.delete("/skills/demo/SKILL.md").error is None
+    assert (
+        backend.read("/skills/demo/SKILL.md").error
+        == "Error: File '/skills/demo/SKILL.md' not found"
+    )
+
+
+def test_s3_backend_never_allows_path_to_escape_prefix() -> None:
+    backend = S3CompatibleBackend(FakeS3Client(), bucket="test", prefix="tenant")
+
+    assert backend.write("/../../outside", "no").error is None
+    # Normalization keeps every object below the assigned prefix.
+    assert backend._key("/../../outside") == "tenant/outside"

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -93,6 +93,23 @@ class TestA2ASecuritySettings:
         assert settings.a2a_security_schemes == schemes
         assert settings.a2a_security_requirements == requirements
 
+    def test_default_durable_file_backend_is_local(self):
+        """Local and development profiles retain an explicit local backend."""
+        settings = TestSettings()
+        assert settings.durable_file_backend == "local"
+        assert not settings.s3_enabled
+
+    def test_s3_compatible_durable_file_configuration(self):
+        """Garage-style endpoint settings select the generic S3 backend."""
+        settings = TestSettings(
+            durable_file_backend="s3",
+            s3_bucket="cognition",
+            s3_endpoint_url="http://garage:3900",
+            s3_force_path_style=True,
+        )
+        assert settings.s3_enabled
+        assert settings.s3_force_path_style
+
 
 class TestSettingsSecrets:
     """Test SecretStr handling in settings."""

--- a/tests/unit/test_v013_strict_execution.py
+++ b/tests/unit/test_v013_strict_execution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -137,7 +136,7 @@ async def test_strict_agent_does_not_inject_host_browser_search_or_inspection(
 
 
 @pytest.mark.asyncio
-async def test_cached_graph_resolves_each_runs_current_sandbox_dynamically(
+async def test_deep_agents_v07_graph_is_not_cached_across_sandboxed_runs(
     tmp_path,
 ) -> None:
     clear_agent_cache()
@@ -176,15 +175,11 @@ async def test_cached_graph_resolves_each_runs_current_sandbox_dynamically(
             )
         )
 
-    assert create.call_count == 1
-    assert first.agent is second.agent is graph
-    backend_factory = create.call_args.kwargs["backend"]
-    first_context = SimpleNamespace(sandbox_backend=first.sandbox_backend)
-    second_context = SimpleNamespace(sandbox_backend=second.sandbox_backend)
-    assert backend_factory(SimpleNamespace(context=first_context)) is first_sandbox
-    assert backend_factory(SimpleNamespace(context=second_context)) is second_sandbox
-    with pytest.raises(RuntimeError, match="no assigned sandbox"):
-        backend_factory(SimpleNamespace(context=SimpleNamespace()))
+    assert create.call_count == 2
+    assert first.agent is graph
+    assert second.agent is graph
+    assert create.call_args_list[0].kwargs["backend"] is first_sandbox
+    assert create.call_args_list[1].kwargs["backend"] is second_sandbox
     clear_agent_cache()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.103.1"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -244,9 +244,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/57/0b758b08cf4606c94d63a997d67a0063f7438efbaf81cfedd0d7c0c69d67/anthropic-0.103.1.tar.gz", hash = "sha256:21c12f4fc0fdd87a2e80d58479cd0af640062b3cfb82bbfa01c7977acd4defeb", size = 848877, upload-time = "2026-05-19T15:43:27.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ec/cf357cf571377a39552c1530390a9b79bbdb6ea463f48fbe4e3624141e3b/anthropic-0.103.1-py3-none-any.whl", hash = "sha256:b9a523fac34e64caf6ee55fdbda213950e6a744b906fce100d34909aad2cd8f4", size = 832551, upload-time = "2026-05-19T15:43:29.663Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]
@@ -389,11 +389,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
 ]
 
 [[package]]
@@ -695,6 +695,9 @@ openai = [
     { name = "langchain-openai" },
     { name = "openai" },
 ]
+s3 = [
+    { name = "boto3" },
+]
 test = [
     { name = "httpx" },
     { name = "pytest" },
@@ -716,7 +719,8 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'deploy'", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
-    { name = "deepagents", specifier = ">=0.6.2" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
+    { name = "deepagents", specifier = ">=0.7.1" },
     { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
     { name = "docker", marker = "extra == 'deploy'", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -733,7 +737,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.4.0" },
     { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'all'", editable = "packages/langchain-k8s-sandbox" },
     { name = "langchain-k8s-sandbox", extras = ["k8s"], marker = "extra == 'k8s'", editable = "packages/langchain-k8s-sandbox" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.1" },
     { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2.0" },
@@ -785,7 +789,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["all", "aws-lambda-microvms", "bedrock", "deploy", "dev", "docs", "k8s", "openai", "test"]
+provides-extras = ["all", "aws-lambda-microvms", "bedrock", "deploy", "dev", "docs", "k8s", "openai", "s3", "test"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
@@ -1082,7 +1086,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.6.12"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -1090,11 +1094,12 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e3/00c98c6b677ba89270b09dcb950848c794d507168b3dc53fa4d5cfb6a2e3/deepagents-0.7.1.tar.gz", hash = "sha256:a556a8af8dac84ee5708d7e97752eda40d613d19e25cc79b7d0e8c728da03c40", size = 270546, upload-time = "2026-07-30T20:34:26.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/3306ab2f544e08ea33852f92d0fb3ab8fbf437c84e5f58189f0e4f895087/deepagents-0.7.1-py3-none-any.whl", hash = "sha256:cbcfb856e95ecc8a969b9d036b1d6b760524ca9a5b83f00e53ae568ddebfd343", size = 297359, upload-time = "2026-07-30T20:34:24.846Z" },
 ]
 
 [[package]]
@@ -2094,30 +2099,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.7"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/d0/5b117541b9e13619a387b3c829b97ef8d54f848716c0cb574df35a326dea/langchain_anthropic-1.4.7.tar.gz", hash = "sha256:34a7eb0db6bb7c92ff89b3f985de6417d5ef7a148d4595f4498fd3ca4f14aa77", size = 706692, upload-time = "2026-06-22T22:56:05.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/5b/25ffc9cc66a8260db9e2da2836ee33b260dfbb874d1ea2f99d70023f2b1d/langchain_anthropic-1.5.3.tar.gz", hash = "sha256:48a7e4fc3856c42f9dcb4396ba112afcdd8dee21b70a402bc43283c970de3941", size = 713962, upload-time = "2026-07-28T17:02:55.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/bf/78c71bdd7b9ec6fcd6ca45114d5910bfbad2fba21e5223523e793a17520d/langchain_anthropic-1.4.7-py3-none-any.whl", hash = "sha256:2e9d9dd4cb66de19394d7a9d552e1dbf2cd3c1da9f799a0c372b5fc84e298d8f", size = 51978, upload-time = "2026-06-22T22:56:04.349Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/19/584ab8517718f48bb411d051be713ebd8b58351741f8a4ca23d6a305cb1b/langchain_anthropic-1.5.3-py3-none-any.whl", hash = "sha256:b1b72b7c9e4bf5c044660629ebbcb79cef18c140fdc80174750eb86de13ec8bc", size = 54034, upload-time = "2026-07-28T17:02:54.594Z" },
 ]
 
 [[package]]
@@ -2165,7 +2170,7 @@ provides-extras = ["aws", "test"]
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2178,14 +2183,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/3e/63af6b9d76d9be907c7c524d6ec18a2efed7e0e2d123fea0230d78dbd73f/langchain_core-1.5.3.tar.gz", hash = "sha256:a56457ac444fef41e9404443c187f0ecea708d36e816ea4ba9573c027f7d1a2d", size = 972461, upload-time = "2026-07-30T14:55:55.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e6/c7c39efe0bc7e1b7c3d8f54f85846e04c901913c3d3e99068b218558c6f1/langchain_core-1.5.3-py3-none-any.whl", hash = "sha256:48b56fa580277209594dd7baf837f5b9a2a3651613f34ff9fb1728b429df015f", size = 561687, upload-time = "2026-07-30T14:55:54.419Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.6"
+version = "4.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2193,9 +2198,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/08/68e4f90b273d1d8dc3a7a948e6535e60baac726adbb2a8341dcf17662f54/langchain_google_genai-4.2.6.tar.gz", hash = "sha256:653dc331e691ddd79784d9ff6a4082749e0f873394c6dc782c414eb4409850eb", size = 280074, upload-time = "2026-06-26T06:18:58.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/2f/e03b63ad3a61fd1aa479bbc0f3df5d27abb8f9159d111cba96629df844ef/langchain_google_genai-4.3.2.tar.gz", hash = "sha256:6471769a4463fedb10d2d19a9b56c31de1cde505edf7fffd8cdbf98af8c1d7da", size = 286018, upload-time = "2026-07-27T16:27:39.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/3c/9a6b43bced0238f95640555e14423fe4a8268e3f4f536f67e26e79e633d4/langchain_google_genai-4.2.6-py3-none-any.whl", hash = "sha256:c40db0c2d033a5fb6db8e2cc3fb6d49c5678b89b337a64da095fb73ec9f72021", size = 70457, upload-time = "2026-06-26T06:18:57.781Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/4a2eb187b108a240d57cf8dcf67e818ca75365f769444bf5716e2823cd98/langchain_google_genai-4.3.2-py3-none-any.whl", hash = "sha256:f3b1c09b264612fd1735a9590987bfa0cccca0bc0111691543decb5a03b8667d", size = 72770, upload-time = "2026-07-27T16:27:38.052Z" },
 ]
 
 [[package]]
@@ -2226,16 +2231,16 @@ provides-extras = ["k8s", "test"]
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/5d/1f43b6a14cf448ea47bceb2860e9a6e3b0a911de0719aba43ed3eb927195/langchain_mcp_adapters-0.3.1.tar.gz", hash = "sha256:e08d4a74a0934d558ddb807ecbb8f89466c93a0d06c1fb58974b93b4703de01c", size = 47140, upload-time = "2026-07-27T18:36:45.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8d/934946caf18559158678099ac00e6eed67d78e68c4e73c7afd01e19d31ec/langchain_mcp_adapters-0.3.1-py3-none-any.whl", hash = "sha256:1e354d9466db9fab9e30f24419adffbd39a84229e7f452927f99ea799e1937f9", size = 28877, upload-time = "2026-07-27T18:36:44.762Z" },
 ]
 
 [[package]]
@@ -2354,7 +2359,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.3"
+version = "0.10.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2372,9 +2377,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/bb/bce9faa416dfd28e1cf60bf6299e9569f9e8483b0ed22eed1d6aefc9e81c/langsmith-0.10.15.tar.gz", hash = "sha256:eefc562b29eb642a635b459e5bb44ca574380d7f32fe840acf28cd603c168647", size = 4790873, upload-time = "2026-07-31T18:15:18.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fb/dc9f70b5581371fba7b01ba0704fe859bfcd12c4dad82b42ec12bd4160b1/langsmith-0.9.3-py3-none-any.whl", hash = "sha256:aac85686868a7e61d77858b880230e510583c61ea48ac0a197e6ceff64ffb22b", size = 619927, upload-time = "2026-06-26T15:56:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7a/58602b770741bc84b0b35b580914f335f6663f4ea699b95eb12b074e70b8/langsmith-0.10.15-py3-none-any.whl", hash = "sha256:7afd7979a9cdf846a88c980e0a31ed518c33631d29e672adbfbb33446f3817cf", size = 731606, upload-time = "2026-07-31T18:15:16.471Z" },
 ]
 
 [package.optional-dependencies]
@@ -5385,14 +5390,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -339,15 +339,15 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "7.0"
+version = "8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/56/4744bcd0c82184e80c52b0ac4076c261a8ffa1f1b343ff2f6e89ce0e1cef/backrefs-8.0.tar.gz", hash = "sha256:b556cd7d36c3a3a2f256b89590b176b8eddfb73bcfaee3a3ddd84ea66d21ce50", size = 7013081, upload-time = "2026-07-26T19:54:24.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
-    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/fd/9bf53b6a6f6f519ffaac765df2f2a25e5c2fc6d32cfd2b2747099e72c911/backrefs-8.0-py310-none-any.whl", hash = "sha256:4a627b817fd2dce43b79ab48da63613340509381cd8ce0897078a0bce79a2ab8", size = 380377, upload-time = "2026-07-26T19:54:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/29/4bd7ae72a2634da00379c2b3bcc5439e7c94620235c6afea8af15229a973/backrefs-8.0-py311-none-any.whl", hash = "sha256:f0c35cf0102ba6b6070c12a492be3c1c1d3f5839529784b9a9565d6d04569a01", size = 392169, upload-time = "2026-07-26T19:54:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
 ]
 
 [[package]]
@@ -2490,11 +2490,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
 ]
 
 [[package]]
@@ -2730,7 +2730,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -2745,9 +2745,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]
@@ -4130,15 +4130,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade Deep Agents and LangChain MCP adapters to the v0.14 runtime contract
- align sandbox and artifact backends with the Deep Agents 0.7 backend protocol
- add AWS S3-compatible durable backend using standard credentials and Garage path-style support, plus real Garage E2E coverage

## Verification
- uv run ruff check .
- uv run pytest tests/unit/test_s3_backend.py tests/unit/test_settings.py -q

The full release suite will run in CI.