### PR TITLE
feat: add skill bundles and durable artifact storage

### DIFF
--- a/server/app/agent/s3_backend.py
+++ b/server/app/agent/s3_backend.py
@@ -8,6 +8,9 @@ S3-compatible deployments such as Garage through an explicit endpoint URL.
 from __future__ import annotations
 
 import fnmatch
+import hashlib
+import hmac
+import json
 import posixpath
 from collections.abc import Iterable
 from datetime import UTC, datetime
@@ -42,6 +45,22 @@ class S3CompatibleBackend(BackendProtocol):
         self._client = client
         self._bucket = bucket
         self._prefix = prefix.strip("/")
+
+    @staticmethod
+    def scope_prefix(
+        *, base_prefix: str, effective_scope: dict[str, str], hmac_key: str
+    ) -> str:
+        """Derive an opaque namespace for one immutable effective scope.
+
+        Object keys must not reveal tenant, user, or project identifiers.  The
+        canonical JSON encoding makes equal scopes resolve to the same prefix
+        independent of mapping insertion order.
+        """
+        canonical_scope = json.dumps(
+            effective_scope, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        digest = hmac.new(hmac_key.encode("utf-8"), canonical_scope, hashlib.sha256).hexdigest()
+        return "/".join(part for part in (base_prefix.strip("/"), "scopes", digest) if part)
 
     @classmethod
     def from_boto3(

--- a/server/app/agent/skills_backend.py
+++ b/server/app/agent/skills_backend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import structlog
 from deepagents.backends.protocol import (
@@ -112,7 +112,7 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         return file_infos
 
     async def adownload_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        """Download SKILL.md file content for SkillsMiddleware.
+        """Download bundle file content for SkillsMiddleware and file tools.
 
         SkillsMiddleware calls this to get the actual skill content for parsing
         YAML frontmatter.
@@ -126,21 +126,21 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         responses: list[FileDownloadResponse] = []
 
         for file_path in paths:
-            # Extract skill name from path like "/web-research/SKILL.md"
-            # (CompositeBackend has already stripped the /skills/api/ prefix)
-            if not file_path.startswith("/") or not file_path.endswith("/SKILL.md"):
+            parsed = _parse_bundle_path(file_path)
+            if parsed is None:
                 responses.append(FileDownloadResponse(path=file_path, error="invalid_path"))
                 continue
-
-            # Remove leading slash and /SKILL.md suffix to get skill name
-            skill_name = file_path[1 : -len("/SKILL.md")]
+            skill_name, relative_path = parsed
 
             try:
                 skill = await self._get_skill(skill_name)
                 if skill is None or not skill.enabled:
                     responses.append(FileDownloadResponse(path=file_path, error="file_not_found"))
                 else:
-                    content = skill.content or ""
+                    content = _bundle_content(skill, relative_path)
+                    if content is None:
+                        responses.append(FileDownloadResponse(path=file_path, error="file_not_found"))
+                        continue
                     responses.append(
                         FileDownloadResponse(
                             path=file_path,
@@ -183,18 +183,19 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
         Returns:
             Formatted file content with line numbers, or an error result.
         """
-        # Reuse the same logic as adownload_files but return formatted string
-        if not file_path.startswith("/") or not file_path.endswith("/SKILL.md"):
+        parsed = _parse_bundle_path(file_path)
+        if parsed is None:
             return ReadResult(error=f"Invalid path {file_path}")
-
-        skill_name = file_path[1 : -len("/SKILL.md")]
+        skill_name, relative_path = parsed
 
         try:
             skill = await self._get_skill(skill_name)
             if skill is None or not skill.enabled:
                 return ReadResult(error=f"Skill not found: {skill_name}")
 
-            content = skill.content or ""
+            content = _bundle_content(skill, relative_path)
+            if content is None:
+                return ReadResult(error=f"Skill bundle file not found: {relative_path}")
             lines = content.splitlines()
 
             # Apply offset and limit
@@ -247,3 +248,20 @@ class ConfigRegistrySkillsBackend(BackendProtocol):
     # are intentionally not implemented. SkillsMiddleware only needs als_info,
     # adownload_files, and aread. All other paths are handled by the default
     # sandbox backend via CompositeBackend routing.
+
+
+def _parse_bundle_path(path: str) -> tuple[str, str] | None:
+    """Parse a route-relative skill bundle path without allowing traversal."""
+    if not path.startswith("/"):
+        return None
+    parts = path.lstrip("/").split("/")
+    if len(parts) < 2 or any(part in {"", ".", ".."} for part in parts):
+        return None
+    return parts[0], "/".join(parts[1:])
+
+
+def _bundle_content(skill: Any, relative_path: str) -> str | None:
+    """Return the primary document or a declared supporting bundle file."""
+    if relative_path == "SKILL.md":
+        return skill.content or ""
+    return cast(dict[str, str], skill.files).get(relative_path)

--- a/server/app/bootstrap.py
+++ b/server/app/bootstrap.py
@@ -250,6 +250,15 @@ async def seed_skills_from_sources(
                 continue
 
             content = skill_md.read_text(encoding="utf-8")
+            files: dict[str, str] = {}
+            for candidate in skill_dir.rglob("*"):
+                if not candidate.is_file() or candidate == skill_md:
+                    continue
+                relative_path = candidate.relative_to(skill_dir).as_posix()
+                try:
+                    files[relative_path] = candidate.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    logger.warning("Skipping non-text skill bundle file", path=str(candidate))
             name = skill_dir.name
             description: str | None = None
             try:
@@ -270,6 +279,7 @@ async def seed_skills_from_sources(
                 enabled=True,
                 description=description,
                 content=content,
+                files=files,
                 scope={},
                 source="file",
             )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -69,6 +69,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         json_format=settings.log_format == "json",
     )
     logger.info("Starting Cognition server")
+    settings.validate_deployment_storage_policy()
 
     # Initialize storage backend
     storage_backend = create_storage_backend(settings)

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
         alias="COGNITION_LOG_FORMAT",
         description="Structured log renderer. Use 'console' for local development.",
     )
+    deployment_mode: Literal["local", "development", "production"] = Field(
+        default="development",
+        alias="COGNITION_DEPLOYMENT_MODE",
+        description="Deployment safety profile. Production rejects host-backed runtime state.",
+    )
 
     # Workspace settings
     workspace_root: Path = Field(
@@ -220,6 +225,14 @@ class Settings(BaseSettings):
         default=False,
         alias="COGNITION_S3_FORCE_PATH_STYLE",
         description="Use path-style S3 requests for Garage and similar compatible stores.",
+    )
+    s3_scope_hmac_key: SecretStr | None = Field(
+        default=None,
+        alias="COGNITION_S3_SCOPE_HMAC_KEY",
+        description=(
+            "HMAC key used to derive opaque, exact-scope object prefixes. "
+            "It is never persisted or exposed to agent runtime data."
+        ),
     )
 
     # Sandbox / Execution backend settings
@@ -485,6 +498,29 @@ class Settings(BaseSettings):
     def s3_enabled(self) -> bool:
         """Return whether durable file data is configured for S3-compatible storage."""
         return self.durable_file_backend == "s3"
+
+    def validate_deployment_storage_policy(self) -> None:
+        """Reject production settings that could persist runtime data on the host.
+
+        Local and development modes intentionally retain SQLite, memory, and
+        local files for a frictionless developer experience.  Production must
+        explicitly select durable infrastructure instead of silently falling
+        back to a workspace path.
+        """
+        if self.s3_enabled and not self.s3_bucket:
+            raise ValueError("COGNITION_S3_BUCKET is required when durable_file_backend=s3")
+        if self.s3_enabled and self.s3_scope_hmac_key is None:
+            raise ValueError(
+                "COGNITION_S3_SCOPE_HMAC_KEY is required when durable_file_backend=s3"
+            )
+        if self.deployment_mode != "production":
+            return
+        if self.persistence_backend != "postgres":
+            raise ValueError("production requires COGNITION_PERSISTENCE_BACKEND=postgres")
+        if not self.s3_enabled:
+            raise ValueError("production requires COGNITION_DURABLE_FILE_BACKEND=s3")
+        if self.sandbox_backend == "local":
+            raise ValueError("production cannot use COGNITION_SANDBOX_BACKEND=local")
 
 
 # Global settings instance

--- a/server/app/storage/artifact_store.py
+++ b/server/app/storage/artifact_store.py
@@ -573,9 +573,120 @@ class MemoryArtifactStore:
         return versions
 
 
+class S3ArtifactStore:
+    """Persist artifact manifests in a database and immutable bodies in S3.
+
+    The wrapped store remains authoritative for identity, version, scope, and
+    lifecycle metadata.  Artifact content is never sent to that store when
+    this wrapper is enabled.
+    """
+
+    def __init__(
+        self,
+        manifest_store: ArtifactStore,
+        *,
+        bucket: str,
+        base_prefix: str,
+        hmac_key: str,
+        endpoint_url: str | None = None,
+        region_name: str | None = None,
+        force_path_style: bool = False,
+    ) -> None:
+        self._manifest_store = manifest_store
+        self._bucket = bucket
+        self._base_prefix = base_prefix
+        self._hmac_key = hmac_key
+        self._endpoint_url = endpoint_url
+        self._region_name = region_name
+        self._force_path_style = force_path_style
+
+    def _backend(self, scope: dict[str, str]) -> Any:
+        from server.app.agent.s3_backend import S3CompatibleBackend
+
+        return S3CompatibleBackend.from_boto3(
+            bucket=self._bucket,
+            prefix=S3CompatibleBackend.scope_prefix(
+                base_prefix=self._base_prefix,
+                effective_scope=scope,
+                hmac_key=self._hmac_key,
+            ),
+            endpoint_url=self._endpoint_url,
+            region_name=self._region_name,
+            force_path_style=self._force_path_style,
+        )
+
+    @staticmethod
+    def _path(artifact: ArtifactDefinition) -> str:
+        return f"/artifacts/{artifact.artifact_type}/{artifact.id}/{artifact.version}"
+
+    async def initialize(self) -> None:
+        initialize = getattr(self._manifest_store, "initialize", None)
+        if initialize is not None:
+            await initialize()
+
+    async def close(self) -> None:
+        close = getattr(self._manifest_store, "close", None)
+        if close is not None:
+            await close()
+
+    async def _hydrate(self, artifact: ArtifactDefinition | None) -> ArtifactDefinition | None:
+        if artifact is None:
+            return None
+        result = self._backend(artifact.scope).read(self._path(artifact), limit=2**31 - 1)
+        if result.error or result.file_data is None:
+            raise RuntimeError("Artifact body is unavailable from configured durable storage")
+        return artifact.model_copy(update={"content": result.file_data["content"]})
+
+    async def get_artifact(
+        self, artifact_id: str, scope: dict[str, str] | None = None
+    ) -> ArtifactDefinition | None:
+        return await self._hydrate(await self._manifest_store.get_artifact(artifact_id, scope))
+
+    async def list_artifacts(
+        self,
+        scope: dict[str, str] | None = None,
+        artifact_type: str | None = None,
+        run_id: str | None = None,
+    ) -> list[ArtifactDefinition]:
+        manifests = await self._manifest_store.list_artifacts(scope, artifact_type, run_id)
+        hydrated = [await self._hydrate(artifact) for artifact in manifests]
+        return [artifact for artifact in hydrated if artifact is not None]
+
+    async def upsert_artifact(self, artifact: ArtifactDefinition) -> None:
+        write = self._backend(artifact.scope).write(self._path(artifact), artifact.content)
+        if write.error:
+            raise RuntimeError("Artifact body could not be written to configured durable storage")
+        await self._manifest_store.upsert_artifact(artifact.model_copy(update={"content": ""}))
+
+    async def delete_artifact(
+        self, artifact_id: str, scope: dict[str, str] | None = None
+    ) -> bool:
+        versions = await self._manifest_store.list_artifact_versions(artifact_id, scope)
+        for artifact in versions:
+            deleted = self._backend(artifact.scope).delete(self._path(artifact))
+            if deleted.error:
+                raise RuntimeError("Artifact body could not be deleted from configured durable storage")
+        return await self._manifest_store.delete_artifact(artifact_id, scope)
+
+    async def get_artifact_version(
+        self, artifact_id: str, version: int, scope: dict[str, str] | None = None
+    ) -> ArtifactDefinition | None:
+        return await self._hydrate(
+            await self._manifest_store.get_artifact_version(artifact_id, version, scope)
+        )
+
+    async def list_artifact_versions(
+        self, artifact_id: str, scope: dict[str, str] | None = None
+    ) -> list[ArtifactDefinition]:
+        manifests = await self._manifest_store.list_artifact_versions(artifact_id, scope)
+        hydrated = [await self._hydrate(artifact) for artifact in manifests]
+        return [artifact for artifact in hydrated if artifact is not None]
+
+
 __all__ = [
     "ArtifactStore",
     "MemoryArtifactStore",
     "PostgresArtifactStore",
+    "S3ArtifactStore",
     "SqliteArtifactStore",
 ]

--- a/server/app/storage/config_models.py
+++ b/server/app/storage/config_models.py
@@ -251,6 +251,10 @@ class SkillDefinition(BaseModel):
     enabled: bool = Field(default=True)
     description: str | None = Field(default=None)
     content: str | None = Field(default=None)
+    files: dict[str, str] = Field(
+        default_factory=dict,
+        description="Supporting bundle files keyed by safe, relative POSIX paths.",
+    )
     scope: dict[str, str] = Field(default_factory=dict)
     source: Literal["file", "api"] = Field(default="file")
 
@@ -261,6 +265,18 @@ class SkillDefinition(BaseModel):
         if not v.replace("-", "").replace("_", "").isalnum():
             raise ValueError(f"Skill name must be alphanumeric with hyphens/underscores only: {v}")
         return v
+
+    @field_validator("files")
+    @classmethod
+    def validate_bundle_files(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject absolute, traversal, and non-text bundle entries."""
+        for path, content in value.items():
+            parts = path.split("/")
+            if not path or path.startswith("/") or any(part in {"", ".", ".."} for part in parts):
+                raise ValueError("Skill bundle file paths must be safe relative POSIX paths")
+            if not isinstance(content, str):
+                raise ValueError("Skill bundle file contents must be text")
+        return value
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/storage/factory.py
+++ b/server/app/storage/factory.py
@@ -186,18 +186,18 @@ def create_artifact_store(settings: Settings) -> ArtifactStore:
         if not db_path.is_absolute():
             db_path = Path(workspace_path) / normalized_uri
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        return SqliteArtifactStore(db_path=str(db_path))
+        store: ArtifactStore = SqliteArtifactStore(db_path=str(db_path))
 
     elif backend_type == "postgres":
         from server.app.storage.artifact_store import PostgresArtifactStore
 
         asyncpg_dsn = uri.replace("postgresql+asyncpg://", "postgresql://", 1)
-        return PostgresArtifactStore(dsn=asyncpg_dsn)
+        store = PostgresArtifactStore(dsn=asyncpg_dsn)
 
     elif backend_type == "memory":
         from server.app.storage.artifact_store import MemoryArtifactStore
 
-        return MemoryArtifactStore()
+        store = MemoryArtifactStore()
 
     else:
         raise StorageBackendError(
@@ -205,3 +205,20 @@ def create_artifact_store(settings: Settings) -> ArtifactStore:
             f"Supported types: sqlite, postgres, memory",
             backend_type=backend_type,
         )
+
+    if not settings.s3_enabled:
+        return store
+
+    from server.app.storage.artifact_store import S3ArtifactStore
+
+    if settings.s3_bucket is None or settings.s3_scope_hmac_key is None:
+        raise StorageBackendError("S3 artifact storage is missing required configuration", "s3")
+    return S3ArtifactStore(
+        store,
+        bucket=settings.s3_bucket,
+        base_prefix=settings.s3_prefix,
+        hmac_key=settings.s3_scope_hmac_key.get_secret_value(),
+        endpoint_url=settings.s3_endpoint_url,
+        region_name=settings.s3_region,
+        force_path_style=settings.s3_force_path_style,
+    )

--- a/tests/e2e/test_s3_garage_e2e.py
+++ b/tests/e2e/test_s3_garage_e2e.py
@@ -11,6 +11,8 @@ import pytest
 from botocore.config import Config
 
 from server.app.agent.s3_backend import S3CompatibleBackend
+from server.app.storage.artifact_store import MemoryArtifactStore, S3ArtifactStore
+from server.app.storage.config_models import ArtifactDefinition
 
 pytestmark = pytest.mark.e2e
 
@@ -110,3 +112,56 @@ def test_s3_backend_against_garage(
         "encoding": "utf-8",
     }
     assert backend.download_files(["/skills/release/SKILL.md"])[0].content == b"garage e2e"
+
+
+@pytest.mark.asyncio
+async def test_s3_artifact_store_against_garage_keeps_scope_bodies_out_of_manifests(
+    garage_endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Artifact manifests stay in the database while Garage holds scoped bodies."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _ACCESS_KEY)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _SECRET_KEY)
+    manifests = MemoryArtifactStore()
+    store = S3ArtifactStore(
+        manifests,
+        bucket=_BUCKET,
+        base_prefix="cognition",
+        hmac_key="test-hmac-key",
+        endpoint_url=garage_endpoint,
+        region_name="garage",
+        force_path_style=True,
+    )
+    acme = ArtifactDefinition(
+        id="report",
+        name="report",
+        artifact_type="artifact",
+        content="acme-only body",
+        scope={"tenant": "acme"},
+    )
+    globex = acme.model_copy(
+        update={"content": "globex-only body", "scope": {"tenant": "globex"}}
+    )
+
+    await store.upsert_artifact(acme)
+    await store.upsert_artifact(globex)
+
+    assert (await manifests.get_artifact("report", {"tenant": "acme"})).content == ""  # type: ignore[union-attr]
+    assert (await manifests.get_artifact("report", {"tenant": "globex"})).content == ""  # type: ignore[union-attr]
+    assert (await store.get_artifact("report", {"tenant": "acme"})).content == "acme-only body"  # type: ignore[union-attr]
+    assert (await store.get_artifact("report", {"tenant": "globex"})).content == "globex-only body"  # type: ignore[union-attr]
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=garage_endpoint,
+        region_name="garage",
+        aws_access_key_id=_ACCESS_KEY,
+        aws_secret_access_key=_SECRET_KEY,
+        config=Config(s3={"addressing_style": "path"}),
+    )
+    keys = [item["Key"] for item in s3.list_objects_v2(Bucket=_BUCKET).get("Contents", [])]
+    assert len([key for key in keys if key.endswith("/artifacts/artifact/report/1")]) == 2
+    assert all("acme" not in key and "globex" not in key for key in keys)
+
+    assert await store.delete_artifact("report", {"tenant": "acme"})
+    assert await store.get_artifact("report", {"tenant": "acme"}) is None
+    assert (await store.get_artifact("report", {"tenant": "globex"})).content == "globex-only body"  # type: ignore[union-attr]

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -198,6 +198,8 @@ class TestSeedSkillsFromSources:
             "---\nname: clean-code\ndescription: Use this skill for clean code.\n---\n\n# Clean Code\n",
             encoding="utf-8",
         )
+        (source_dir / "references").mkdir()
+        (source_dir / "references" / "guide.md").write_text("Supporting guide", encoding="utf-8")
 
         store = DefaultConfigStore(MemoryConfigRegistry(), workspace_path=tmp_path)
         inserted = await seed_skills_from_sources(
@@ -211,6 +213,7 @@ class TestSeedSkillsFromSources:
         assert skill is not None
         assert skill.source == "file"
         assert skill.description == "Use this skill for clean code."
+        assert skill.files == {"references/guide.md": "Supporting guide"}
 
     @pytest.mark.asyncio
     async def test_does_not_override_api_skill(self, tmp_path: Path) -> None:

--- a/tests/unit/test_s3_artifact_store.py
+++ b/tests/unit/test_s3_artifact_store.py
@@ -1,0 +1,76 @@
+"""Tests for database-manifest / S3-body artifact persistence."""
+
+from __future__ import annotations
+
+import pytest
+from deepagents.backends.protocol import DeleteResult, FileData, ReadResult, WriteResult
+
+from server.app.storage.artifact_store import MemoryArtifactStore, S3ArtifactStore
+from server.app.storage.config_models import ArtifactDefinition
+
+
+class _FakeObjectBackend:
+    def __init__(self) -> None:
+        self.objects: dict[str, str] = {}
+
+    def write(self, path: str, content: str) -> WriteResult:
+        self.objects[path] = content
+        return WriteResult(path=path)
+
+    def read(self, path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        del offset, limit
+        content = self.objects.get(path)
+        if content is None:
+            return ReadResult(error="missing")
+        return ReadResult(file_data=FileData(content=content, encoding="utf-8"))
+
+    def delete(self, path: str) -> DeleteResult:
+        self.objects.pop(path, None)
+        return DeleteResult(path=path)
+
+
+@pytest.mark.asyncio
+async def test_s3_artifact_store_keeps_body_out_of_database_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifests = MemoryArtifactStore()
+    store = S3ArtifactStore(
+        manifests,
+        bucket="test",
+        base_prefix="cognition",
+        hmac_key="test-key",
+    )
+    backend = _FakeObjectBackend()
+    monkeypatch.setattr(store, "_backend", lambda scope: backend)
+    artifact = ArtifactDefinition(
+        id="report",
+        name="report",
+        artifact_type="artifact",
+        content="tenant-safe content",
+        scope={"tenant": "acme"},
+    )
+
+    await store.upsert_artifact(artifact)
+
+    manifest = await manifests.get_artifact("report", {"tenant": "acme"})
+    assert manifest is not None
+    assert manifest.content == ""
+    assert backend.objects == {"/artifacts/artifact/report/1": "tenant-safe content"}
+
+    hydrated = await store.get_artifact("report", {"tenant": "acme"})
+    assert hydrated is not None
+    assert hydrated.content == "tenant-safe content"
+
+
+@pytest.mark.asyncio
+async def test_s3_artifact_store_deletes_versioned_bodies(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifests = MemoryArtifactStore()
+    store = S3ArtifactStore(manifests, bucket="test", base_prefix="cognition", hmac_key="test-key")
+    backend = _FakeObjectBackend()
+    monkeypatch.setattr(store, "_backend", lambda scope: backend)
+    first = ArtifactDefinition(id="report", name="report", content="one", scope={"tenant": "acme"})
+    second = first.model_copy(update={"content": "two", "version": 2, "parent_version": 1})
+
+    await store.upsert_artifact(first)
+    await store.upsert_artifact(second)
+    assert await store.delete_artifact("report", {"tenant": "acme"})
+    assert backend.objects == {}
+    assert await manifests.get_artifact("report", {"tenant": "acme"}) is None

--- a/tests/unit/test_s3_backend.py
+++ b/tests/unit/test_s3_backend.py
@@ -83,3 +83,20 @@ def test_s3_backend_never_allows_path_to_escape_prefix() -> None:
     assert backend.write("/../../outside", "no").error is None
     # Normalization keeps every object below the assigned prefix.
     assert backend._key("/../../outside") == "tenant/outside"
+
+
+def test_scope_prefix_is_opaque_and_stable_for_an_exact_scope() -> None:
+    prefix = S3CompatibleBackend.scope_prefix(
+        base_prefix="cognition",
+        effective_scope={"tenant": "acme", "user": "ada"},
+        hmac_key="test-key",
+    )
+
+    assert prefix.startswith("cognition/scopes/")
+    assert "acme" not in prefix
+    assert "ada" not in prefix
+    assert prefix == S3CompatibleBackend.scope_prefix(
+        base_prefix="cognition",
+        effective_scope={"user": "ada", "tenant": "acme"},
+        hmac_key="test-key",
+    )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -99,6 +99,29 @@ class TestA2ASecuritySettings:
         assert settings.durable_file_backend == "local"
         assert not settings.s3_enabled
 
+    def test_s3_backend_requires_bucket_and_scope_key_at_startup(self):
+        with pytest.raises(ValueError, match="COGNITION_S3_BUCKET"):
+            TestSettings(durable_file_backend="s3").validate_deployment_storage_policy()
+
+        with pytest.raises(ValueError, match="COGNITION_S3_SCOPE_HMAC_KEY"):
+            TestSettings(
+                durable_file_backend="s3", s3_bucket="cognition"
+            ).validate_deployment_storage_policy()
+
+    def test_production_rejects_host_backed_runtime_storage(self):
+        with pytest.raises(ValueError, match="PERSISTENCE_BACKEND=postgres"):
+            TestSettings(deployment_mode="production").validate_deployment_storage_policy()
+
+        settings = TestSettings(
+            deployment_mode="production",
+            persistence_backend="postgres",
+            durable_file_backend="s3",
+            s3_bucket="cognition",
+            s3_scope_hmac_key="test-key",
+            sandbox_backend="docker",
+        )
+        settings.validate_deployment_storage_policy()
+
     def test_s3_compatible_durable_file_configuration(self):
         """Garage-style endpoint settings select the generic S3 backend."""
         settings = TestSettings(

--- a/tests/unit/test_skills_backend.py
+++ b/tests/unit/test_skills_backend.py
@@ -149,8 +149,8 @@ class TestAdownloadFiles:
         assert result[0].error == "file_not_found"
 
     async def test_returns_invalid_path_for_malformed_paths(self, backend):
-        """Should return invalid_path for non-SKILL.md paths."""
-        result = await backend.adownload_files(["/some/other/file.txt"])
+        """Should return invalid_path for paths outside a skill bundle."""
+        result = await backend.adownload_files(["/../file.txt"])
         assert result[0].error == "invalid_path"
 
     async def test_handles_empty_content(self, registry, backend):
@@ -189,6 +189,19 @@ class TestAdownloadFiles:
         assert result[0].content == b"# skill-a"
         assert result[1].content == b"# skill-b"
         assert result[2].error == "file_not_found"
+
+    async def test_downloads_skill_supporting_file(self, registry, backend):
+        await registry.upsert_skill(
+            SkillDefinition(
+                name="bundle-skill",
+                path="/skills/api/bundle-skill/SKILL.md",
+                content="# Bundle",
+                files={"references/guide.md": "Supporting guidance"},
+            )
+        )
+
+        result = await backend.adownload_files(["/bundle-skill/references/guide.md"])
+        assert result[0].content == b"Supporting guidance"
 
 
 class TestAread:
@@ -242,6 +255,19 @@ class TestAread:
         assert lines[0].startswith("     2")
         assert lines[1].startswith("     3")
 
+    async def test_reads_supporting_file(self, registry, backend):
+        await registry.upsert_skill(
+            SkillDefinition(
+                name="bundle-skill",
+                path="/skills/api/bundle-skill/SKILL.md",
+                content="# Bundle",
+                files={"examples/example.txt": "one\ntwo"},
+            )
+        )
+
+        result = await backend.aread("/bundle-skill/examples/example.txt")
+        assert "one" in self._content(result)
+
     async def test_returns_error_for_missing_skill(self, backend):
         """Should return error for non-existent skill."""
         result = await backend.aread("/missing/SKILL.md")
@@ -264,7 +290,7 @@ class TestAread:
 
     async def test_returns_error_for_invalid_path(self, backend):
         """Should return error for malformed path."""
-        result = await backend.aread("/invalid/path.txt")
+        result = await backend.aread("/invalid/../path.txt")
         assert result.error is not None
         assert "Invalid path" in result.error
 


### PR DESCRIPTION
## Summary
- support complete Deep Agents skill bundles, including safe supporting files
- persist artifact bodies in S3-compatible object storage with opaque scope prefixes
- enforce PostgreSQL, S3, and non-local sandboxing for production while retaining local SQLite and memory development modes
- add unit coverage and Garage-backed S3 artifact coverage

## Validation
- `uv run ruff check …`
- `uv run mypy …`
- `uv run pytest tests/unit/test_skills_backend.py tests/unit/test_s3_backend.py tests/unit/test_s3_artifact_store.py tests/unit/test_settings.py -q`