### PR TITLE
feat: define standard MCP authentication modes

### DIFF
--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -795,8 +795,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
             _build_mcp_callbacks,
         )
 
-        enabled_configs = [c for c in params.mcp_configs if c.enabled]
-        if enabled_configs:
+        if params.mcp_configs:
             if not settings.allow_host_tools:
                 STRICT_EXECUTION_REJECTIONS_TOTAL.labels(reason="host_mcp_tools").inc()
                 raise RuntimeError(
@@ -807,7 +806,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
             try:
                 mcp_callbacks = _build_mcp_callbacks()
                 mcp_tools = await load_mcp_tools_per_server(
-                    enabled_configs,
+                    params.mcp_configs,
                     callbacks=mcp_callbacks,
                 )
                 agent_tools.extend(mcp_tools)

--- a/server/app/agent/definition.py
+++ b/server/app/agent/definition.py
@@ -212,49 +212,94 @@ class AgentConfig(BaseModel):
     sandbox_execution_role_arn: str | None = Field(default=None)
 
 
-class McpAuthConfig(BaseModel):
-    """Outbound authentication policy for one Agent-scoped MCP server."""
+MCPAuthType = Literal[
+    "none",
+    "mcp_oauth",
+    "workload_token_exchange",
+    "static_bearer",
+]
 
-    type: Literal["none", "oauth", "outbound_provider"] = Field(default="none")
-    header_allowlist: list[str] = Field(default_factory=list)
-    auth_profile: str | None = Field(default=None)
-    oauth_provider: str | None = Field(default=None)
-    scopes: list[str] = Field(default_factory=list)
 
-    @field_validator("header_allowlist", mode="before")
-    @classmethod
-    def normalize_header_allowlist(cls, value: Any) -> list[str]:
-        if value is None:
-            return []
-        return [str(item).lower() for item in value]
+class McpNoAuthConfig(BaseModel):
+    """Anonymous MCP transport with no Cognition-provided authentication."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["none"] = "none"
+
+
+class McpOAuthConfig(BaseModel):
+    """Standard MCP OAuth authorization handled by the upstream MCP SDK."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["mcp_oauth"] = "mcp_oauth"
+
+
+class McpWorkloadTokenExchangeAuthConfig(BaseModel):
+    """Deployment-profile selection for workload OAuth token exchange."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["workload_token_exchange"] = "workload_token_exchange"
+    profile: str = Field(min_length=1, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class McpStaticBearerAuthConfig(BaseModel):
+    """Environment-backed static bearer transport authentication."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["static_bearer"] = "static_bearer"
+    env: str = Field(min_length=1, pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+McpAuthConfig = Annotated[
+    McpNoAuthConfig
+    | McpOAuthConfig
+    | McpWorkloadTokenExchangeAuthConfig
+    | McpStaticBearerAuthConfig,
+    Field(discriminator="type"),
+]
+
 
 class AgentMcpServerConfig(BaseModel):
     """Agent-scoped MCP server definition."""
 
+    model_config = ConfigDict(extra="forbid")
+
     url: str = Field(..., min_length=1)
-    transport: Literal["sse", "streamable_http", "http"] = Field(default="streamable_http")
-    enabled: bool = Field(default=True)
+    transport: Literal["streamable_http"] = Field(default="streamable_http")
     required: bool = Field(default=True)
-    auth: McpAuthConfig = Field(default_factory=McpAuthConfig)
+    auth: McpAuthConfig = Field(default_factory=McpNoAuthConfig)
 
     @field_validator("url")
     @classmethod
     def validate_url(cls, value: str) -> str:
-        if not value.startswith(("http://", "https://")):
+        if not value or any(character.isspace() for character in value):
+            raise ValueError("Agent MCP server URL must not be empty or contain whitespace")
+        try:
+            parsed = urlsplit(value)
+            hostname = parsed.hostname
+            _ = parsed.port
+        except ValueError as exc:
+            raise ValueError("Agent MCP server URL is malformed") from exc
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
             raise ValueError(
-                "Agent MCP servers must use HTTP/HTTPS URLs; local stdio MCP servers "
-                "are not supported"
+                "Agent MCP servers must use absolute HTTP/HTTPS URLs; local stdio "
+                "servers are not supported"
             )
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("Agent MCP server URLs must not contain credentials")
+        if parsed.fragment:
+            raise ValueError("Agent MCP server URLs must not contain fragments")
         return value
-
-    @field_validator("transport")
-    @classmethod
-    def normalize_transport(cls, value: str) -> str:
-        return "streamable_http" if value == "http" else value
 
 
 class AgentMcpConfig(BaseModel):
     """Agent-owned MCP configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     servers: dict[str, AgentMcpServerConfig] = Field(default_factory=dict)
 
@@ -776,6 +821,11 @@ __all__ = [
     "AgentMcpServerConfig",
     "AsyncSubagentConfig",
     "McpAuthConfig",
+    "MCPAuthType",
+    "McpNoAuthConfig",
+    "McpOAuthConfig",
+    "McpStaticBearerAuthConfig",
+    "McpWorkloadTokenExchangeAuthConfig",
     "SubagentDefinition",
     "load_agent_definition",
     "load_agent_definition_from_markdown",

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -12,20 +12,24 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 import structlog
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
-from langchain_mcp_adapters.sessions import (
-    SSEConnection,
-    StreamableHttpConnection,
-)
+from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from mcp.types import LoggingMessageNotificationParams
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from server.app.agent.definition import AgentMcpServerConfig
+from server.app.agent.definition import (
+    AgentMcpServerConfig,
+    McpAuthConfig,
+    McpNoAuthConfig,
+    McpWorkloadTokenExchangeAuthConfig,
+)
+from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
 
 logger = structlog.get_logger(__name__)
 
@@ -39,18 +43,32 @@ class McpServerDiscoveryError(RuntimeError):
         super().__init__(f"MCP server '{server_alias}' failed: {category}")
 
 
+class McpTransportAuthenticationError(RuntimeError):
+    """Raised when selected MCP transport authentication cannot be applied."""
+
+    def __init__(self, server_alias: str, category: str = "auth_unavailable") -> None:
+        self.server_alias = server_alias
+        self.category = category
+        super().__init__(f"MCP server '{server_alias}' failed: {category}")
+
+
 class McpServerConfig(BaseModel):
     """Configuration for a remote MCP server connection."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(..., description="Unique name for this MCP server")
-    url: str = Field(..., description="MCP server URL (must be HTTP/SSE endpoint)")
-    headers: dict[str, str] = Field(
-        default_factory=dict, description="Headers to include in requests"
-    )
-    enabled: bool = Field(default=True, description="Whether this server is enabled")
+    url: str = Field(..., description="MCP Streamable HTTP endpoint")
     required: bool = Field(default=True, description="Whether discovery failure is fatal")
-    transport: Literal["sse", "streamable_http"] = Field(
-        default="streamable_http", description="Transport protocol"
+    transport: Literal["streamable_http"] = Field(
+        default="streamable_http", description="MCP transport protocol"
+    )
+    auth: McpAuthConfig = Field(default_factory=McpNoAuthConfig)
+    workload_profile: McpWorkloadTokenExchangeProfile | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description="Resolved deployment profile; never an Agent/API projection",
     )
 
     @classmethod
@@ -58,28 +76,41 @@ class McpServerConfig(BaseModel):
         cls,
         alias: str,
         config: AgentMcpServerConfig,
+        settings: Settings,
     ) -> McpServerConfig:
-        transport: Literal["sse", "streamable_http"] = (
-            "streamable_http" if config.transport == "http" else config.transport
-        )
+        workload_profile = None
+        if isinstance(config.auth, McpWorkloadTokenExchangeAuthConfig):
+            workload_profile = settings.get_mcp_auth_profile(config.auth.profile)
         return cls(
             name=alias,
             url=config.url,
-            headers={},
-            enabled=config.enabled,
             required=config.required,
-            transport=transport,
+            transport=config.transport,
+            auth=config.auth,
+            workload_profile=workload_profile,
         )
 
     @field_validator("url")
     @classmethod
     def validate_url(cls, v: str, info: Any) -> str:
-        if not v.startswith(("http://", "https://")):
+        if not v or any(character.isspace() for character in v):
+            raise ValueError("MCP server URL must not be empty or contain whitespace")
+        try:
+            parsed = urlsplit(v)
+            hostname = parsed.hostname
+            _ = parsed.port
+        except ValueError as exc:
+            raise ValueError("MCP server URL is malformed") from exc
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
             raise ValueError(
                 f"MCP server '{info.data.get('name', 'unknown')}' has invalid URL: {v}. "
                 "Only HTTP/HTTPS URLs are supported. "
                 "Local (stdio) MCP servers are not supported for security reasons."
             )
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("MCP server URLs must not contain credentials")
+        if parsed.fragment:
+            raise ValueError("MCP server URLs must not contain fragments")
         return v
 
 
@@ -94,11 +125,10 @@ class McpToolInfo(BaseModel):
     task_support: str | None = None
 
 
-def mcp_config_to_connection(config: McpServerConfig) -> SSEConnection | StreamableHttpConnection:
-    transport: Literal["sse", "streamable_http"] = config.transport
-    if transport == "sse":
-        return {"transport": "sse", "url": config.url, "headers": dict(config.headers)}
-    return {"transport": "streamable_http", "url": config.url, "headers": dict(config.headers)}
+def mcp_config_to_connection(config: McpServerConfig) -> StreamableHttpConnection:
+    if not isinstance(config.auth, McpNoAuthConfig):
+        raise McpTransportAuthenticationError(config.name)
+    return {"transport": "streamable_http", "url": config.url}
 
 
 def create_mcp_client(
@@ -106,9 +136,7 @@ def create_mcp_client(
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
 ) -> MultiServerMCPClient:
-    connections: dict[str, Any] = {
-        c.name: mcp_config_to_connection(c) for c in configs if c.enabled
-    }
+    connections: dict[str, Any] = {c.name: mcp_config_to_connection(c) for c in configs}
     return MultiServerMCPClient(
         connections=connections or None,
         callbacks=callbacks,
@@ -127,8 +155,6 @@ async def load_mcp_tools_per_server(
     tools: list[BaseTool] = []
     seen: set[str] = set()
     for config in configs:
-        if not config.enabled:
-            continue
         client = create_mcp_client(
             [config],
             callbacks=callbacks,

--- a/server/app/config_loader.py
+++ b/server/app/config_loader.py
@@ -215,6 +215,25 @@ def _get_settings_schema() -> list[dict[str, Any]]:
             "test": "test",
         }
 
+        # Deployment-owned MCP auth profiles are intentionally top-level so
+        # Agent definitions can reference them without embedding identity
+        # system configuration.
+        if field_name == "mcp_auth_profiles":
+            yaml_path = ["mcp_auth_profiles"]
+            default_factory = getattr(field_info, "default_factory", None)
+            default = default_factory() if callable(default_factory) else {}
+            schema.append(
+                {
+                    "field_name": field_name,
+                    "env_var": env_var,
+                    "yaml_path": yaml_path,
+                    "default": default,
+                    "annotation": str(field_info.annotation),
+                    "is_secret": False,
+                }
+            )
+            continue
+
         # Find which section this field belongs to
         parts = field_name.split("_")
         section = None

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -510,9 +510,8 @@ class DeepAgentStreamingService:
             from server.app.agent.mcp_client import McpServerConfig
 
             resolved.mcp_configs = [
-                McpServerConfig.from_agent_config(alias, config)
+                McpServerConfig.from_agent_config(alias, config, self.settings)
                 for alias, config in agent_def.mcp.servers.items()
-                if config.enabled
             ]
 
         return resolved, custom_tools

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -5,8 +5,49 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import AliasChoices, Field, SecretStr, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class McpWorkloadTokenExchangeProfile(BaseModel):
+    """Deployment-owned OAuth token-exchange profile for MCP transport."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["oauth_token_exchange"] = "oauth_token_exchange"
+    token_endpoint: str
+    subject_token_source: Literal["workload_identity"] = "workload_identity"
+    audience: str = Field(min_length=1)
+
+    @field_validator("token_endpoint")
+    @classmethod
+    def validate_token_endpoint(cls, value: str) -> str:
+        """Require an absolute HTTP(S) token endpoint without URL credentials."""
+        from urllib.parse import urlsplit
+
+        if not value or any(character.isspace() for character in value):
+            raise ValueError("MCP token endpoint must not be empty or contain whitespace")
+        try:
+            parsed = urlsplit(value)
+            hostname = parsed.hostname
+            _ = parsed.port
+        except ValueError as exc:
+            raise ValueError("MCP token endpoint is malformed") from exc
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
+            raise ValueError("MCP token endpoint must be an absolute HTTP(S) URL")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("MCP token endpoint must not contain credentials")
+        if parsed.fragment:
+            raise ValueError("MCP token endpoint must not contain a fragment")
+        return value
+
+    @field_validator("audience")
+    @classmethod
+    def validate_audience(cls, value: str) -> str:
+        """Reject ambiguous audience values while allowing URI-shaped identifiers."""
+        if value != value.strip() or any(character.isspace() for character in value):
+            raise ValueError("MCP token-exchange audience must not contain whitespace")
+        return value
 
 
 class Settings(BaseSettings):
@@ -40,7 +81,18 @@ class Settings(BaseSettings):
     deployment_mode: Literal["local", "development", "production"] = Field(
         default="development",
         alias="COGNITION_DEPLOYMENT_MODE",
-        description="Deployment safety profile. Production rejects host-backed runtime state.",
+        description=(
+            "Builder-defined deployment label for operational metadata. Cognition does not "
+            "infer storage or MCP authentication policy from this value."
+        ),
+    )
+
+    # MCP transport identity is deployment configuration. Profiles contain no
+    # subject token or provider credential and are referenced opaquely by Agent
+    # definitions using workload_token_exchange authentication.
+    mcp_auth_profiles: dict[str, McpWorkloadTokenExchangeProfile] = Field(
+        default_factory=dict,
+        alias="COGNITION_MCP_AUTH_PROFILES",
     )
 
     # Workspace settings
@@ -210,9 +262,9 @@ class Settings(BaseSettings):
         alias="COGNITION_PERSISTENCE_URI",
     )
 
-    # Durable Deep Agents file backend. SQLite/in-memory/local remain supported
-    # only for local and development profiles; production uses S3-compatible
-    # object storage for durable file-shaped runtime data.
+    # Durable Deep Agents file backend. Builders select local or S3-compatible
+    # placement explicitly; Cognition never changes backends based on a
+    # deployment label or after a selected-backend failure.
     durable_file_backend: Literal["local", "s3"] = Field(
         default="local",
         alias="COGNITION_DURABLE_FILE_BACKEND",
@@ -500,27 +552,18 @@ class Settings(BaseSettings):
         return self.durable_file_backend == "s3"
 
     def validate_deployment_storage_policy(self) -> None:
-        """Reject production settings that could persist runtime data on the host.
-
-        Local and development modes intentionally retain SQLite, memory, and
-        local files for a frictionless developer experience.  Production must
-        explicitly select durable infrastructure instead of silently falling
-        back to a workspace path.
-        """
+        """Validate the builder-selected storage backend without classifying it."""
         if self.s3_enabled and not self.s3_bucket:
             raise ValueError("COGNITION_S3_BUCKET is required when durable_file_backend=s3")
         if self.s3_enabled and self.s3_scope_hmac_key is None:
-            raise ValueError(
-                "COGNITION_S3_SCOPE_HMAC_KEY is required when durable_file_backend=s3"
-            )
-        if self.deployment_mode != "production":
-            return
-        if self.persistence_backend != "postgres":
-            raise ValueError("production requires COGNITION_PERSISTENCE_BACKEND=postgres")
-        if not self.s3_enabled:
-            raise ValueError("production requires COGNITION_DURABLE_FILE_BACKEND=s3")
-        if self.sandbox_backend == "local":
-            raise ValueError("production cannot use COGNITION_SANDBOX_BACKEND=local")
+            raise ValueError("COGNITION_S3_SCOPE_HMAC_KEY is required when durable_file_backend=s3")
+
+    def get_mcp_auth_profile(self, name: str) -> McpWorkloadTokenExchangeProfile:
+        """Resolve one deployment-owned MCP auth profile by opaque name."""
+        try:
+            return self.mcp_auth_profiles[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown MCP authentication profile: {name}") from exc
 
 
 # Global settings instance

--- a/tests/e2e/test_scenarios/p3_tools/test_mcp.py
+++ b/tests/e2e/test_scenarios/p3_tools/test_mcp.py
@@ -24,11 +24,10 @@ def test_agent_owned_mcp_config_round_trips_through_definition() -> None:
                     "github": {
                         "url": "https://mcp.example.test/github",
                         "required": True,
-                        "transport": "http",
+                        "transport": "streamable_http",
                         "auth": {
-                            "type": "outbound_provider",
-                            "auth_profile": "agent-machine",
-                            "header_allowlist": ["Authorization"],
+                            "type": "workload_token_exchange",
+                            "profile": "agent-machine",
                         },
                     }
                 }
@@ -38,7 +37,7 @@ def test_agent_owned_mcp_config_round_trips_through_definition() -> None:
 
     dumped = definition.model_dump(mode="json")
     assert dumped["mcp"]["servers"]["github"]["transport"] == "streamable_http"
-    assert dumped["mcp"]["servers"]["github"]["auth"]["auth_profile"] == "agent-machine"
+    assert dumped["mcp"]["servers"]["github"]["auth"]["profile"] == "agent-machine"
     assert "headers" not in dumped["mcp"]["servers"]["github"]["auth"]
 
 

--- a/tests/e2e/test_scenarios/p3_tools/test_mcp_coingecko_scenario.py
+++ b/tests/e2e/test_scenarios/p3_tools/test_mcp_coingecko_scenario.py
@@ -20,7 +20,7 @@ from tests.e2e.test_scenarios.conftest import (
     stream_completed,
 )
 
-COINGECKO_MCP_URL = "https://mcp.api.coingecko.com/sse"
+COINGECKO_MCP_URL = "https://mcp.api.coingecko.com/mcp"
 
 
 def _unique(prefix: str) -> str:
@@ -84,9 +84,8 @@ async def _create_coingecko_agent(api_client: ScenarioTestClient, name: str) -> 
                 "servers": {
                     "coingecko": {
                         "url": COINGECKO_MCP_URL,
-                        "enabled": True,
                         "required": True,
-                        "transport": "sse",
+                        "transport": "streamable_http",
                     }
                 }
             },
@@ -120,9 +119,7 @@ class TestCoinGeckoMcpScenario:
         finally:
             await api_client.delete(f"/agents/{agent_name}")
 
-    async def test_agent_can_call_coingecko_mcp_tool(
-        self, api_client: ScenarioTestClient
-    ) -> None:
+    async def test_agent_can_call_coingecko_mcp_tool(self, api_client: ScenarioTestClient) -> None:
         agent_name = _unique("coingecko-agent")
         session_id: str | None = None
         try:

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -8,8 +8,11 @@ from server.app.agent.definition import AgentDefinition
 from server.app.agent.mcp_client import (
     McpServerConfig,
     McpServerDiscoveryError,
+    McpTransportAuthenticationError,
     load_mcp_tools_per_server,
+    mcp_config_to_connection,
 )
+from server.app.settings import Settings
 
 
 def test_agent_definition_carries_agent_owned_mcp_config() -> None:
@@ -18,26 +21,81 @@ def test_agent_definition_carries_agent_owned_mcp_config() -> None:
             "name": "tenant-agent",
             "system_prompt": "Use configured tools.",
             "mcp": {
-            "servers": {
-                "github": {
-                    "url": "https://mcp.example.test/github",
-                    "transport": "http",
-                    "required": True,
-                    "auth": {
-                        "type": "outbound_provider",
-                        "auth_profile": "agent-machine",
-                        "header_allowlist": ["Authorization"],
-                    },
+                "servers": {
+                    "github": {
+                        "url": "https://mcp.example.test/github",
+                        "transport": "streamable_http",
+                        "required": True,
+                        "auth": {
+                            "type": "workload_token_exchange",
+                            "profile": "agent-machine",
+                        },
+                    }
                 }
-            }
-        },
+            },
         }
     )
 
     server = agent.mcp.servers["github"]
     assert server.transport == "streamable_http"
-    assert server.auth.type == "outbound_provider"
-    assert server.auth.header_allowlist == ["authorization"]
+    assert server.auth.type == "workload_token_exchange"
+    assert server.auth.profile == "agent-machine"
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        {"type": "none"},
+        {"type": "mcp_oauth"},
+        {"type": "workload_token_exchange", "profile": "internal-egress"},
+        {"type": "static_bearer", "env": "MCP_ACCESS_TOKEN"},
+    ],
+)
+def test_agent_definition_accepts_each_standard_mcp_auth_type(auth) -> None:
+    agent = AgentDefinition.model_validate(
+        {
+            "name": "auth-agent",
+            "system_prompt": "Use configured tools.",
+            "mcp": {
+                "servers": {
+                    "remote": {
+                        "url": "https://mcp.example.test/tools",
+                        "auth": auth,
+                    }
+                }
+            },
+        }
+    )
+
+    assert agent.mcp.servers["remote"].auth.model_dump(exclude_none=True) == auth
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        {"type": "oauth"},
+        {"type": "outbound_provider", "auth_profile": "legacy"},
+        {"type": "static_bearer", "env": "invalid-name"},
+        {"type": "workload_token_exchange"},
+        {"type": "none", "headers": {"Authorization": "Bearer secret"}},
+    ],
+)
+def test_agent_mcp_config_rejects_legacy_or_unbounded_auth(auth) -> None:
+    with pytest.raises(ValueError):
+        AgentDefinition.model_validate(
+            {
+                "name": "bad-auth-agent",
+                "system_prompt": "Do not accept transport secrets.",
+                "mcp": {
+                    "servers": {
+                        "remote": {
+                            "url": "https://mcp.example.test/tools",
+                            "auth": auth,
+                        }
+                    }
+                },
+            }
+        )
 
 
 def test_agent_mcp_config_rejects_local_servers() -> None:
@@ -49,6 +107,101 @@ def test_agent_mcp_config_rejects_local_servers() -> None:
                 "mcp": {"servers": {"local": {"url": "stdio://filesystem"}}},
             }
         )
+
+
+@pytest.mark.parametrize(
+    "server",
+    [
+        {"url": "https://user:password@mcp.example.test/tools"},
+        {"url": "https://mcp.example.test/tools#fragment"},
+        {"url": "https://mcp.example.test/tools", "headers": {"X-Token": "secret"}},
+        {"url": "https://mcp.example.test/sse", "transport": "sse"},
+        {"url": "https://mcp.example.test/tools", "enabled": False},
+    ],
+)
+def test_agent_mcp_config_rejects_unbounded_server_transport_fields(server) -> None:
+    with pytest.raises(ValueError):
+        AgentDefinition.model_validate(
+            {
+                "name": "bad-server-agent",
+                "system_prompt": "Use only bounded remote MCP.",
+                "mcp": {"servers": {"remote": server}},
+            }
+        )
+
+
+def test_workload_profile_resolves_from_deployment_configuration_only() -> None:
+    agent = AgentDefinition.model_validate(
+        {
+            "name": "gateway-agent",
+            "system_prompt": "Use the approved gateway.",
+            "mcp": {
+                "servers": {
+                    "github": {
+                        "url": "https://mcp-egress.internal/mcp/github",
+                        "auth": {
+                            "type": "workload_token_exchange",
+                            "profile": "egress",
+                        },
+                    }
+                }
+            },
+        }
+    )
+    settings = Settings.model_validate(
+        {
+            "mcp_auth_profiles": {
+                "egress": {
+                    "type": "oauth_token_exchange",
+                    "token_endpoint": "https://identity.internal/token",
+                    "subject_token_source": "workload_identity",
+                    "audience": "canonical_server_uri",
+                }
+            }
+        }
+    )
+
+    resolved = McpServerConfig.from_agent_config("github", agent.mcp.servers["github"], settings)
+
+    assert resolved.workload_profile is not None
+    assert resolved.workload_profile.token_endpoint == "https://identity.internal/token"
+    assert "workload_profile" not in resolved.model_dump(mode="json")
+
+
+def test_unknown_workload_profile_fails_resolution() -> None:
+    agent = AgentDefinition.model_validate(
+        {
+            "name": "gateway-agent",
+            "system_prompt": "Fail closed when deployment config is absent.",
+            "mcp": {
+                "servers": {
+                    "github": {
+                        "url": "https://mcp-egress.internal/mcp/github",
+                        "auth": {
+                            "type": "workload_token_exchange",
+                            "profile": "missing",
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unknown MCP authentication profile"):
+        McpServerConfig.from_agent_config("github", agent.mcp.servers["github"], Settings())
+
+
+def test_protected_auth_never_silently_builds_anonymous_transport() -> None:
+    config = McpServerConfig.model_validate(
+        {
+            "name": "github",
+            "url": "https://mcp.example.test/github",
+            "auth": {"type": "mcp_oauth"},
+        }
+    )
+
+    with pytest.raises(McpTransportAuthenticationError, match="auth_unavailable"):
+        mcp_config_to_connection(config)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from server.app.config_loader import _resolve_env_vars, load_config
+from server.app.config_loader import ConfigLoader, _resolve_env_vars, load_config
 
 
 class TestResolveEnvVars:
@@ -64,3 +65,28 @@ class TestLoadConfig:
 
         assert config["llm"]["provider"] == "bedrock"
         assert missing == {}
+
+    def test_mcp_auth_profiles_map_from_top_level_yaml(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / ".cognition").mkdir(parents=True)
+        (workspace / ".cognition" / "config.yaml").write_text(
+            """mcp_auth_profiles:
+  egress:
+    type: oauth_token_exchange
+    token_endpoint: https://identity.internal/token
+    subject_token_source: workload_identity
+    audience: canonical_server_uri
+""",
+            encoding="utf-8",
+        )
+
+        env_vars = ConfigLoader(cwd=workspace).to_env_vars()
+
+        assert json.loads(env_vars["COGNITION_MCP_AUTH_PROFILES"]) == {
+            "egress": {
+                "type": "oauth_token_exchange",
+                "token_endpoint": "https://identity.internal/token",
+                "subject_token_source": "workload_identity",
+                "audience": "canonical_server_uri",
+            }
+        }

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -108,19 +108,13 @@ class TestA2ASecuritySettings:
                 durable_file_backend="s3", s3_bucket="cognition"
             ).validate_deployment_storage_policy()
 
-    def test_production_rejects_host_backed_runtime_storage(self):
-        with pytest.raises(ValueError, match="PERSISTENCE_BACKEND=postgres"):
-            TestSettings(deployment_mode="production").validate_deployment_storage_policy()
-
-        settings = TestSettings(
-            deployment_mode="production",
-            persistence_backend="postgres",
-            durable_file_backend="s3",
-            s3_bucket="cognition",
-            s3_scope_hmac_key="test-key",
-            sandbox_backend="docker",
-        )
+    def test_storage_validation_does_not_classify_builder_deployment(self):
+        settings = TestSettings(deployment_mode="production")
         settings.validate_deployment_storage_policy()
+
+        assert settings.persistence_backend == "sqlite"
+        assert settings.durable_file_backend == "local"
+        assert settings.sandbox_backend == "local"
 
     def test_s3_compatible_durable_file_configuration(self):
         """Garage-style endpoint settings select the generic S3 backend."""
@@ -132,6 +126,58 @@ class TestA2ASecuritySettings:
         )
         assert settings.s3_enabled
         assert settings.s3_force_path_style
+
+
+class TestMcpAuthProfiles:
+    """Deployment-owned workload token-exchange profile settings."""
+
+    def test_parses_profiles_from_environment_json(self, monkeypatch: pytest.MonkeyPatch):
+        profiles = {
+            "production_egress": {
+                "type": "oauth_token_exchange",
+                "token_endpoint": "https://identity.internal/token",
+                "subject_token_source": "workload_identity",
+                "audience": "canonical_server_uri",
+            }
+        }
+        monkeypatch.setenv("COGNITION_MCP_AUTH_PROFILES", json.dumps(profiles))
+
+        settings = TestSettings()
+        profile = settings.get_mcp_auth_profile("production_egress")
+
+        assert profile.token_endpoint == "https://identity.internal/token"
+        assert profile.audience == "canonical_server_uri"
+
+    def test_rejects_unknown_profile(self) -> None:
+        with pytest.raises(ValueError, match="Unknown MCP authentication profile"):
+            TestSettings().get_mcp_auth_profile("missing")
+
+    @pytest.mark.parametrize(
+        "profile",
+        [
+            {
+                "type": "custom_callback",
+                "token_endpoint": "https://identity.internal/token",
+                "subject_token_source": "workload_identity",
+                "audience": "canonical_server_uri",
+            },
+            {
+                "type": "oauth_token_exchange",
+                "token_endpoint": "https://user:secret@identity.internal/token",
+                "subject_token_source": "workload_identity",
+                "audience": "canonical_server_uri",
+            },
+            {
+                "type": "oauth_token_exchange",
+                "token_endpoint": "https://identity.internal/token",
+                "subject_token_source": "python_callback",
+                "audience": "canonical_server_uri",
+            },
+        ],
+    )
+    def test_rejects_invalid_profile(self, profile) -> None:
+        with pytest.raises(ValueError):
+            TestSettings.model_validate({"mcp_auth_profiles": {"egress": profile}})
 
 
 class TestSettingsSecrets:


### PR DESCRIPTION
## Summary
- replace the legacy MCP auth schema with `none`, `mcp_oauth`, `workload_token_exchange`, and `static_bearer` discriminated configurations
- reject raw headers, URL credentials, legacy SSE/enable fields, callbacks, and obsolete auth names
- load workload token-exchange profiles from deployment YAML/environment configuration and resolve opaque Agent references fail-closed
- remove deployment-label storage enforcement while retaining validation of the builder-selected S3 backend
- keep protected transports fail-closed until the follow-up transport implementation lands

## Validation
- `uv run mypy .`
- `uv run ruff check .`
- 73 focused MCP/settings/security tests
- 113 Agent CRUD/definition/manifest tests
- serial full suite sampled 60 passing tests with no failures before stopping in slow live-stream scenarios; CI is the authoritative full regression gate

## Architecture
Implements the schema/profile-resolution portion of ADR-0004 and the builder-owned storage-policy correction in ADR-0005. This is an intentional breaking change with no legacy aliases or compatibility translation.