### PR TITLE
feat: add MCP transport authentication

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -596,6 +596,28 @@ a named environment variable and is supported but not recommended. Cognition
 does not infer a production or multi-tenant mode or enforce the builder's
 authentication-mode policy.
 
+Define workload exchange outside the Agent:
+
+```yaml
+mcp_auth_profiles:
+  production_egress:
+    type: oauth_token_exchange
+    token_endpoint: https://identity.internal/token
+    subject_token_source: workload_identity
+    audience: canonical_server_uri
+```
+
+Set `COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN_FILE` to a projected, rotating
+workload token file. `COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN` is an environment
+fallback when file projection is unavailable. Cognition rereads the projected
+file for each uncached exchange and caches only the short-lived exchanged token
+until its bounded expiry.
+
+Token endpoints that require confidential-client authentication may add
+`client_auth: client_secret_basic`, `client_id`, and `client_secret_env` to the
+deployment profile. `client_secret_env` names an environment variable; its
+value never enters YAML, Agent configuration, persistence, or telemetry.
+
 ---
 
 ## Model Catalog

--- a/docs/proposals/v0.14.0-mcp-runtime-contract.md
+++ b/docs/proposals/v0.14.0-mcp-runtime-contract.md
@@ -139,6 +139,13 @@ mcp_auth_profiles:
     audience: canonical_server_uri
 ```
 
+The ambient workload identity is read from the projected file named by
+`COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN_FILE`; an environment token is a
+supported fallback. When the token endpoint requires client authentication,
+the deployment profile may select `client_secret_basic` with a non-secret
+`client_id` and `client_secret_env` reference. These are deployment inputs, not
+Agent fields.
+
 The profile owns the identity-system endpoint and subject-token source. The
 symbolic `canonical_server_uri` audience resolves to the canonical URL of the
 selected MCP server. A profile may instead define a builder-selected exact
@@ -225,6 +232,23 @@ alter:
 - server alias or provider tool name;
 - Agent identity, revision, or `effective_scope`; or
 - required/optional server policy.
+
+The version 1 envelope uses a fixed header set:
+
+| Header | Source |
+|---|---|
+| `X-Cognition-Context-Version` | Constant `1` |
+| `X-Cognition-Agent-ID` | Immutable resolved Agent name |
+| `X-Cognition-Agent-Revision` | Pinned revision |
+| `X-Cognition-Effective-Scope` | Canonical JSON from trusted ingress scope |
+| `X-Cognition-MCP-Server-Alias` | Pinned server alias |
+| `X-Cognition-MCP-Server-URI` | Canonical configured endpoint |
+| `X-Cognition-Session-ID` | Active runtime context, when available |
+| `X-Cognition-Run-ID` | Active runtime context, when available |
+| `X-Cognition-Request-Deadline` | Unix milliseconds, when a deadline exists |
+
+No other Agent-, model-, or interceptor-supplied header survives the mandatory
+workload-context projection.
 
 A gateway must accept the envelope only together with the authenticated
 Cognition workload request and must strip equivalent fields at untrusted

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -79,6 +79,7 @@ class CognitionContext:
         thread_id: LangGraph checkpoint thread id, when available.
         agent_name: Agent definition bound to the session, when available.
         metadata: Builder-provided session metadata. This is not a secret channel.
+        request_deadline: Absolute Unix-millisecond execution deadline, when configured.
     """
 
     effective_scope: dict[str, str] = field(default_factory=dict)
@@ -86,6 +87,7 @@ class CognitionContext:
     thread_id: str | None = None
     agent_name: str | None = None
     metadata: dict[str, str] = field(default_factory=dict)
+    request_deadline: int | None = None
     # Process-local invocation state. This field is supplied for every run and
     # is intentionally absent from durable checkpoints and manifests.
     sandbox_backend: Any | None = field(default=None, repr=False)
@@ -99,6 +101,7 @@ class CognitionContext:
         thread_id: str | None = None,
         agent_name: str | None = None,
         metadata: dict[str, str] | None = None,
+        request_deadline: int | None = None,
         sandbox_backend: Any | None = None,
     ) -> CognitionContext:
         return cls(
@@ -107,6 +110,7 @@ class CognitionContext:
             thread_id=thread_id,
             agent_name=agent_name,
             metadata=dict(metadata or {}),
+            request_deadline=request_deadline,
             sandbox_backend=sandbox_backend,
         )
 
@@ -807,6 +811,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                 mcp_callbacks = _build_mcp_callbacks()
                 mcp_tools = await load_mcp_tools_per_server(
                     params.mcp_configs,
+                    settings,
                     callbacks=mcp_callbacks,
                 )
                 agent_tools.extend(mcp_tools)

--- a/server/app/agent/mcp_auth.py
+++ b/server/app/agent/mcp_auth.py
@@ -1,0 +1,307 @@
+"""Mandatory MCP transport authentication and trusted-context projection."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Mapping
+from pathlib import Path
+from typing import Any
+
+import httpx
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallResult
+from pydantic import SecretStr
+
+from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
+
+_TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
+_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+_CONTEXT_HEADER_PREFIX = "X-Cognition-"
+_MAX_SCOPE_HEADER_BYTES = 8 * 1024
+_MAX_CONTEXT_HEADER_BYTES = 16 * 1024
+_MAX_CONTEXT_VALUE_BYTES = 8 * 1024
+
+
+class McpAuthenticationError(RuntimeError):
+    """Typed, redacted MCP authentication failure."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(f"MCP authentication failed: {category}")
+
+
+class StaticBearerAuth(httpx.Auth):
+    """Apply an environment-backed bearer token without exposing its value."""
+
+    def __init__(self, token: SecretStr) -> None:
+        self._token = token
+
+    @classmethod
+    def from_environment(cls, env_name: str) -> StaticBearerAuth:
+        """Read a named environment variable at transport construction."""
+        value = os.environ.get(env_name)
+        if not value:
+            raise McpAuthenticationError("static_bearer_unavailable")
+        return cls(SecretStr(value))
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        request.headers["Authorization"] = f"Bearer {self._token.get_secret_value()}"
+        yield request
+
+
+class AmbientWorkloadIdentity:
+    """Read a rotating projected workload token or an environment fallback."""
+
+    def __init__(self, *, token_file: Path | None, token: SecretStr | None) -> None:
+        if token_file is None and token is None:
+            raise McpAuthenticationError("workload_identity_unavailable")
+        self._token_file = token_file
+        self._token = token
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> AmbientWorkloadIdentity:
+        return cls(
+            token_file=settings.mcp_workload_identity_token_file,
+            token=settings.mcp_workload_identity_token,
+        )
+
+    async def get_subject_token(self) -> SecretStr:
+        """Return the current ambient subject token, preferring a projected file."""
+        if self._token_file is not None:
+            try:
+                value = await asyncio.to_thread(
+                    self._token_file.read_text,
+                    encoding="utf-8",
+                )
+            except OSError as exc:
+                raise McpAuthenticationError("workload_identity_unavailable") from exc
+            value = value.strip()
+            if not value:
+                raise McpAuthenticationError("workload_identity_unavailable")
+            return SecretStr(value)
+        if self._token is None:
+            raise McpAuthenticationError("workload_identity_unavailable")
+        return self._token
+
+
+class WorkloadTokenExchangeAuth(httpx.Auth):
+    """Exchange ambient workload identity for one short-lived audience token."""
+
+    requires_request_body = True
+
+    def __init__(
+        self,
+        *,
+        profile: McpWorkloadTokenExchangeProfile,
+        audience: str,
+        identity: AmbientWorkloadIdentity,
+        client_secret: SecretStr | None = None,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self._profile = profile
+        self._audience = audience
+        self._identity = identity
+        self._client_secret = client_secret
+        self._client_factory = client_factory or (
+            lambda: httpx.AsyncClient(timeout=profile.timeout_seconds)
+        )
+        self._cached_token: SecretStr | None = None
+        self._cached_until = 0.0
+        self._lock = asyncio.Lock()
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        token = await self._get_access_token()
+        request.headers["Authorization"] = f"Bearer {token.get_secret_value()}"
+        yield request
+
+    async def _get_access_token(self) -> SecretStr:
+        now = time.monotonic()
+        if self._cached_token is not None and now < self._cached_until:
+            return self._cached_token
+
+        async with self._lock:
+            now = time.monotonic()
+            if self._cached_token is not None and now < self._cached_until:
+                return self._cached_token
+            subject_token = await self._identity.get_subject_token()
+            token, expires_in = await self._exchange(subject_token)
+            self._cached_token = token
+            if expires_in is None:
+                self._cached_until = 0.0
+            else:
+                leeway = min(30.0, max(1.0, expires_in * 0.1))
+                self._cached_until = time.monotonic() + max(0.0, expires_in - leeway)
+            return token
+
+    async def _exchange(self, subject_token: SecretStr) -> tuple[SecretStr, float | None]:
+        form = {
+            "grant_type": _TOKEN_EXCHANGE_GRANT,
+            "subject_token": subject_token.get_secret_value(),
+            "subject_token_type": self._profile.subject_token_type,
+            "requested_token_type": _ACCESS_TOKEN_TYPE,
+            "audience": self._audience,
+        }
+        auth: httpx.BasicAuth | None = None
+        if self._profile.client_auth == "client_secret_basic":
+            if self._profile.client_id is None or self._client_secret is None:
+                raise McpAuthenticationError("token_exchange_client_auth_unavailable")
+            auth = httpx.BasicAuth(
+                self._profile.client_id,
+                self._client_secret.get_secret_value(),
+            )
+        try:
+            async with self._client_factory() as client:
+                if auth is None:
+                    response = await client.post(
+                        self._profile.token_endpoint,
+                        data=form,
+                        headers={"Accept": "application/json"},
+                    )
+                else:
+                    response = await client.post(
+                        self._profile.token_endpoint,
+                        data=form,
+                        auth=auth,
+                        headers={"Accept": "application/json"},
+                    )
+        except httpx.HTTPError as exc:
+            raise McpAuthenticationError("token_exchange_unavailable") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise McpAuthenticationError("token_exchange_denied")
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise McpAuthenticationError("token_exchange_invalid_response") from exc
+        if not isinstance(payload, Mapping):
+            raise McpAuthenticationError("token_exchange_invalid_response")
+        access_token = payload.get("access_token")
+        token_type = payload.get("token_type", "Bearer")
+        if (
+            not isinstance(access_token, str)
+            or not access_token
+            or str(token_type).lower() != "bearer"
+        ):
+            raise McpAuthenticationError("token_exchange_invalid_response")
+        expires_raw = payload.get("expires_in")
+        expires_in: float | None = None
+        if expires_raw is not None:
+            try:
+                expires_in = float(expires_raw)
+            except (TypeError, ValueError) as exc:
+                raise McpAuthenticationError("token_exchange_invalid_response") from exc
+            if expires_in <= 0:
+                raise McpAuthenticationError("token_exchange_invalid_response")
+        return SecretStr(access_token), expires_in
+
+
+def resolve_workload_client_secret(
+    profile: McpWorkloadTokenExchangeProfile,
+) -> SecretStr | None:
+    """Resolve optional deployment-owned token-endpoint client authentication."""
+    if profile.client_auth == "none":
+        return None
+    if profile.client_secret_env is None:
+        raise McpAuthenticationError("token_exchange_client_auth_unavailable")
+    value = os.environ.get(profile.client_secret_env)
+    if not value:
+        raise McpAuthenticationError("token_exchange_client_auth_unavailable")
+    return SecretStr(value)
+
+
+def trusted_context_headers(
+    *,
+    agent_name: str,
+    agent_revision: int,
+    effective_scope: Mapping[str, str],
+    server_alias: str,
+    canonical_server_uri: str,
+    runtime: object | None = None,
+) -> dict[str, str]:
+    """Build the fixed, versioned, model-invisible gateway context envelope."""
+    scope_json = json.dumps(
+        dict(sorted(effective_scope.items())),
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    if len(scope_json.encode("utf-8")) > _MAX_SCOPE_HEADER_BYTES:
+        raise McpAuthenticationError("trusted_context_too_large")
+    headers = {
+        f"{_CONTEXT_HEADER_PREFIX}Context-Version": "1",
+        f"{_CONTEXT_HEADER_PREFIX}Agent-ID": agent_name,
+        f"{_CONTEXT_HEADER_PREFIX}Agent-Revision": str(agent_revision),
+        f"{_CONTEXT_HEADER_PREFIX}Effective-Scope": scope_json,
+        f"{_CONTEXT_HEADER_PREFIX}MCP-Server-Alias": server_alias,
+        f"{_CONTEXT_HEADER_PREFIX}MCP-Server-URI": canonical_server_uri,
+    }
+    dynamic = _runtime_context_values(runtime)
+    for header, value in (
+        (f"{_CONTEXT_HEADER_PREFIX}Session-ID", dynamic.get("session_id")),
+        (f"{_CONTEXT_HEADER_PREFIX}Run-ID", dynamic.get("run_id")),
+        (f"{_CONTEXT_HEADER_PREFIX}Request-Deadline", dynamic.get("request_deadline")),
+    ):
+        if value is not None:
+            headers[header] = str(value)
+    total_bytes = 0
+    for header, value in headers.items():
+        value_bytes = value.encode("utf-8")
+        if len(value_bytes) > _MAX_CONTEXT_VALUE_BYTES:
+            raise McpAuthenticationError("trusted_context_too_large")
+        if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+            raise McpAuthenticationError("trusted_context_invalid")
+        total_bytes += len(header.encode("ascii")) + len(value_bytes)
+    if total_bytes > _MAX_CONTEXT_HEADER_BYTES:
+        raise McpAuthenticationError("trusted_context_too_large")
+    return headers
+
+
+def _runtime_context_values(runtime: object | None) -> dict[str, Any]:
+    context = getattr(runtime, "context", None)
+    config = getattr(runtime, "config", None)
+    config_dict = config if isinstance(config, dict) else {}
+    configurable_raw = config_dict.get("configurable")
+    configurable = configurable_raw if isinstance(configurable_raw, dict) else {}
+
+    def context_value(name: str) -> Any:
+        if isinstance(context, dict):
+            return context.get(name)
+        return getattr(context, name, None) if context is not None else None
+
+    thread_id = context_value("thread_id") or configurable.get("thread_id")
+    return {
+        "session_id": context_value("session_id") or configurable.get("session_id"),
+        "run_id": config_dict.get("run_id") or configurable.get("run_id") or thread_id,
+        "request_deadline": context_value("request_deadline"),
+    }
+
+
+class McpTrustedContextInterceptor:
+    """Overwrite per-call headers with Cognition's fixed workload context."""
+
+    def __init__(self, contexts: Mapping[str, Mapping[str, Any]]) -> None:
+        self._contexts = dict(contexts)
+
+    async def __call__(
+        self,
+        request: MCPToolCallRequest,
+        handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+    ) -> MCPToolCallResult:
+        context = self._contexts.get(request.server_name)
+        if context is None:
+            raise McpAuthenticationError("trusted_context_unavailable")
+        headers = trusted_context_headers(runtime=request.runtime, **context)
+        return await handler(request.override(headers=headers))
+
+
+__all__ = [
+    "AmbientWorkloadIdentity",
+    "McpAuthenticationError",
+    "McpTrustedContextInterceptor",
+    "StaticBearerAuth",
+    "WorkloadTokenExchangeAuth",
+    "resolve_workload_client_secret",
+    "trusted_context_headers",
+]

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -4,16 +4,17 @@ Wraps langchain-mcp-adapters for Cognition's remote-only MCP server integration.
 Replaces the previous custom McpSseClient / McpManager / McpAdapterTool layer.
 
 Security stance:
-- Remote MCP servers: Allowed (SSE transport, HTTP/HTTPS URLs only).
+- Remote MCP servers: Allowed (Streamable HTTP transport, HTTP/HTTPS URLs only).
 - Local (stdio) MCP servers: NOT supported for security reasons.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
+import httpx
 import structlog
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
@@ -27,7 +28,18 @@ from server.app.agent.definition import (
     AgentMcpServerConfig,
     McpAuthConfig,
     McpNoAuthConfig,
+    McpOAuthConfig,
+    McpStaticBearerAuthConfig,
     McpWorkloadTokenExchangeAuthConfig,
+)
+from server.app.agent.mcp_auth import (
+    AmbientWorkloadIdentity,
+    McpAuthenticationError,
+    McpTrustedContextInterceptor,
+    StaticBearerAuth,
+    WorkloadTokenExchangeAuth,
+    resolve_workload_client_secret,
+    trusted_context_headers,
 )
 from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
 
@@ -64,6 +76,9 @@ class McpServerConfig(BaseModel):
         default="streamable_http", description="MCP transport protocol"
     )
     auth: McpAuthConfig = Field(default_factory=McpNoAuthConfig)
+    agent_name: str = Field(default="", exclude=True)
+    agent_revision: int = Field(default=1, ge=1, exclude=True)
+    effective_scope: dict[str, str] = Field(default_factory=dict, exclude=True)
     workload_profile: McpWorkloadTokenExchangeProfile | None = Field(
         default=None,
         exclude=True,
@@ -77,16 +92,23 @@ class McpServerConfig(BaseModel):
         alias: str,
         config: AgentMcpServerConfig,
         settings: Settings,
+        *,
+        agent_name: str,
+        agent_revision: int,
+        effective_scope: Mapping[str, str],
     ) -> McpServerConfig:
         workload_profile = None
         if isinstance(config.auth, McpWorkloadTokenExchangeAuthConfig):
             workload_profile = settings.get_mcp_auth_profile(config.auth.profile)
         return cls(
             name=alias,
-            url=config.url,
+            url=_canonical_server_uri(config.url),
             required=config.required,
             transport=config.transport,
             auth=config.auth,
+            agent_name=agent_name,
+            agent_revision=agent_revision,
+            effective_scope=dict(effective_scope),
             workload_profile=workload_profile,
         )
 
@@ -125,28 +147,76 @@ class McpToolInfo(BaseModel):
     task_support: str | None = None
 
 
-def mcp_config_to_connection(config: McpServerConfig) -> StreamableHttpConnection:
-    if not isinstance(config.auth, McpNoAuthConfig):
+def mcp_config_to_connection(
+    config: McpServerConfig,
+    settings: Settings,
+) -> StreamableHttpConnection:
+    if isinstance(config.auth, McpNoAuthConfig):
+        return {"transport": "streamable_http", "url": config.url}
+    if isinstance(config.auth, McpStaticBearerAuthConfig):
+        try:
+            static_auth = StaticBearerAuth.from_environment(config.auth.env)
+        except McpAuthenticationError as exc:
+            raise McpTransportAuthenticationError(config.name, exc.category) from exc
+        return {
+            "transport": "streamable_http",
+            "url": config.url,
+            "auth": static_auth,
+        }
+    if isinstance(config.auth, McpWorkloadTokenExchangeAuthConfig):
+        profile = config.workload_profile
+        if profile is None:
+            raise McpTransportAuthenticationError(config.name, "auth_profile_unavailable")
+        audience = config.url if profile.audience == "canonical_server_uri" else profile.audience
+        try:
+            workload_auth = WorkloadTokenExchangeAuth(
+                profile=profile,
+                audience=audience,
+                identity=AmbientWorkloadIdentity.from_settings(settings),
+                client_secret=resolve_workload_client_secret(profile),
+            )
+            headers = trusted_context_headers(**_trusted_context_kwargs(config))
+        except McpAuthenticationError as exc:
+            raise McpTransportAuthenticationError(config.name, exc.category) from exc
+        return {
+            "transport": "streamable_http",
+            "url": config.url,
+            "headers": headers,
+            "auth": workload_auth,
+        }
+    if isinstance(config.auth, McpOAuthConfig):
         raise McpTransportAuthenticationError(config.name)
-    return {"transport": "streamable_http", "url": config.url}
+    raise McpTransportAuthenticationError(config.name, "auth_invalid")
 
 
 def create_mcp_client(
     configs: Sequence[McpServerConfig],
+    settings: Settings,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
 ) -> MultiServerMCPClient:
-    connections: dict[str, Any] = {c.name: mcp_config_to_connection(c) for c in configs}
+    connections: dict[str, Any] = {c.name: mcp_config_to_connection(c, settings) for c in configs}
+    workload_contexts = {
+        config.name: _trusted_context_kwargs(config)
+        for config in configs
+        if isinstance(config.auth, McpWorkloadTokenExchangeAuthConfig)
+    }
+    interceptors = list(tool_interceptors or [])
+    if workload_contexts:
+        # Security projection is innermost so earlier interceptors cannot add or
+        # retain arbitrary per-call headers after this default-deny overwrite.
+        interceptors.append(McpTrustedContextInterceptor(workload_contexts))
     return MultiServerMCPClient(
         connections=connections or None,
         callbacks=callbacks,
-        tool_interceptors=tool_interceptors,
+        tool_interceptors=interceptors or None,
         tool_name_prefix=True,
     )
 
 
 async def load_mcp_tools_per_server(
     configs: Sequence[McpServerConfig],
+    settings: Settings,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
 ) -> list[BaseTool]:
@@ -155,22 +225,29 @@ async def load_mcp_tools_per_server(
     tools: list[BaseTool] = []
     seen: set[str] = set()
     for config in configs:
-        client = create_mcp_client(
-            [config],
-            callbacks=callbacks,
-            tool_interceptors=tool_interceptors,
-        )
         try:
+            client = create_mcp_client(
+                [config],
+                settings,
+                callbacks=callbacks,
+                tool_interceptors=tool_interceptors,
+            )
             server_tools = await client.get_tools(server_name=config.name)
         except Exception as exc:
+            category = (
+                exc.category
+                if isinstance(exc, McpTransportAuthenticationError)
+                else "discovery_failed"
+            )
             logger.warning(
                 "mcp_server_discovery_failed",
                 server=config.name,
                 required=config.required,
+                category=category,
                 error_type=type(exc).__name__,
             )
             if config.required:
-                raise McpServerDiscoveryError(config.name) from exc
+                raise McpServerDiscoveryError(config.name, category) from exc
             continue
 
         for tool in server_tools:
@@ -180,6 +257,21 @@ async def load_mcp_tools_per_server(
             seen.add(canonical_name)
             tools.append(tool)
     return tools
+
+
+def _trusted_context_kwargs(config: McpServerConfig) -> dict[str, Any]:
+    return {
+        "agent_name": config.agent_name,
+        "agent_revision": config.agent_revision,
+        "effective_scope": config.effective_scope,
+        "server_alias": config.name,
+        "canonical_server_uri": config.url,
+    }
+
+
+def _canonical_server_uri(value: str) -> str:
+    """Canonicalize an already validated MCP HTTP endpoint."""
+    return str(httpx.URL(value))
 
 
 def _build_mcp_callbacks() -> Callbacks:
@@ -195,7 +287,7 @@ def _build_mcp_callbacks() -> Callbacks:
             tool=context.tool_name,
             progress=progress,
             total=total,
-            message=message,
+            message_present=message is not None,
         )
 
     async def on_logging_message(
@@ -207,7 +299,7 @@ def _build_mcp_callbacks() -> Callbacks:
             "mcp_server_log",
             server=context.server_name,
             level=params.level,
-            data=str(params.data),
+            data_present=params.data is not None,
         )
 
     return Callbacks(

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -509,8 +509,19 @@ class DeepAgentStreamingService:
         if agent_def.mcp.servers:
             from server.app.agent.mcp_client import McpServerConfig
 
+            pinned_revision = (
+                pinned_agent.get("revision") if isinstance(pinned_agent, Mapping) else None
+            )
+            agent_revision = pinned_revision if isinstance(pinned_revision, int) else 1
             resolved.mcp_configs = [
-                McpServerConfig.from_agent_config(alias, config, self.settings)
+                McpServerConfig.from_agent_config(
+                    alias,
+                    config,
+                    self.settings,
+                    agent_name=agent_def.name,
+                    agent_revision=agent_revision,
+                    effective_scope=effective_scope or {},
+                )
                 for alias, config in agent_def.mcp.servers.items()
             ]
 
@@ -583,12 +594,23 @@ class DeepAgentStreamingService:
 
             from server.app.agent.cognition_agent import CognitionContext
 
+            execution_timeout_seconds = (
+                agent_cfg.agent_def.config.timeout_seconds
+                if agent_cfg.agent_def is not None
+                else None
+            )
+            request_deadline = (
+                int((time.time() + execution_timeout_seconds) * 1000)
+                if execution_timeout_seconds is not None
+                else None
+            )
             invocation_context = CognitionContext.from_scope(
                 effective_scope,
                 session_id=session.id if session else session_id,
                 thread_id=session.thread_id if session else thread_id,
                 agent_name=session.agent_name if session else None,
                 metadata=session.metadata if session else None,
+                request_deadline=request_deadline,
             )
 
             context_policy = _effective_context_policy(
@@ -672,12 +694,6 @@ class DeepAgentStreamingService:
                 default_provider=provider,
                 default_model=model_id,
             )
-            execution_timeout_seconds = (
-                agent_cfg.agent_def.config.timeout_seconds
-                if agent_cfg.agent_def is not None
-                else None
-            )
-
             runtime_exception: Exception | None = None
 
             try:

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, SecretStr, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,7 +25,15 @@ class McpWorkloadTokenExchangeProfile(BaseModel):
     type: Literal["oauth_token_exchange"] = "oauth_token_exchange"
     token_endpoint: str
     subject_token_source: Literal["workload_identity"] = "workload_identity"
+    subject_token_type: str = "urn:ietf:params:oauth:token-type:access_token"
     audience: str = Field(min_length=1)
+    client_auth: Literal["none", "client_secret_basic"] = "none"
+    client_id: str | None = None
+    client_secret_env: str | None = Field(
+        default=None,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+    )
+    timeout_seconds: float = Field(default=10.0, gt=0, le=60)
 
     @field_validator("token_endpoint")
     @classmethod
@@ -48,6 +64,16 @@ class McpWorkloadTokenExchangeProfile(BaseModel):
         if value != value.strip() or any(character.isspace() for character in value):
             raise ValueError("MCP token-exchange audience must not contain whitespace")
         return value
+
+    @model_validator(mode="after")
+    def validate_client_auth(self) -> McpWorkloadTokenExchangeProfile:
+        """Require bounded environment client auth fields as one complete unit."""
+        if self.client_auth == "client_secret_basic":
+            if not self.client_id or self.client_secret_env is None:
+                raise ValueError("client_secret_basic requires client_id and client_secret_env")
+        elif self.client_id is not None or self.client_secret_env is not None:
+            raise ValueError("client_id/client_secret_env require client_secret_basic")
+        return self
 
 
 class Settings(BaseSettings):
@@ -93,6 +119,16 @@ class Settings(BaseSettings):
     mcp_auth_profiles: dict[str, McpWorkloadTokenExchangeProfile] = Field(
         default_factory=dict,
         alias="COGNITION_MCP_AUTH_PROFILES",
+    )
+    mcp_workload_identity_token_file: Path | None = Field(
+        default=None,
+        alias="COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN_FILE",
+        description="Projected, rotating workload subject-token file.",
+    )
+    mcp_workload_identity_token: SecretStr | None = Field(
+        default=None,
+        alias="COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN",
+        description="Environment fallback for the ambient workload subject token.",
     )
 
     # Workspace settings

--- a/tests/e2e/test_scenarios/p3_tools/test_mcp.py
+++ b/tests/e2e/test_scenarios/p3_tools/test_mcp.py
@@ -12,6 +12,7 @@ from server.app.agent.mcp_client import (
     McpServerDiscoveryError,
     load_mcp_tools_per_server,
 )
+from server.app.settings import Settings
 
 
 def test_agent_owned_mcp_config_round_trips_through_definition() -> None:
@@ -65,14 +66,17 @@ async def test_per_server_discovery_keeps_optional_failure_isolated(monkeypatch)
 
     monkeypatch.setattr(
         "server.app.agent.mcp_client.create_mcp_client",
-        lambda configs, callbacks=None, tool_interceptors=None: FakeClient(list(configs)[0]),
+        lambda configs, settings, callbacks=None, tool_interceptors=None: FakeClient(
+            list(configs)[0]
+        ),
     )
 
     tools = await load_mcp_tools_per_server(
         [
             McpServerConfig(name="optional", url="https://optional.test/mcp", required=False),
             McpServerConfig(name="required", url="https://required.test/mcp", required=True),
-        ]
+        ],
+        Settings(),
     )
 
     assert [tool.name for tool in tools] == ["required__lookup"]
@@ -86,12 +90,13 @@ async def test_required_discovery_failure_is_redacted(monkeypatch) -> None:
 
     monkeypatch.setattr(
         "server.app.agent.mcp_client.create_mcp_client",
-        lambda configs, callbacks=None, tool_interceptors=None: FakeClient(),
+        lambda configs, settings, callbacks=None, tool_interceptors=None: FakeClient(),
     )
 
     with pytest.raises(McpServerDiscoveryError) as exc_info:
         await load_mcp_tools_per_server(
-            [McpServerConfig(name="github", url="https://github.test/mcp", required=True)]
+            [McpServerConfig(name="github", url="https://github.test/mcp", required=True)],
+            Settings(),
         )
 
     assert exc_info.value.category == "discovery_failed"

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -9,6 +9,7 @@ from server.app.agent.mcp_client import (
     McpServerConfig,
     McpServerDiscoveryError,
     McpTransportAuthenticationError,
+    create_mcp_client,
     load_mcp_tools_per_server,
     mcp_config_to_connection,
 )
@@ -161,7 +162,14 @@ def test_workload_profile_resolves_from_deployment_configuration_only() -> None:
         }
     )
 
-    resolved = McpServerConfig.from_agent_config("github", agent.mcp.servers["github"], settings)
+    resolved = McpServerConfig.from_agent_config(
+        "github",
+        agent.mcp.servers["github"],
+        settings,
+        agent_name=agent.name,
+        agent_revision=3,
+        effective_scope={"tenant": "acme"},
+    )
 
     assert resolved.workload_profile is not None
     assert resolved.workload_profile.token_endpoint == "https://identity.internal/token"
@@ -188,7 +196,14 @@ def test_unknown_workload_profile_fails_resolution() -> None:
     )
 
     with pytest.raises(ValueError, match="Unknown MCP authentication profile"):
-        McpServerConfig.from_agent_config("github", agent.mcp.servers["github"], Settings())
+        McpServerConfig.from_agent_config(
+            "github",
+            agent.mcp.servers["github"],
+            Settings(),
+            agent_name=agent.name,
+            agent_revision=1,
+            effective_scope={"tenant": "acme"},
+        )
 
 
 def test_protected_auth_never_silently_builds_anonymous_transport() -> None:
@@ -201,7 +216,7 @@ def test_protected_auth_never_silently_builds_anonymous_transport() -> None:
     )
 
     with pytest.raises(McpTransportAuthenticationError, match="auth_unavailable"):
-        mcp_config_to_connection(config)
+        mcp_config_to_connection(config, Settings())
 
 
 @pytest.mark.asyncio
@@ -215,7 +230,7 @@ async def test_optional_mcp_server_failure_preserves_healthy_tools(monkeypatch) 
                 raise RuntimeError("connection refused")
             return [SimpleNamespace(name=f"{server_name}__search")]
 
-    def fake_create_client(configs, callbacks=None, tool_interceptors=None):
+    def fake_create_client(configs, settings, callbacks=None, tool_interceptors=None):
         return FakeClient(list(configs)[0])
 
     monkeypatch.setattr("server.app.agent.mcp_client.create_mcp_client", fake_create_client)
@@ -224,7 +239,46 @@ async def test_optional_mcp_server_failure_preserves_healthy_tools(monkeypatch) 
         [
             McpServerConfig(name="optional", url="https://optional.test/mcp", required=False),
             McpServerConfig(name="healthy", url="https://healthy.test/mcp", required=True),
-        ]
+        ],
+        Settings(),
+    )
+
+    assert [tool.name for tool in tools] == ["healthy__search"]
+
+
+@pytest.mark.asyncio
+async def test_optional_auth_failure_preserves_healthy_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeClient:
+        async def get_tools(self, *, server_name: str | None = None):
+            return [SimpleNamespace(name=f"{server_name}__search")]
+
+    def create_client(configs, settings, callbacks=None, tool_interceptors=None):
+        config = list(configs)[0]
+        if config.name == "optional-auth":
+            return create_mcp_client(
+                [config],
+                settings,
+                callbacks=callbacks,
+                tool_interceptors=tool_interceptors,
+            )
+        return FakeClient()
+
+    monkeypatch.setattr("server.app.agent.mcp_client.create_mcp_client", create_client)
+    tools = await load_mcp_tools_per_server(
+        [
+            McpServerConfig.model_validate(
+                {
+                    "name": "optional-auth",
+                    "url": "https://optional.test/mcp",
+                    "required": False,
+                    "auth": {"type": "static_bearer", "env": "MISSING_OPTIONAL_TOKEN"},
+                }
+            ),
+            McpServerConfig(name="healthy", url="https://healthy.test/mcp"),
+        ],
+        Settings(),
     )
 
     assert [tool.name for tool in tools] == ["healthy__search"]
@@ -238,16 +292,38 @@ async def test_required_mcp_server_failure_is_typed_and_redacted(monkeypatch) ->
 
     monkeypatch.setattr(
         "server.app.agent.mcp_client.create_mcp_client",
-        lambda configs, callbacks=None, tool_interceptors=None: FakeClient(),
+        lambda configs, settings, callbacks=None, tool_interceptors=None: FakeClient(),
     )
 
     with pytest.raises(McpServerDiscoveryError) as exc_info:
         await load_mcp_tools_per_server(
-            [McpServerConfig(name="github", url="https://github.test/mcp", required=True)]
+            [McpServerConfig(name="github", url="https://github.test/mcp", required=True)],
+            Settings(),
         )
 
     assert exc_info.value.server_alias == "github"
     assert "secret-value" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_required_auth_failure_is_typed_and_redacted() -> None:
+    with pytest.raises(McpServerDiscoveryError) as exc_info:
+        await load_mcp_tools_per_server(
+            [
+                McpServerConfig.model_validate(
+                    {
+                        "name": "github",
+                        "url": "https://github.test/mcp",
+                        "required": True,
+                        "auth": {"type": "mcp_oauth"},
+                    }
+                )
+            ],
+            Settings(),
+        )
+
+    assert exc_info.value.category == "auth_unavailable"
+    assert str(exc_info.value) == "MCP server 'github' failed: auth_unavailable"
 
 
 @pytest.mark.asyncio
@@ -258,7 +334,7 @@ async def test_duplicate_mcp_tool_identity_fails_discovery(monkeypatch) -> None:
 
     monkeypatch.setattr(
         "server.app.agent.mcp_client.create_mcp_client",
-        lambda configs, callbacks=None, tool_interceptors=None: FakeClient(),
+        lambda configs, settings, callbacks=None, tool_interceptors=None: FakeClient(),
     )
 
     with pytest.raises(McpServerDiscoveryError, match="duplicate_tool_identity"):
@@ -266,7 +342,8 @@ async def test_duplicate_mcp_tool_identity_fails_discovery(monkeypatch) -> None:
             [
                 McpServerConfig(name="one", url="https://one.test/mcp"),
                 McpServerConfig(name="two", url="https://two.test/mcp"),
-            ]
+            ],
+            Settings(),
         )
 
 

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,0 +1,363 @@
+"""Security tests for mandatory MCP transport authentication."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+from mcp.types import CallToolResult
+from pydantic import SecretStr
+
+from server.app.agent.mcp_auth import (
+    AmbientWorkloadIdentity,
+    McpAuthenticationError,
+    McpTrustedContextInterceptor,
+    StaticBearerAuth,
+    WorkloadTokenExchangeAuth,
+    trusted_context_headers,
+)
+from server.app.agent.mcp_client import (
+    McpServerConfig,
+    McpTransportAuthenticationError,
+    mcp_config_to_connection,
+)
+from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
+
+
+def _profile(**overrides) -> McpWorkloadTokenExchangeProfile:
+    values = {
+        "type": "oauth_token_exchange",
+        "token_endpoint": "https://identity.internal/token",
+        "subject_token_source": "workload_identity",
+        "audience": "canonical_server_uri",
+    }
+    values.update(overrides)
+    return McpWorkloadTokenExchangeProfile.model_validate(values)
+
+
+def test_none_connection_adds_no_authentication_or_context_headers() -> None:
+    connection = mcp_config_to_connection(
+        McpServerConfig(name="docs", url="https://mcp.example.test/docs"),
+        Settings(),
+    )
+
+    assert connection == {
+        "transport": "streamable_http",
+        "url": "https://mcp.example.test/docs",
+    }
+
+
+def test_static_bearer_reads_named_environment_at_transport_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DIRECT_MCP_TOKEN", "static-secret")
+    config = McpServerConfig.model_validate(
+        {
+            "name": "direct",
+            "url": "https://mcp.example.test/direct",
+            "auth": {"type": "static_bearer", "env": "DIRECT_MCP_TOKEN"},
+        }
+    )
+
+    connection = mcp_config_to_connection(config, Settings())
+    auth = connection["auth"]
+    assert isinstance(auth, StaticBearerAuth)
+    request = httpx.Request("POST", config.url)
+    authenticated = next(auth.auth_flow(request))
+
+    assert authenticated.headers["Authorization"] == "Bearer static-secret"
+    assert "static-secret" not in repr(auth)
+    assert "static-secret" not in str(config.model_dump(mode="json"))
+
+
+def test_static_bearer_missing_environment_fails_redacted() -> None:
+    config = McpServerConfig.model_validate(
+        {
+            "name": "direct",
+            "url": "https://mcp.example.test/direct",
+            "auth": {"type": "static_bearer", "env": "MISSING_MCP_TOKEN"},
+        }
+    )
+
+    with pytest.raises(
+        McpTransportAuthenticationError,
+        match="static_bearer_unavailable",
+    ):
+        mcp_config_to_connection(config, Settings())
+
+
+@pytest.mark.asyncio
+async def test_workload_exchange_is_exact_audience_bound_and_expiry_cached() -> None:
+    exchange_requests: list[httpx.Request] = []
+    mcp_authorization: list[str] = []
+
+    async def exchange_handler(request: httpx.Request) -> httpx.Response:
+        exchange_requests.append(request)
+        return httpx.Response(
+            200,
+            json={"access_token": "route-token", "token_type": "Bearer", "expires_in": 60},
+        )
+
+    async def mcp_handler(request: httpx.Request) -> httpx.Response:
+        mcp_authorization.append(request.headers["Authorization"])
+        return httpx.Response(200, json={"ok": True})
+
+    auth = WorkloadTokenExchangeAuth(
+        profile=_profile(),
+        audience="https://mcp-egress.internal/mcp/github",
+        identity=AmbientWorkloadIdentity(token_file=None, token=SecretStr("subject-token")),
+        client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(exchange_handler)),
+    )
+
+    async with httpx.AsyncClient(
+        auth=auth,
+        transport=httpx.MockTransport(mcp_handler),
+    ) as client:
+        await client.post("https://mcp-egress.internal/mcp/github")
+        await client.post("https://mcp-egress.internal/mcp/github")
+
+    assert len(exchange_requests) == 1
+    form = parse_qs(exchange_requests[0].content.decode("utf-8"))
+    assert form["audience"] == ["https://mcp-egress.internal/mcp/github"]
+    assert form["subject_token"] == ["subject-token"]
+    assert form["grant_type"] == ["urn:ietf:params:oauth:grant-type:token-exchange"]
+    assert mcp_authorization == ["Bearer route-token", "Bearer route-token"]
+
+
+@pytest.mark.asyncio
+async def test_workload_exchange_failure_never_exposes_token_response() -> None:
+    async def denied(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="subject-token provider-secret route-token")
+
+    auth = WorkloadTokenExchangeAuth(
+        profile=_profile(),
+        audience="https://mcp-egress.internal/mcp/github",
+        identity=AmbientWorkloadIdentity(token_file=None, token=SecretStr("subject-token")),
+        client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(denied)),
+    )
+
+    with pytest.raises(McpAuthenticationError) as exc_info:
+        async with httpx.AsyncClient(
+            auth=auth,
+            transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+        ) as client:
+            await client.post("https://mcp-egress.internal/mcp/github")
+
+    message = str(exc_info.value)
+    assert exc_info.value.category == "token_exchange_denied"
+    assert "subject-token" not in message
+    assert "provider-secret" not in message
+    assert "route-token" not in message
+
+
+@pytest.mark.asyncio
+async def test_workload_exchange_supports_deployment_client_secret_basic() -> None:
+    exchange_requests: list[httpx.Request] = []
+
+    async def exchange_handler(request: httpx.Request) -> httpx.Response:
+        exchange_requests.append(request)
+        return httpx.Response(200, json={"access_token": "route-token"})
+
+    profile = _profile(
+        client_auth="client_secret_basic",
+        client_id="cognition-exchange",
+        client_secret_env="TOKEN_EXCHANGE_CLIENT_SECRET",
+    )
+    auth = WorkloadTokenExchangeAuth(
+        profile=profile,
+        audience="https://mcp-egress.internal/mcp/github",
+        identity=AmbientWorkloadIdentity(token_file=None, token=SecretStr("subject-token")),
+        client_secret=SecretStr("client-secret"),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(exchange_handler)
+        ),
+    )
+
+    async with httpx.AsyncClient(
+        auth=auth,
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    ) as client:
+        await client.post("https://mcp-egress.internal/mcp/github")
+
+    encoded = base64.b64encode(b"cognition-exchange:client-secret").decode("ascii")
+    assert exchange_requests[0].headers["Authorization"] == f"Basic {encoded}"
+
+
+@pytest.mark.asyncio
+async def test_projected_workload_identity_is_reread_for_rotation(tmp_path) -> None:
+    token_file = tmp_path / "workload-token"
+    token_file.write_text("first-token", encoding="utf-8")
+    identity = AmbientWorkloadIdentity(token_file=token_file, token=None)
+
+    first = await identity.get_subject_token()
+    token_file.write_text("second-token", encoding="utf-8")
+    second = await identity.get_subject_token()
+
+    assert first.get_secret_value() == "first-token"
+    assert second.get_secret_value() == "second-token"
+
+
+def test_workload_connection_resolves_canonical_audience_and_discovery_context() -> None:
+    settings = Settings.model_validate(
+        {
+            "mcp_auth_profiles": {"egress": _profile().model_dump()},
+            "mcp_workload_identity_token": "ambient-subject",
+        }
+    )
+    config = McpServerConfig.model_validate(
+        {
+            "name": "github",
+            "url": "https://mcp-egress.internal/mcp/github",
+            "auth": {"type": "workload_token_exchange", "profile": "egress"},
+            "agent_name": "support-agent",
+            "agent_revision": 4,
+            "effective_scope": {"tenant": "acme"},
+            "workload_profile": settings.mcp_auth_profiles["egress"],
+        }
+    )
+
+    connection = mcp_config_to_connection(config, settings)
+
+    assert isinstance(connection["auth"], WorkloadTokenExchangeAuth)
+    assert connection["headers"] == {
+        "X-Cognition-Context-Version": "1",
+        "X-Cognition-Agent-ID": "support-agent",
+        "X-Cognition-Agent-Revision": "4",
+        "X-Cognition-Effective-Scope": '{"tenant":"acme"}',
+        "X-Cognition-MCP-Server-Alias": "github",
+        "X-Cognition-MCP-Server-URI": "https://mcp-egress.internal/mcp/github",
+    }
+
+
+@pytest.mark.asyncio
+async def test_trusted_context_interceptor_default_denies_incoming_headers() -> None:
+    contexts = {
+        "github": {
+            "agent_name": "support-agent",
+            "agent_revision": 7,
+            "effective_scope": {"tenant": "acme"},
+            "server_alias": "github",
+            "canonical_server_uri": "https://mcp-egress.internal/mcp/github",
+        }
+    }
+    runtime = SimpleNamespace(
+        context=SimpleNamespace(
+            session_id="session-1",
+            thread_id="thread-1",
+            request_deadline=1_800_000_000_000,
+        ),
+        config={"run_id": "run-1"},
+    )
+    request = MCPToolCallRequest(
+        name="search",
+        args={"query": "safe"},
+        server_name="github",
+        headers={
+            "Authorization": "Bearer model-token",
+            "X-Cognition-Agent-ID": "model-agent",
+            "X-Arbitrary": "model-value",
+        },
+        runtime=runtime,
+    )
+    captured: MCPToolCallRequest | None = None
+
+    async def handler(value: MCPToolCallRequest) -> CallToolResult:
+        nonlocal captured
+        captured = value
+        return CallToolResult(content=[])
+
+    await McpTrustedContextInterceptor(contexts)(request, handler)
+
+    assert captured is not None
+    assert captured.headers is not None
+    assert "Authorization" not in captured.headers
+    assert "X-Arbitrary" not in captured.headers
+    assert captured.headers["X-Cognition-Agent-ID"] == "support-agent"
+    assert captured.headers["X-Cognition-Session-ID"] == "session-1"
+    assert captured.headers["X-Cognition-Run-ID"] == "run-1"
+    assert captured.headers["X-Cognition-Request-Deadline"] == "1800000000000"
+
+
+@pytest.mark.asyncio
+async def test_trusted_context_interceptor_fails_closed_for_unknown_server() -> None:
+    request = MCPToolCallRequest(
+        name="search",
+        args={},
+        server_name="unexpected",
+        headers={"Authorization": "Bearer untrusted"},
+        runtime=None,
+    )
+
+    async def handler(value: MCPToolCallRequest) -> CallToolResult:
+        pytest.fail(f"unexpected transport call: {value.server_name}")
+
+    with pytest.raises(McpAuthenticationError) as exc_info:
+        await McpTrustedContextInterceptor({})(request, handler)
+
+    assert exc_info.value.category == "trusted_context_unavailable"
+
+
+def test_two_scopes_produce_distinct_trusted_context_without_cross_use() -> None:
+    first = trusted_context_headers(
+        agent_name="support-agent",
+        agent_revision=1,
+        effective_scope={"tenant": "one"},
+        server_alias="github",
+        canonical_server_uri="https://mcp-egress.internal/mcp/github",
+    )
+    second = trusted_context_headers(
+        agent_name="support-agent",
+        agent_revision=1,
+        effective_scope={"tenant": "two"},
+        server_alias="github",
+        canonical_server_uri="https://mcp-egress.internal/mcp/github",
+    )
+
+    assert first["X-Cognition-Effective-Scope"] == '{"tenant":"one"}'
+    assert second["X-Cognition-Effective-Scope"] == '{"tenant":"two"}'
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    ("agent_name", "category"),
+    [
+        ("support-agent\r\nX-Forged: true", "trusted_context_invalid"),
+        ("a" * 9000, "trusted_context_too_large"),
+    ],
+)
+def test_trusted_context_rejects_injection_and_unbounded_values(
+    agent_name: str,
+    category: str,
+) -> None:
+    with pytest.raises(McpAuthenticationError) as exc_info:
+        trusted_context_headers(
+            agent_name=agent_name,
+            agent_revision=1,
+            effective_scope={"tenant": "acme"},
+            server_alias="github",
+            canonical_server_uri="https://mcp-egress.internal/mcp/github",
+        )
+
+    assert exc_info.value.category == category
+
+
+def test_workload_transport_fails_when_ambient_identity_is_unavailable() -> None:
+    settings = Settings.model_validate({"mcp_auth_profiles": {"egress": _profile().model_dump()}})
+    config = McpServerConfig.model_validate(
+        {
+            "name": "github",
+            "url": "https://mcp-egress.internal/mcp/github",
+            "auth": {"type": "workload_token_exchange", "profile": "egress"},
+            "workload_profile": settings.mcp_auth_profiles["egress"],
+        }
+    )
+
+    with pytest.raises(
+        McpTransportAuthenticationError,
+        match="workload_identity_unavailable",
+    ):
+        mcp_config_to_connection(config, settings)


### PR DESCRIPTION
## Summary

- implement anonymous, environment-backed static bearer, and workload token-exchange MCP transports
- project a fixed, model-invisible trusted runtime context for workload gateway authorization
- add exact-audience exchange, bounded token caching, projected identity rotation, redacted failures, and per-server failure isolation
- retain fail-closed behavior for `mcp_oauth` until its encrypted scoped token store lands separately

## Security boundaries

- Agent configuration contains no raw token, client secret, arbitrary headers, or callback
- token-exchange profiles are deployment-owned and referenced opaquely by Agents
- workload tokens authenticate the Cognition workload; the trusted context envelope supplies logical Agent context for live gateway authorization
- the mandatory context interceptor overwrites all per-call headers and fails closed when context is unavailable
- logs contain failure categories and presence flags, not MCP arguments/results/credentials

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- 135 focused tests passed, 2 skipped
- `uv run mkdocs build --strict`
- `git diff --check`
