### PR TITLE
feat: add encrypted MCP OAuth storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "python-multipart>=0.0.12",
     "sqlalchemy[asyncio]>=2.0.0",
     "alembic>=1.14.0",
+    "cryptography>=48.0.1",
     # Client
     "httpx>=0.27.0",
     "prompt-toolkit>=3.0.43",

--- a/server/app/api/dependencies.py
+++ b/server/app/api/dependencies.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from server.app.llm.model_catalog import ModelCatalog
     from server.app.storage.artifact_store import ArtifactStore
     from server.app.storage.backend import StorageBackend
+    from server.app.storage.mcp_oauth import McpOAuthStateRepository
 
 # ---------------------------------------------------------------------------
 # Global references — set once during lifespan, read via Depends()
@@ -42,6 +43,7 @@ _storage_backend: StorageBackend | None = None
 _session_agent_manager: SessionAgentManager | None = None
 _model_catalog: ModelCatalog | None = None
 _artifact_store: ArtifactStore | None = None
+_mcp_oauth_state_repository: McpOAuthStateRepository | None = None
 
 
 def set_config_store(store: ConfigStore) -> None:
@@ -72,6 +74,11 @@ def set_model_catalog_dep(catalog: ModelCatalog) -> None:
 def set_artifact_store(store: ArtifactStore) -> None:
     global _artifact_store
     _artifact_store = store
+
+
+def set_mcp_oauth_state_repository(repository: McpOAuthStateRepository) -> None:
+    global _mcp_oauth_state_repository
+    _mcp_oauth_state_repository = repository
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +136,12 @@ def get_artifact_store() -> ArtifactStore:
     return _artifact_store
 
 
+def get_mcp_oauth_state_repository() -> McpOAuthStateRepository:
+    if _mcp_oauth_state_repository is None:
+        raise RuntimeError("MCP OAuth state repository not initialized during startup.")
+    return _mcp_oauth_state_repository
+
+
 def get_rate_limiter_dep() -> RateLimiter:
     return get_rate_limiter()
 
@@ -148,6 +161,7 @@ __all__ = [
     "ConfigStore",
     "RuntimeResolver",
     "get_artifact_store",
+    "get_mcp_oauth_state_repository",
     "get_config_store",
     "get_model_catalog_dep",
     "get_rate_limiter_dep",
@@ -162,4 +176,5 @@ __all__ = [
     "set_runtime_resolver",
     "set_session_agent_manager_dep",
     "set_storage_backend_dep",
+    "set_mcp_oauth_state_repository",
 ]

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -16,6 +16,7 @@ from server.app.api.dependencies import (
     get_storage_backend_dep,
     set_artifact_store,
     set_config_store,
+    set_mcp_oauth_state_repository,
     set_model_catalog_dep,
     set_runtime_resolver,
     set_session_agent_manager_dep,
@@ -75,6 +76,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await storage_backend.initialize()
     set_storage_backend_dep(storage_backend)
     logger.info("Storage backend initialized")
+
+    from server.app.storage.factory import create_mcp_oauth_state_repository
+
+    mcp_oauth_state_repository = create_mcp_oauth_state_repository(settings)
+    await mcp_oauth_state_repository.initialize()
+    set_mcp_oauth_state_repository(mcp_oauth_state_repository)
+    logger.info("MCP OAuth state repository initialized")
 
     # Initialize ConfigRegistry
     from server.app.storage.factory import create_config_dispatcher, create_config_registry
@@ -276,6 +284,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Close storage backend connections
     if storage_backend:
         await storage_backend.close()
+    await mcp_oauth_state_repository.close()
     logger.info("Server shutdown complete")
 
 

--- a/server/app/storage/factory.py
+++ b/server/app/storage/factory.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from server.app.storage.backend import StorageBackend
     from server.app.storage.config_dispatcher import ConfigChangeDispatcher
     from server.app.storage.config_registry import ConfigRegistry
+    from server.app.storage.mcp_oauth import McpOAuthStateRepository
 
 
 class StorageBackendError(CognitionError):
@@ -60,7 +61,6 @@ def create_storage_backend(settings: Settings) -> StorageBackend:
             connection_string=uri,
             workspace_path=workspace_path,
         )
-
     elif backend_type == "postgres":
         from server.app.storage.postgres import PostgresStorageBackend
 
@@ -81,6 +81,41 @@ def create_storage_backend(settings: Settings) -> StorageBackend:
             f"Supported types: sqlite, postgres, memory",
             backend_type=backend_type,
         )
+
+
+def create_mcp_oauth_state_repository(settings: Settings) -> McpOAuthStateRepository:
+    """Create the deployment-matched opaque MCP OAuth state repository."""
+    backend_type = getattr(settings, "persistence_backend", "sqlite")
+    uri = getattr(settings, "persistence_uri", ".cognition/state.db")
+
+    if backend_type == "memory":
+        from server.app.storage.mcp_oauth import MemoryMcpOAuthStateRepository
+
+        return MemoryMcpOAuthStateRepository()
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from server.app.storage.mcp_oauth import SqlMcpOAuthStateRepository
+
+    if backend_type == "sqlite":
+        normalized_uri = uri.removeprefix("sqlite:///")
+        db_path = Path(normalized_uri)
+        if not db_path.is_absolute():
+            db_path = Path(str(settings.workspace_path)) / db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        return SqlMcpOAuthStateRepository(engine)
+
+    if backend_type == "postgres":
+        sqlalchemy_dsn = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+        engine = create_async_engine(sqlalchemy_dsn)
+        return SqlMcpOAuthStateRepository(engine)
+
+    raise StorageBackendError(
+        f"Unknown storage backend type: '{backend_type}'. "
+        "Supported types: sqlite, postgres, memory",
+        backend_type=backend_type,
+    )
 
 
 def create_config_registry(settings: Settings) -> ConfigRegistry:

--- a/server/app/storage/mcp_oauth.py
+++ b/server/app/storage/mcp_oauth.py
@@ -1,0 +1,203 @@
+"""Encrypted, exact-scope persistence for the upstream MCP OAuth client."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from cryptography.fernet import Fernet, InvalidToken
+from mcp.client.auth import TokenStorage
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import SecretStr, ValidationError
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from server.app.storage.schema import mcp_oauth_state_table
+
+
+class McpOAuthStorageError(RuntimeError):
+    """Typed, redacted OAuth persistence failure."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(f"MCP OAuth storage failed: {category}")
+
+
+class McpOAuthStateRepository(Protocol):
+    """Opaque ciphertext repository used by the SDK storage adapter."""
+
+    async def get_ciphertext(self, partition_key: str, field: str) -> str | None: ...
+
+    async def set_ciphertext(self, partition_key: str, field: str, value: str) -> None: ...
+
+    async def initialize(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+class MemoryMcpOAuthStateRepository:
+    """Process-local OAuth state repository for memory-backed development."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, dict[str, str]] = {}
+
+    async def initialize(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self._rows.clear()
+
+    async def get_ciphertext(self, partition_key: str, field: str) -> str | None:
+        return self._rows.get(partition_key, {}).get(field)
+
+    async def set_ciphertext(self, partition_key: str, field: str, value: str) -> None:
+        self._rows.setdefault(partition_key, {})[field] = value
+
+
+class SqlMcpOAuthStateRepository:
+    """SQLAlchemy repository shared by SQLite and PostgreSQL deployments."""
+
+    _FIELDS = frozenset({"tokens_ciphertext", "client_info_ciphertext"})
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def initialize(self) -> None:
+        async with self._engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: mcp_oauth_state_table.create(
+                    sync_connection,
+                    checkfirst=True,
+                )
+            )
+
+    async def close(self) -> None:
+        await self._engine.dispose()
+
+    async def get_ciphertext(self, partition_key: str, field: str) -> str | None:
+        column = self._column(field)
+        async with self._engine.connect() as connection:
+            result = await connection.execute(
+                select(column).where(mcp_oauth_state_table.c.partition_key == partition_key)
+            )
+        value = result.scalar_one_or_none()
+        return str(value) if value is not None else None
+
+    async def set_ciphertext(self, partition_key: str, field: str, value: str) -> None:
+        self._column(field)
+        dialect = self._engine.dialect.name
+        values = {"partition_key": partition_key, field: value}
+        if dialect == "sqlite":
+            statement: Any = sqlite_insert(mcp_oauth_state_table).values(**values)
+        elif dialect == "postgresql":
+            statement = postgres_insert(mcp_oauth_state_table).values(**values)
+        else:  # pragma: no cover - factory admits only supported SQL backends
+            raise McpOAuthStorageError("backend_unsupported")
+        statement = statement.on_conflict_do_update(
+            index_elements=[mcp_oauth_state_table.c.partition_key],
+            set_={field: value},
+        )
+        async with self._engine.begin() as connection:
+            await connection.execute(statement)
+
+    @classmethod
+    def _column(cls, field: str) -> Any:
+        if field not in cls._FIELDS:
+            raise McpOAuthStorageError("field_invalid")
+        return mcp_oauth_state_table.c[field]
+
+
+class EncryptedMcpOAuthTokenStorage(TokenStorage):
+    """MCP SDK token storage encrypted and partitioned by trusted runtime identity."""
+
+    def __init__(
+        self,
+        *,
+        repository: McpOAuthStateRepository,
+        encryption_key: SecretStr,
+        agent_name: str,
+        effective_scope: Mapping[str, str],
+        canonical_server_uri: str,
+    ) -> None:
+        try:
+            key = encryption_key.get_secret_value().encode("ascii")
+            self._fernet = Fernet(key)
+        except (ValueError, UnicodeEncodeError) as exc:
+            raise McpOAuthStorageError("encryption_key_invalid") from exc
+        self._repository = repository
+        self._partition_key = _partition_key(
+            key=key,
+            agent_name=agent_name,
+            effective_scope=effective_scope,
+            canonical_server_uri=canonical_server_uri,
+        )
+
+    async def get_tokens(self) -> OAuthToken | None:
+        payload = await self._read("tokens_ciphertext")
+        if payload is None:
+            return None
+        try:
+            return OAuthToken.model_validate_json(payload)
+        except ValidationError as exc:
+            raise McpOAuthStorageError("state_invalid") from exc
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        await self._write("tokens_ciphertext", tokens.model_dump_json())
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        payload = await self._read("client_info_ciphertext")
+        if payload is None:
+            return None
+        try:
+            return OAuthClientInformationFull.model_validate_json(payload)
+        except ValidationError as exc:
+            raise McpOAuthStorageError("state_invalid") from exc
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        await self._write("client_info_ciphertext", client_info.model_dump_json())
+
+    async def _read(self, field: str) -> str | None:
+        ciphertext = await self._repository.get_ciphertext(self._partition_key, field)
+        if ciphertext is None:
+            return None
+        try:
+            return self._fernet.decrypt(ciphertext.encode("ascii")).decode("utf-8")
+        except (InvalidToken, UnicodeDecodeError, UnicodeEncodeError) as exc:
+            raise McpOAuthStorageError("state_unreadable") from exc
+
+    async def _write(self, field: str, payload: str) -> None:
+        ciphertext = self._fernet.encrypt(payload.encode("utf-8")).decode("ascii")
+        await self._repository.set_ciphertext(self._partition_key, field, ciphertext)
+
+
+def _partition_key(
+    *,
+    key: bytes,
+    agent_name: str,
+    effective_scope: Mapping[str, str],
+    canonical_server_uri: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "agent_name": agent_name,
+            "canonical_server_uri": canonical_server_uri,
+            "effective_scope": dict(sorted(effective_scope.items())),
+        },
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hmac.new(key, canonical, hashlib.sha256).hexdigest()
+
+
+__all__ = [
+    "EncryptedMcpOAuthTokenStorage",
+    "McpOAuthStateRepository",
+    "McpOAuthStorageError",
+    "MemoryMcpOAuthStateRepository",
+    "SqlMcpOAuthStateRepository",
+]

--- a/server/app/storage/schema.py
+++ b/server/app/storage/schema.py
@@ -64,6 +64,24 @@ class _JsonbOrJson(TypeDecorator):
 # Central metadata object that holds all table definitions
 metadata = MetaData()
 
+# Encrypted MCP OAuth SDK state. Partition keys are deployment-keyed digests of
+# exact effective scope + Agent identity + canonical server URI; no raw scope or
+# OAuth material is stored in indexable columns.
+mcp_oauth_state_table = Table(
+    "mcp_oauth_state",
+    metadata,
+    Column("partition_key", String(64), primary_key=True),
+    Column("tokens_ciphertext", Text),
+    Column("client_info_ciphertext", Text),
+    Column(
+        "updated_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    ),
+)
+
 # Sessions table - stores conversation session metadata
 sessions_table = Table(
     "sessions",

--- a/tests/unit/test_mcp_oauth_storage.py
+++ b/tests/unit/test_mcp_oauth_storage.py
@@ -1,0 +1,139 @@
+"""Encrypted persistence tests for MCP OAuth SDK state."""
+
+from __future__ import annotations
+
+from cryptography.fernet import Fernet
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import SecretStr
+
+from server.app.settings import Settings
+from server.app.storage.factory import create_mcp_oauth_state_repository
+from server.app.storage.mcp_oauth import (
+    EncryptedMcpOAuthTokenStorage,
+    McpOAuthStorageError,
+    MemoryMcpOAuthStateRepository,
+)
+
+
+def _key() -> SecretStr:
+    return SecretStr(Fernet.generate_key().decode("ascii"))
+
+
+def _storage(
+    repository: MemoryMcpOAuthStateRepository,
+    key: SecretStr,
+    *,
+    scope: dict[str, str] | None = None,
+    agent_name: str = "support-agent",
+    uri: str = "https://mcp.example.test/github",
+) -> EncryptedMcpOAuthTokenStorage:
+    return EncryptedMcpOAuthTokenStorage(
+        repository=repository,
+        encryption_key=key,
+        agent_name=agent_name,
+        effective_scope=scope or {"tenant": "acme"},
+        canonical_server_uri=uri,
+    )
+
+
+async def test_tokens_and_dynamic_client_secrets_are_encrypted_at_rest() -> None:
+    repository = MemoryMcpOAuthStateRepository()
+    storage = _storage(repository, _key())
+    tokens = OAuthToken(
+        access_token="access-secret",
+        refresh_token="refresh-secret",
+        expires_in=300,
+    )
+    client = OAuthClientInformationFull.model_validate(
+        {
+            "redirect_uris": ["https://cognition.example.test/mcp/oauth/callback"],
+            "client_id": "dynamic-client",
+            "client_secret": "client-secret",
+        }
+    )
+
+    await storage.set_tokens(tokens)
+    await storage.set_client_info(client)
+
+    serialized_repository = str(repository._rows)  # noqa: SLF001 - ciphertext assertion
+    assert "access-secret" not in serialized_repository
+    assert "refresh-secret" not in serialized_repository
+    assert "client-secret" not in serialized_repository
+    assert await storage.get_tokens() == tokens
+    assert await storage.get_client_info() == client
+
+
+async def test_exact_scope_agent_and_server_partitions_do_not_cross_read() -> None:
+    repository = MemoryMcpOAuthStateRepository()
+    key = _key()
+    source = _storage(repository, key)
+    await source.set_tokens(OAuthToken(access_token="source-token"))
+
+    different_scope = _storage(repository, key, scope={"tenant": "other"})
+    different_agent = _storage(repository, key, agent_name="other-agent")
+    different_server = _storage(repository, key, uri="https://mcp.example.test/slack")
+
+    assert (await source.get_tokens()).access_token == "source-token"  # type: ignore[union-attr]
+    assert await different_scope.get_tokens() is None
+    assert await different_agent.get_tokens() is None
+    assert await different_server.get_tokens() is None
+    assert len(repository._rows) == 1  # noqa: SLF001 - partition assertion
+    partition_key = next(iter(repository._rows))  # noqa: SLF001 - partition assertion
+    assert len(partition_key) == 64
+    assert "acme" not in partition_key
+
+
+async def test_corrupt_ciphertext_fails_with_redacted_category() -> None:
+    repository = MemoryMcpOAuthStateRepository()
+    storage = _storage(repository, _key())
+    await storage.set_tokens(OAuthToken(access_token="secret-token"))
+    row = next(iter(repository._rows.values()))  # noqa: SLF001 - corruption fixture
+    row["tokens_ciphertext"] = "not-valid-fernet-ciphertext"
+
+    try:
+        await storage.get_tokens()
+    except McpOAuthStorageError as exc:
+        assert exc.category == "state_unreadable"
+        assert "secret-token" not in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("wrong encryption key unexpectedly decrypted OAuth state")
+
+
+async def test_sqlite_repository_persists_only_encrypted_state(tmp_path) -> None:
+    settings = Settings.model_validate(
+        {
+            "workspace_root": str(tmp_path),
+            "persistence_backend": "sqlite",
+            "persistence_uri": "oauth.db",
+        }
+    )
+    key = _key()
+    first_repository = create_mcp_oauth_state_repository(settings)
+    await first_repository.initialize()
+    first_storage = EncryptedMcpOAuthTokenStorage(
+        repository=first_repository,
+        encryption_key=key,
+        agent_name="support-agent",
+        effective_scope={"tenant": "acme"},
+        canonical_server_uri="https://mcp.example.test/github",
+    )
+    await first_storage.set_tokens(OAuthToken(access_token="durable-secret"))
+    await first_repository.close()
+
+    database_bytes = (tmp_path / "oauth.db").read_bytes()
+    assert b"durable-secret" not in database_bytes
+
+    second_repository = create_mcp_oauth_state_repository(settings)
+    await second_repository.initialize()
+    second_storage = EncryptedMcpOAuthTokenStorage(
+        repository=second_repository,
+        encryption_key=key,
+        agent_name="support-agent",
+        effective_scope={"tenant": "acme"},
+        canonical_server_uri="https://mcp.example.test/github",
+    )
+    restored = await second_storage.get_tokens()
+    await second_repository.close()
+
+    assert restored is not None
+    assert restored.access_token == "durable-secret"

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -31,7 +31,8 @@ class TestSchemaDefinitions:
         assert "session_runs" in table_names
         assert "session_events" in table_names
         assert "runtime_tasks" in table_names
-        assert len(table_names) == 8
+        assert "mcp_oauth_state" in table_names
+        assert len(table_names) == 9
 
     def test_sessions_table_columns(self) -> None:
         """Test sessions table has expected columns."""

--- a/uv.lock
+++ b/uv.lock
@@ -609,6 +609,7 @@ source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "alembic" },
+    { name = "cryptography" },
     { name = "deepagents" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -720,6 +721,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "deepagents", specifier = ">=0.7.1" },
     { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
     { name = "docker", marker = "extra == 'deploy'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary

- add an opaque MCP OAuth state repository for SQLite, PostgreSQL, and in-memory development
- adapt the upstream MCP SDK `TokenStorage` contract with authenticated encryption
- partition tokens and dynamically registered client information by exact effective scope, Agent identity, and canonical MCP server URI
- initialize and close the repository with the Cognition application lifecycle

## Security boundaries

- database rows contain only a keyed partition digest and Fernet ciphertext
- access tokens, refresh tokens, dynamic client secrets, and raw scope values are never stored in plaintext
- unreadable/corrupt state fails with a typed, redacted category
- no production-mode classifier is introduced; the memory repository remains available for local/development use

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- 81 focused tests passed, 2 skipped
- `uv run mkdocs build --strict`
- `git diff --check`
