### PR TITLE
feat: wire standard MCP OAuth transport

### DIFF
--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -466,6 +466,7 @@ class CognitionAgentParams:
     tools: Sequence[Any] | None = None
     settings: Settings | None = None
     mcp_configs: Sequence[McpServerConfig] | None = None
+    mcp_oauth_repository: Any | None = None
     scope: dict[str, str] | None = None
     config_store: ConfigStore | None = None
     sandbox_profile: str | None = None
@@ -813,6 +814,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                     params.mcp_configs,
                     settings,
                     callbacks=mcp_callbacks,
+                    oauth_repository=params.mcp_oauth_repository,
                 )
                 agent_tools.extend(mcp_tools)
                 logger.info("MCP tools loaded", count=len(mcp_tools))

--- a/server/app/agent/mcp_auth.py
+++ b/server/app/agent/mcp_auth.py
@@ -12,9 +12,16 @@ from typing import Any
 
 import httpx
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallResult
+from mcp.client.auth import OAuthClientProvider
+from mcp.shared.auth import OAuthClientMetadata
 from pydantic import SecretStr
 
 from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
+from server.app.storage.mcp_oauth import (
+    EncryptedMcpOAuthTokenStorage,
+    McpOAuthStateRepository,
+    McpOAuthStorageError,
+)
 
 _TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
 _ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
@@ -212,6 +219,52 @@ def resolve_workload_client_secret(
     return SecretStr(value)
 
 
+def create_mcp_oauth_auth(
+    *,
+    settings: Settings,
+    repository: McpOAuthStateRepository | None,
+    agent_name: str,
+    effective_scope: Mapping[str, str],
+    canonical_server_uri: str,
+) -> OAuthClientProvider:
+    """Create the upstream MCP OAuth provider with exact-scope encrypted state."""
+    if (
+        repository is None
+        or settings.mcp_oauth_encryption_key is None
+        or settings.mcp_oauth_redirect_uri is None
+    ):
+        raise McpAuthenticationError("oauth_configuration_unavailable")
+    try:
+        storage = EncryptedMcpOAuthTokenStorage(
+            repository=repository,
+            encryption_key=settings.mcp_oauth_encryption_key,
+            agent_name=agent_name,
+            effective_scope=effective_scope,
+            canonical_server_uri=canonical_server_uri,
+        )
+        metadata = OAuthClientMetadata.model_validate(
+            {
+                "redirect_uris": [settings.mcp_oauth_redirect_uri],
+                "token_endpoint_auth_method": "none",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "client_name": settings.mcp_oauth_client_name,
+            }
+        )
+        return OAuthClientProvider(
+            server_url=canonical_server_uri,
+            client_metadata=metadata,
+            storage=storage,
+            timeout=settings.mcp_oauth_timeout_seconds,
+            client_metadata_url=settings.mcp_oauth_client_metadata_url,
+        )
+    except (McpOAuthStorageError, ValueError) as exc:
+        category = (
+            exc.category if isinstance(exc, McpOAuthStorageError) else "oauth_configuration_invalid"
+        )
+        raise McpAuthenticationError(category) from exc
+
+
 def trusted_context_headers(
     *,
     agent_name: str,
@@ -302,6 +355,7 @@ __all__ = [
     "McpTrustedContextInterceptor",
     "StaticBearerAuth",
     "WorkloadTokenExchangeAuth",
+    "create_mcp_oauth_auth",
     "resolve_workload_client_secret",
     "trusted_context_headers",
 ]

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -38,10 +38,12 @@ from server.app.agent.mcp_auth import (
     McpTrustedContextInterceptor,
     StaticBearerAuth,
     WorkloadTokenExchangeAuth,
+    create_mcp_oauth_auth,
     resolve_workload_client_secret,
     trusted_context_headers,
 )
 from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
+from server.app.storage.mcp_oauth import McpOAuthStateRepository
 
 logger = structlog.get_logger(__name__)
 
@@ -150,6 +152,7 @@ class McpToolInfo(BaseModel):
 def mcp_config_to_connection(
     config: McpServerConfig,
     settings: Settings,
+    oauth_repository: McpOAuthStateRepository | None = None,
 ) -> StreamableHttpConnection:
     if isinstance(config.auth, McpNoAuthConfig):
         return {"transport": "streamable_http", "url": config.url}
@@ -185,7 +188,21 @@ def mcp_config_to_connection(
             "auth": workload_auth,
         }
     if isinstance(config.auth, McpOAuthConfig):
-        raise McpTransportAuthenticationError(config.name)
+        try:
+            oauth_auth = create_mcp_oauth_auth(
+                settings=settings,
+                repository=oauth_repository,
+                agent_name=config.agent_name,
+                effective_scope=config.effective_scope,
+                canonical_server_uri=config.url,
+            )
+        except McpAuthenticationError as exc:
+            raise McpTransportAuthenticationError(config.name, exc.category) from exc
+        return {
+            "transport": "streamable_http",
+            "url": config.url,
+            "auth": oauth_auth,
+        }
     raise McpTransportAuthenticationError(config.name, "auth_invalid")
 
 
@@ -194,8 +211,12 @@ def create_mcp_client(
     settings: Settings,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    *,
+    oauth_repository: McpOAuthStateRepository | None = None,
 ) -> MultiServerMCPClient:
-    connections: dict[str, Any] = {c.name: mcp_config_to_connection(c, settings) for c in configs}
+    connections: dict[str, Any] = {
+        c.name: mcp_config_to_connection(c, settings, oauth_repository) for c in configs
+    }
     workload_contexts = {
         config.name: _trusted_context_kwargs(config)
         for config in configs
@@ -219,6 +240,8 @@ async def load_mcp_tools_per_server(
     settings: Settings,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    *,
+    oauth_repository: McpOAuthStateRepository | None = None,
 ) -> list[BaseTool]:
     """Load MCP tools server-by-server and enforce canonical identity uniqueness."""
 
@@ -226,12 +249,13 @@ async def load_mcp_tools_per_server(
     seen: set[str] = set()
     for config in configs:
         try:
-            client = create_mcp_client(
-                [config],
-                settings,
-                callbacks=callbacks,
-                tool_interceptors=tool_interceptors,
-            )
+            client_kwargs: dict[str, Any] = {
+                "callbacks": callbacks,
+                "tool_interceptors": tool_interceptors,
+            }
+            if oauth_repository is not None:
+                client_kwargs["oauth_repository"] = oauth_repository
+            client = create_mcp_client([config], settings, **client_kwargs)
             server_tools = await client.get_tools(server_name=config.name)
         except Exception as exc:
             category = (

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -330,11 +330,13 @@ class DeepAgentStreamingService:
         settings: Settings,
         runtime_resolver: RuntimeResolver | None = None,
         config_store: ConfigStore | None = None,
+        mcp_oauth_repository: Any | None = None,
     ) -> None:
         self.settings = settings
         self.storage_backend = create_storage_backend(settings)
         self._runtime_resolver = runtime_resolver
         self._config_store = config_store
+        self._mcp_oauth_repository = mcp_oauth_repository
 
     def _get_runtime_resolver(self) -> RuntimeResolver:
         if self._runtime_resolver is None:
@@ -655,6 +657,7 @@ class DeepAgentStreamingService:
                 blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
                 mcp_configs=agent_cfg.mcp_configs or None,
+                mcp_oauth_repository=self._mcp_oauth_repository,
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -924,6 +927,7 @@ class DeepAgentStreamingService:
                 blocked_tools=agent_cfg.blocked_tools,
                 middleware=agent_cfg.middleware,
                 mcp_configs=agent_cfg.mcp_configs or None,
+                mcp_oauth_repository=self._mcp_oauth_repository,
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -1111,6 +1115,7 @@ class SessionAgentManager:
         storage_backend: Any | None = None,
         runtime_resolver: RuntimeResolver | None = None,
         config_store: ConfigStore | None = None,
+        mcp_oauth_repository: Any | None = None,
     ) -> None:
         """Initialize the session manager.
 
@@ -1124,6 +1129,7 @@ class SessionAgentManager:
         self._storage_backend = storage_backend
         self._runtime_resolver = runtime_resolver
         self._config_store = config_store
+        self._mcp_oauth_repository = mcp_oauth_repository
         self._services: dict[str, DeepAgentStreamingService] = {}
         self._project_paths: dict[str, str] = {}
         self._service_access: dict[str, float] = {}
@@ -1159,6 +1165,7 @@ class SessionAgentManager:
             settings=self.settings,
             runtime_resolver=self._runtime_resolver,
             config_store=self._config_store,
+            mcp_oauth_repository=self._mcp_oauth_repository,
         )
         if self._storage_backend is not None:
             service.storage_backend = self._storage_backend

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -161,6 +161,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         storage_backend=storage_backend,
         runtime_resolver=runtime_resolver,
         config_store=config_store,
+        mcp_oauth_repository=mcp_oauth_state_repository,
     )
     set_session_agent_manager_dep(session_agent_manager)
     logger.info("SessionAgentManager initialized")

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -130,6 +130,33 @@ class Settings(BaseSettings):
         alias="COGNITION_MCP_WORKLOAD_IDENTITY_TOKEN",
         description="Environment fallback for the ambient workload subject token.",
     )
+    mcp_oauth_encryption_key: SecretStr | None = Field(
+        default=None,
+        alias="COGNITION_MCP_OAUTH_ENCRYPTION_KEY",
+        description="Fernet key for exact-scope MCP OAuth SDK state.",
+    )
+    mcp_oauth_redirect_uri: str | None = Field(
+        default=None,
+        alias="COGNITION_MCP_OAUTH_REDIRECT_URI",
+        description="Builder-routable OAuth callback URI registered by the MCP client.",
+    )
+    mcp_oauth_client_name: str = Field(
+        default="Cognition",
+        alias="COGNITION_MCP_OAUTH_CLIENT_NAME",
+        min_length=1,
+        max_length=100,
+    )
+    mcp_oauth_client_metadata_url: str | None = Field(
+        default=None,
+        alias="COGNITION_MCP_OAUTH_CLIENT_METADATA_URL",
+        description="Optional HTTPS client metadata document URL supported by the MCP SDK.",
+    )
+    mcp_oauth_timeout_seconds: float = Field(
+        default=300.0,
+        alias="COGNITION_MCP_OAUTH_TIMEOUT_SECONDS",
+        gt=0,
+        le=900,
+    )
 
     # Workspace settings
     workspace_root: Path = Field(

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -215,7 +215,10 @@ def test_protected_auth_never_silently_builds_anonymous_transport() -> None:
         }
     )
 
-    with pytest.raises(McpTransportAuthenticationError, match="auth_unavailable"):
+    with pytest.raises(
+        McpTransportAuthenticationError,
+        match="oauth_configuration_unavailable",
+    ):
         mcp_config_to_connection(config, Settings())
 
 
@@ -322,8 +325,10 @@ async def test_required_auth_failure_is_typed_and_redacted() -> None:
             Settings(),
         )
 
-    assert exc_info.value.category == "auth_unavailable"
-    assert str(exc_info.value) == "MCP server 'github' failed: auth_unavailable"
+    assert exc_info.value.category == "oauth_configuration_unavailable"
+    assert str(exc_info.value) == (
+        "MCP server 'github' failed: oauth_configuration_unavailable"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -8,7 +8,10 @@ from urllib.parse import parse_qs
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet
 from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+from mcp.client.auth import OAuthClientProvider
+from mcp.shared.auth import OAuthToken
 from mcp.types import CallToolResult
 from pydantic import SecretStr
 
@@ -26,6 +29,10 @@ from server.app.agent.mcp_client import (
     mcp_config_to_connection,
 )
 from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
+from server.app.storage.mcp_oauth import (
+    EncryptedMcpOAuthTokenStorage,
+    MemoryMcpOAuthStateRepository,
+)
 
 
 def _profile(**overrides) -> McpWorkloadTokenExchangeProfile:
@@ -88,6 +95,68 @@ def test_static_bearer_missing_environment_fails_redacted() -> None:
         match="static_bearer_unavailable",
     ):
         mcp_config_to_connection(config, Settings())
+
+
+@pytest.mark.asyncio
+async def test_mcp_oauth_uses_upstream_provider_and_encrypted_exact_scope_state() -> None:
+    repository = MemoryMcpOAuthStateRepository()
+    key = SecretStr(Fernet.generate_key().decode("ascii"))
+    settings = Settings.model_validate(
+        {
+            "mcp_oauth_encryption_key": key,
+            "mcp_oauth_redirect_uri": "https://cognition.example.test/mcp/oauth/callback",
+        }
+    )
+    config = McpServerConfig.model_validate(
+        {
+            "name": "github",
+            "url": "https://mcp.example.test/github",
+            "auth": {"type": "mcp_oauth"},
+            "agent_name": "support-agent",
+            "effective_scope": {"tenant": "acme"},
+        }
+    )
+    storage = EncryptedMcpOAuthTokenStorage(
+        repository=repository,
+        encryption_key=key,
+        agent_name="support-agent",
+        effective_scope={"tenant": "acme"},
+        canonical_server_uri="https://mcp.example.test/github",
+    )
+    await storage.set_tokens(OAuthToken(access_token="scoped-oauth-token", expires_in=300))
+
+    connection = mcp_config_to_connection(config, settings, repository)
+    auth = connection["auth"]
+    assert isinstance(auth, OAuthClientProvider)
+    observed: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed.append(request.headers["Authorization"])
+        return httpx.Response(200, json={"ok": True})
+
+    async with httpx.AsyncClient(
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        await client.post(config.url)
+
+    assert observed == ["Bearer scoped-oauth-token"]
+
+
+def test_mcp_oauth_missing_deployment_configuration_fails_redacted() -> None:
+    config = McpServerConfig.model_validate(
+        {
+            "name": "github",
+            "url": "https://mcp.example.test/github",
+            "auth": {"type": "mcp_oauth"},
+        }
+    )
+
+    with pytest.raises(
+        McpTransportAuthenticationError,
+        match="oauth_configuration_unavailable",
+    ):
+        mcp_config_to_connection(config, Settings(), MemoryMcpOAuthStateRepository())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- construct the upstream MCP SDK `OAuthClientProvider` for `mcp_oauth` servers
- provide deployment-owned OAuth client metadata and redirect configuration
- inject the shared encrypted exact-scope token repository through session runtimes
- retain typed fail-closed behavior when OAuth deployment configuration is incomplete

## Boundaries

- OAuth state partitions remain exact effective scope + Agent identity + canonical server URI
- Agent configuration selects only `type: mcp_oauth`; it cannot select redirects, client metadata, scopes, tokens, or headers
- existing/refreshable tokens use the SDK transport directly
- initial interactive authorization remains fail-closed until the builder-facing PKCE handoff endpoint lands in the next focused PR

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- 132 focused tests passed, 3 skipped
- `git diff --check`
