### PR TITLE
refactor: remove global MCP registry

### DIFF
--- a/docs/architecture/03-server-components.md
+++ b/docs/architecture/03-server-components.md
@@ -81,7 +81,8 @@ per-request factories.
 
 FastAPI routers provide CRUD and discovery for:
 
-- Agents, tools, skills, MCP servers, providers/models, and sandbox profiles
+- Agents, tools, skills, providers/models, and sandbox profiles
+- Agent-owned MCP authorization handoff and scoped status
 - Sessions, runs, events, messages, artifacts, and runtime context
 - Deployment configuration, capabilities, health, and readiness
 
@@ -162,4 +163,3 @@ stream and cancellation state cannot be assumed to migrate.
 - [State and configuration](05-state-and-configuration.md)
 - [Runtime flows](07-runtime-flows.md)
 - [System context](01-system-context.md)
-

--- a/docs/architecture/05-state-and-configuration.md
+++ b/docs/architecture/05-state-and-configuration.md
@@ -154,9 +154,9 @@ multiple server replicas.
 
 ## Dynamic configuration
 
-`ConfigRegistry` stores providers, tools, skills, Agents, MCP servers, sandbox
-profiles, and global defaults as `(entity_type, name, scope, definition,
-source)` rows.
+`ConfigRegistry` stores providers, tools, skills, Agents, sandbox profiles, and
+global defaults as `(entity_type, name, scope, definition, source)` rows. MCP
+servers exist only inside immutable Agent definitions.
 
 Configuration resolution remains hierarchical for configuration entities:
 

--- a/docs/guides/extending-agents.md
+++ b/docs/guides/extending-agents.md
@@ -9,7 +9,7 @@ Cognition uses a convention-over-configuration model. Most extensions require ze
 | Agents | `.cognition/agents/` YAML or Markdown | No | Yes |
 | Tools | Python functions | Yes | Yes |
 | Middleware | Python classes | Yes | No |
-| MCP servers | Remote HTTP/SSE endpoints | No | Yes |
+| MCP servers | Agent-owned remote Streamable HTTP endpoints | No | Yes |
 | A2A exposure | `a2a.exposed: true` on agent definition | No | Yes |
 | Custom LLM providers | Python factories | Yes | No |
 

--- a/server/app/storage/config_models.py
+++ b/server/app/storage/config_models.py
@@ -280,41 +280,6 @@ class SkillDefinition(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# MCP Server
-# ---------------------------------------------------------------------------
-
-
-class McpServerRegistration(BaseModel):
-    """An MCP (Model Context Protocol) server registered in the config registry.
-
-    Attributes:
-        name: Server identifier.
-        url: HTTP/HTTPS URL for the MCP server.
-        headers: Optional request headers (e.g. auth tokens).
-        enabled: Whether this server is active.
-        scope: Scope this entry applies to.
-        source: "file" or "api".
-        transport: Transport protocol ("sse" or "streamable_http").
-    """
-
-    name: str = Field(..., min_length=1, max_length=100)
-    url: str = Field(..., min_length=1)
-    headers: dict[str, str] = Field(default_factory=dict)
-    enabled: bool = Field(default=True)
-    scope: dict[str, str] = Field(default_factory=dict)
-    source: Literal["file", "api"] = Field(default="file")
-    transport: Literal["sse", "streamable_http"] = Field(default="sse")
-
-    @field_validator("url")
-    @classmethod
-    def validate_url(cls, v: str) -> str:
-        """Ensure URL uses HTTP/HTTPS only."""
-        if not v.startswith(("http://", "https://")):
-            raise ValueError(f"MCP server URL must start with http:// or https://, got: {v!r}")
-        return v
-
-
-# ---------------------------------------------------------------------------
 # Sandbox Profile
 # ---------------------------------------------------------------------------
 
@@ -533,7 +498,6 @@ EntityType = Literal[
     "tool",
     "skill",
     "agent",
-    "mcp_server",
     "sandbox_profile",
 ]
 OperationType = Literal["upsert", "delete"]
@@ -646,7 +610,6 @@ __all__ = [
     "GlobalAgentDefaults",
     "GlobalProviderDefaults",
     "LambdaMicroVmCloudWatchLogging",
-    "McpServerRegistration",
     "OperationType",
     "ProviderConfig",
     "LambdaMicroVmIdlePolicy",

--- a/server/app/storage/config_registry.py
+++ b/server/app/storage/config_registry.py
@@ -48,7 +48,6 @@ from server.app.storage.config_models import (
     EntityType,
     GlobalAgentDefaults,
     GlobalProviderDefaults,
-    McpServerRegistration,
     ProviderConfig,
     SandboxProfile,
     SkillDefinition,
@@ -191,24 +190,6 @@ class ConfigRegistry(Protocol):
         expected_revision: int | None = None,
     ) -> bool:
         """Delete an agent definition row. Returns True if row existed."""
-        ...
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        """List all MCP server registrations visible in the given scope."""
-        ...
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        """Create or replace an MCP server registration."""
-        ...
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        """Delete an MCP server registration. Returns True if row existed."""
         ...
 
     # ------------------------------------------------------------------
@@ -914,23 +895,6 @@ class SqliteConfigRegistry:
         return await self._delete_entity("agent", name, scope)
 
     # ------------------------------------------------------------------
-    # MCP server CRUD (SqliteConfigRegistry)
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        rows = await self._list_entities("mcp_server", scope)
-        return [McpServerRegistration.model_validate(r) for r in rows]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        data = server.model_dump()
-        await self._upsert_entity("mcp_server", server.name, server.scope, data, server.source)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return await self._delete_entity("mcp_server", name, scope)
-
-    # ------------------------------------------------------------------
     # Sandbox profile CRUD (SqliteConfigRegistry)
     # ------------------------------------------------------------------
 
@@ -1607,24 +1571,6 @@ class PostgresConfigRegistry:
             return deleted
 
     # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        rows = await self._list_entities("mcp_server", scope)
-        return [McpServerRegistration.model_validate(r) for r in rows]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        await self._upsert_entity(
-            "mcp_server", server.name, server.scope, server.model_dump(), server.source
-        )
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return await self._delete_entity("mcp_server", name, scope)
-
-    # ------------------------------------------------------------------
     # Sandbox profile CRUD
     # ------------------------------------------------------------------
 
@@ -2010,21 +1956,6 @@ class MemoryConfigRegistry:
                 f"Expected revision {expected_revision} was not current"
             )
         return self._delete("agent", name, scope)
-
-    # MCP
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        return [
-            McpServerRegistration.model_validate(r)
-            for r in self._list_entities("mcp_server", scope)
-        ]
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        self._upsert("mcp_server", server.name, server.scope, server.model_dump(), server.source)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return self._delete("mcp_server", name, scope)
 
     # Sandbox profile
     async def get_sandbox_profile(

--- a/server/app/storage/config_store.py
+++ b/server/app/storage/config_store.py
@@ -36,7 +36,6 @@ from server.app.storage.config_models import (
     EntityType,
     GlobalAgentDefaults,
     GlobalProviderDefaults,
-    McpServerRegistration,
     ProviderConfig,
     SandboxProfile,
     SkillDefinition,
@@ -176,18 +175,6 @@ class ConfigStore(Protocol):
     async def is_valid_primary(self, name: str, scope: dict[str, str] | None = None) -> bool:
         """Check if an agent name is a valid primary agent."""
         ...
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]: ...
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None: ...
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool: ...
 
     # ------------------------------------------------------------------
     # Sandbox profile CRUD
@@ -509,23 +496,6 @@ class DefaultConfigStore:
         if agent is None or agent.hidden:
             return False
         return agent.mode in ("primary", "all")
-
-    # ------------------------------------------------------------------
-    # MCP server CRUD
-    # ------------------------------------------------------------------
-
-    async def list_mcp_servers(
-        self, scope: dict[str, str] | None = None
-    ) -> list[McpServerRegistration]:
-        return cast(
-            list[McpServerRegistration], await self._config_registry.list_mcp_servers(scope)
-        )
-
-    async def upsert_mcp_server(self, server: McpServerRegistration) -> None:
-        await self._config_registry.upsert_mcp_server(server)
-
-    async def delete_mcp_server(self, name: str, scope: dict[str, str] | None = None) -> bool:
-        return bool(await self._config_registry.delete_mcp_server(name, scope))
 
     # ------------------------------------------------------------------
     # Sandbox profile CRUD

--- a/server/app/storage/schema.py
+++ b/server/app/storage/schema.py
@@ -315,7 +315,7 @@ Index("idx_session_events_type_created", session_events_table.c.event_type, sess
 # ---------------------------------------------------------------------------
 
 # config_entities — single source of truth for all hot-reloadable config.
-# entity_type: "provider" | "tool" | "skill" | "agent" | "mcp_server"
+# entity_type: "provider" | "tool" | "skill" | "agent" | "sandbox_profile"
 # name:        entity identifier (e.g. "openai-gpt4o", "default")
 # scope:       JSON dict of scope key-values (empty = global)
 # definition:  JSON blob of the entity's Pydantic model fields

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import get_args
 
 import pytest
 
@@ -14,6 +15,9 @@ from server.app.agent.mcp_client import (
     mcp_config_to_connection,
 )
 from server.app.settings import Settings
+from server.app.storage.config_models import EntityType
+from server.app.storage.config_registry import MemoryConfigRegistry
+from server.app.storage.config_store import DefaultConfigStore
 
 
 def test_agent_definition_carries_agent_owned_mcp_config() -> None:
@@ -357,3 +361,11 @@ def test_global_mcp_servers_route_is_not_registered() -> None:
 
     paths = {str(getattr(route, "path", "")) for route in app.routes}
     assert "/mcp-servers" not in paths
+
+
+def test_global_mcp_registry_contract_is_removed() -> None:
+    assert "mcp_server" not in get_args(EntityType)
+    for target in (MemoryConfigRegistry, DefaultConfigStore):
+        assert not hasattr(target, "list_mcp_servers")
+        assert not hasattr(target, "upsert_mcp_server")
+        assert not hasattr(target, "delete_mcp_server")


### PR DESCRIPTION
## Summary

- delete the obsolete global MCP registration model and `mcp_server` ConfigRegistry entity type
- remove MCP CRUD from the ConfigStore and every SQLite, PostgreSQL, and memory registry implementation
- update architecture and extension docs to identify Agent definitions as the only MCP configuration authority
- add an executable assertion that the global registry contract cannot reappear silently

## Breaking change

There is no compatibility adapter or migration surface. Existing `mcp_server` config rows become inaccessible; builders must compile approved servers into Agent definitions.

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- 80 focused tests passed
- `uv run mkdocs build --strict`
- `git diff --check`
