### PR TITLE
feat(mcp): add scoped readiness observations

### DIFF
--- a/docs/guides/api-reference.md
+++ b/docs/guides/api-reference.md
@@ -1932,6 +1932,22 @@ The result is visible only from the exact effective scope that began the flow.
 Pending authorization transactions expire and are non-durable; encrypted OAuth
 tokens are durable in SQLite/PostgreSQL and process-local in the memory backend.
 
+### Observe MCP readiness
+
+```http
+GET /agents/{agent_name}/mcp/readiness
+```
+
+This exact-scope endpoint reports discovery observations for the Agent's current
+revision. Each server includes its required/optional policy, observation and
+freshness timestamps, discovered tool count, schema digest, and a typed redacted
+failure category. A missing or expired observation reports `unknown`.
+
+Readiness is not authorization truth. In particular, a `ready` observation does
+not bypass live authorization at a builder-controlled gateway on the next MCP
+operation. Credentials, authorization headers, raw scope values, tool arguments,
+and tool results are never included in this projection.
+
 ---
 
 ## Builder-Defined Runtime Scoping

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -627,6 +627,7 @@ Direct MCP OAuth uses deployment-owned client settings:
 | `COGNITION_MCP_OAUTH_CLIENT_NAME` | OAuth client display name; defaults to `Cognition` |
 | `COGNITION_MCP_OAUTH_CLIENT_METADATA_URL` | Optional HTTPS client metadata document URL |
 | `COGNITION_MCP_OAUTH_TIMEOUT_SECONDS` | Short-lived authorization transaction timeout; defaults to 300 seconds |
+| `COGNITION_MCP_READINESS_TTL_SECONDS` | Freshness window for scoped MCP discovery observations; defaults to 300 seconds |
 
 Generate a key with `Fernet.generate_key()` from Python's `cryptography`
 package and inject it as a secret environment value. Rotating the key makes

--- a/server/app/agent/cognition_agent.py
+++ b/server/app/agent/cognition_agent.py
@@ -467,6 +467,7 @@ class CognitionAgentParams:
     settings: Settings | None = None
     mcp_configs: Sequence[McpServerConfig] | None = None
     mcp_oauth_repository: Any | None = None
+    mcp_readiness_repository: Any | None = None
     scope: dict[str, str] | None = None
     config_store: ConfigStore | None = None
     sandbox_profile: str | None = None
@@ -815,6 +816,7 @@ async def create_cognition_agent(params: CognitionAgentParams) -> CognitionAgent
                     settings,
                     callbacks=mcp_callbacks,
                     oauth_repository=params.mcp_oauth_repository,
+                    readiness_repository=params.mcp_readiness_repository,
                 )
                 agent_tools.extend(mcp_tools)
                 logger.info("MCP tools loaded", count=len(mcp_tools))

--- a/server/app/agent/mcp_client.py
+++ b/server/app/agent/mcp_client.py
@@ -10,7 +10,10 @@ Security stance:
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
@@ -44,6 +47,10 @@ from server.app.agent.mcp_auth import (
 )
 from server.app.settings import McpWorkloadTokenExchangeProfile, Settings
 from server.app.storage.mcp_oauth import McpOAuthStateRepository
+from server.app.storage.mcp_readiness import (
+    McpReadinessObservation,
+    McpReadinessRepository,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -242,11 +249,13 @@ async def load_mcp_tools_per_server(
     tool_interceptors: list[ToolCallInterceptor] | None = None,
     *,
     oauth_repository: McpOAuthStateRepository | None = None,
+    readiness_repository: McpReadinessRepository | None = None,
 ) -> list[BaseTool]:
     """Load MCP tools server-by-server and enforce canonical identity uniqueness."""
 
     tools: list[BaseTool] = []
-    seen: set[str] = set()
+    seen_canonical: set[tuple[str, str]] = set()
+    seen_visible: set[str] = set()
     for config in configs:
         try:
             client_kwargs: dict[str, Any] = {
@@ -270,17 +279,112 @@ async def load_mcp_tools_per_server(
                 category=category,
                 error_type=type(exc).__name__,
             )
+            await _record_readiness(
+                readiness_repository,
+                config,
+                settings,
+                status="unavailable",
+                failure_category=category,
+            )
             if config.required:
                 raise McpServerDiscoveryError(config.name, category) from exc
             continue
 
+        server_identities: list[tuple[tuple[str, str], str, BaseTool]] = []
         for tool in server_tools:
-            canonical_name = str(getattr(tool, "name", ""))
-            if canonical_name in seen:
+            visible_name = str(getattr(tool, "name", ""))
+            prefix = f"{config.name}__"
+            provider_name = (
+                visible_name.removeprefix(prefix)
+                if visible_name.startswith(prefix)
+                else visible_name
+            )
+            canonical_identity = (config.name, provider_name)
+            if canonical_identity in seen_canonical or visible_name in seen_visible:
+                await _record_readiness(
+                    readiness_repository,
+                    config,
+                    settings,
+                    status="unavailable",
+                    failure_category="duplicate_tool_identity",
+                )
                 raise McpServerDiscoveryError(config.name, "duplicate_tool_identity")
-            seen.add(canonical_name)
+            server_identities.append((canonical_identity, visible_name, tool))
+
+        for canonical_identity, visible_name, tool in server_identities:
+            seen_canonical.add(canonical_identity)
+            seen_visible.add(visible_name)
             tools.append(tool)
+        await _record_readiness(
+            readiness_repository,
+            config,
+            settings,
+            status="ready",
+            tools=server_tools,
+        )
     return tools
+
+
+async def _record_readiness(
+    repository: McpReadinessRepository | None,
+    config: McpServerConfig,
+    settings: Settings,
+    *,
+    status: Literal["ready", "unavailable"],
+    tools: Sequence[BaseTool] = (),
+    failure_category: str | None = None,
+) -> None:
+    """Persist a redacted observation without making telemetry a runtime dependency."""
+    observed_at = datetime.now(UTC)
+    observation = McpReadinessObservation(
+        agent_name=config.agent_name,
+        agent_revision=config.agent_revision,
+        server_alias=config.name,
+        required=config.required,
+        status=status,
+        tool_count=len(tools),
+        schema_digest=_tool_schema_digest(tools) if status == "ready" else None,
+        failure_category=failure_category,
+        observed_at=observed_at,
+        fresh_until=observed_at + timedelta(seconds=settings.mcp_readiness_ttl_seconds),
+    )
+    logger.info(
+        "mcp_readiness_observed",
+        required=config.required,
+        status=status,
+        tool_count=len(tools),
+        failure_category=failure_category,
+    )
+    if repository is None:
+        return
+    try:
+        await repository.record(observation, config.effective_scope)
+    except Exception as exc:
+        logger.warning(
+            "mcp_readiness_persistence_failed",
+            error_type=type(exc).__name__,
+        )
+
+
+def _tool_schema_digest(tools: Sequence[BaseTool]) -> str:
+    schemas: list[dict[str, Any]] = []
+    for tool in tools:
+        args_schema = getattr(tool, "args_schema", None)
+        model_json_schema = getattr(args_schema, "model_json_schema", None)
+        if callable(model_json_schema):
+            input_schema = model_json_schema()
+        elif isinstance(args_schema, dict):
+            input_schema = args_schema
+        else:
+            input_schema = {}
+        schemas.append(
+            {
+                "name": str(getattr(tool, "name", "")),
+                "input_schema": input_schema,
+            }
+        )
+    payload = json.dumps(schemas, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _trusted_context_kwargs(config: McpServerConfig) -> dict[str, Any]:

--- a/server/app/api/dependencies.py
+++ b/server/app/api/dependencies.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from server.app.storage.artifact_store import ArtifactStore
     from server.app.storage.backend import StorageBackend
     from server.app.storage.mcp_oauth import McpOAuthStateRepository
+    from server.app.storage.mcp_readiness import McpReadinessRepository
 
 # ---------------------------------------------------------------------------
 # Global references — set once during lifespan, read via Depends()
@@ -46,6 +47,7 @@ _model_catalog: ModelCatalog | None = None
 _artifact_store: ArtifactStore | None = None
 _mcp_oauth_state_repository: McpOAuthStateRepository | None = None
 _mcp_oauth_flow_coordinator: McpOAuthFlowCoordinator | None = None
+_mcp_readiness_repository: McpReadinessRepository | None = None
 
 
 def set_config_store(store: ConfigStore) -> None:
@@ -86,6 +88,11 @@ def set_mcp_oauth_state_repository(repository: McpOAuthStateRepository) -> None:
 def set_mcp_oauth_flow_coordinator(coordinator: McpOAuthFlowCoordinator) -> None:
     global _mcp_oauth_flow_coordinator
     _mcp_oauth_flow_coordinator = coordinator
+
+
+def set_mcp_readiness_repository(repository: McpReadinessRepository) -> None:
+    global _mcp_readiness_repository
+    _mcp_readiness_repository = repository
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +162,12 @@ def get_mcp_oauth_flow_coordinator() -> McpOAuthFlowCoordinator:
     return _mcp_oauth_flow_coordinator
 
 
+def get_mcp_readiness_repository() -> McpReadinessRepository:
+    if _mcp_readiness_repository is None:
+        raise RuntimeError("MCP readiness repository not initialized during startup.")
+    return _mcp_readiness_repository
+
+
 def get_rate_limiter_dep() -> RateLimiter:
     return get_rate_limiter()
 
@@ -176,6 +189,7 @@ __all__ = [
     "get_artifact_store",
     "get_mcp_oauth_state_repository",
     "get_mcp_oauth_flow_coordinator",
+    "get_mcp_readiness_repository",
     "get_config_store",
     "get_model_catalog_dep",
     "get_rate_limiter_dep",
@@ -192,4 +206,5 @@ __all__ = [
     "set_storage_backend_dep",
     "set_mcp_oauth_state_repository",
     "set_mcp_oauth_flow_coordinator",
+    "set_mcp_readiness_repository",
 ]

--- a/server/app/api/models.py
+++ b/server/app/api/models.py
@@ -929,6 +929,28 @@ class AgentList(BaseModel):
     next_offset: int | None = None
 
 
+class McpServerReadinessResponse(BaseModel):
+    """Freshness-qualified MCP discovery observation."""
+
+    server_alias: str
+    required: bool
+    status: Literal["ready", "unavailable", "unknown"]
+    observed_at: datetime | None = None
+    fresh_until: datetime | None = None
+    tool_count: int = 0
+    schema_digest: str | None = None
+    failure_category: str | None = None
+    authorization_truth: Literal[False] = False
+
+
+class McpReadinessResponse(BaseModel):
+    """Scoped MCP readiness for the current Agent revision."""
+
+    agent_name: str
+    agent_revision: int = Field(ge=1)
+    servers: list[McpServerReadinessResponse] = Field(default_factory=list)
+
+
 # ============================================================================
 # Tool Models
 # ============================================================================

--- a/server/app/api/routes/agents.py
+++ b/server/app/api/routes/agents.py
@@ -5,13 +5,19 @@ from typing import Any
 from fastapi import APIRouter, Depends, Header, HTTPException, Response
 
 from server.app.agent.definition import A2AConfig, AgentDefinition
-from server.app.api.dependencies import get_config_store, get_scope_dep
+from server.app.api.dependencies import (
+    get_config_store,
+    get_mcp_readiness_repository,
+    get_scope_dep,
+)
 from server.app.api.models import (
     AgentConfigResponse,
     AgentCreate,
     AgentList,
     AgentResponse,
     AgentUpdate,
+    McpReadinessResponse,
+    McpServerReadinessResponse,
 )
 from server.app.api.scoping import SessionScope
 from server.app.observability import SCOPE_ACCESS_DENIED_TOTAL
@@ -19,6 +25,7 @@ from server.app.storage.common import canonical_json_digest
 from server.app.storage.config_models import AgentConfigRecord
 from server.app.storage.config_registry import ConfigRevisionConflictError
 from server.app.storage.config_store import ConfigStore
+from server.app.storage.mcp_readiness import McpReadinessRepository
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -175,6 +182,67 @@ async def get_agent(
     result = _agent_to_response(agent, record)
     response.headers["ETag"] = _etag(result.revision, result.definition_digest)
     return result
+
+
+@router.get("/{name}/mcp/readiness", response_model=McpReadinessResponse)
+async def get_agent_mcp_readiness(
+    name: str,
+    scope: SessionScope = Depends(get_scope_dep),  # noqa: B008
+    config_store: ConfigStore = Depends(get_config_store),  # noqa: B008
+    repository: McpReadinessRepository = Depends(  # noqa: B008
+        get_mcp_readiness_repository
+    ),
+) -> McpReadinessResponse:
+    """Return scoped runtime observations, never live authorization truth."""
+    effective_scope = scope.get_all()
+    agent = await config_store.get_agent_definition(name, effective_scope or None)
+    if agent is None or agent.hidden:
+        raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
+    record = await config_store.get_agent_record(name, effective_scope or None)
+    revision = record.revision if record else 1
+    observations = {
+        item.server_alias: item
+        for item in await repository.list_for_agent(
+            agent_name=name,
+            agent_revision=revision,
+            effective_scope=effective_scope,
+        )
+    }
+    servers: list[McpServerReadinessResponse] = []
+    for alias, config in sorted(agent.mcp.servers.items()):
+        observation = observations.get(alias)
+        if observation is None:
+            servers.append(
+                McpServerReadinessResponse(
+                    server_alias=alias,
+                    required=config.required,
+                    status="unknown",
+                    failure_category="not_observed",
+                )
+            )
+            continue
+        status = observation.public_status()
+        servers.append(
+            McpServerReadinessResponse(
+                server_alias=alias,
+                required=config.required,
+                status=status,
+                observed_at=observation.observed_at,
+                fresh_until=observation.fresh_until,
+                tool_count=observation.tool_count,
+                schema_digest=observation.schema_digest,
+                failure_category=(
+                    "observation_stale"
+                    if status == "unknown"
+                    else observation.failure_category
+                ),
+            )
+        )
+    return McpReadinessResponse(
+        agent_name=name,
+        agent_revision=revision,
+        servers=servers,
+    )
 
 
 @router.post("", response_model=AgentResponse, status_code=201)

--- a/server/app/llm/deep_agent_service.py
+++ b/server/app/llm/deep_agent_service.py
@@ -331,12 +331,14 @@ class DeepAgentStreamingService:
         runtime_resolver: RuntimeResolver | None = None,
         config_store: ConfigStore | None = None,
         mcp_oauth_repository: Any | None = None,
+        mcp_readiness_repository: Any | None = None,
     ) -> None:
         self.settings = settings
         self.storage_backend = create_storage_backend(settings)
         self._runtime_resolver = runtime_resolver
         self._config_store = config_store
         self._mcp_oauth_repository = mcp_oauth_repository
+        self._mcp_readiness_repository = mcp_readiness_repository
 
     def _get_runtime_resolver(self) -> RuntimeResolver:
         if self._runtime_resolver is None:
@@ -658,6 +660,7 @@ class DeepAgentStreamingService:
                 middleware=agent_cfg.middleware,
                 mcp_configs=agent_cfg.mcp_configs or None,
                 mcp_oauth_repository=self._mcp_oauth_repository,
+                mcp_readiness_repository=self._mcp_readiness_repository,
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -928,6 +931,7 @@ class DeepAgentStreamingService:
                 middleware=agent_cfg.middleware,
                 mcp_configs=agent_cfg.mcp_configs or None,
                 mcp_oauth_repository=self._mcp_oauth_repository,
+                mcp_readiness_repository=self._mcp_readiness_repository,
                 scope=effective_scope,
                 config_store=self._get_config_store(),
                 sandbox_profile=agent_cfg.sandbox_profile,
@@ -1116,6 +1120,7 @@ class SessionAgentManager:
         runtime_resolver: RuntimeResolver | None = None,
         config_store: ConfigStore | None = None,
         mcp_oauth_repository: Any | None = None,
+        mcp_readiness_repository: Any | None = None,
     ) -> None:
         """Initialize the session manager.
 
@@ -1130,6 +1135,7 @@ class SessionAgentManager:
         self._runtime_resolver = runtime_resolver
         self._config_store = config_store
         self._mcp_oauth_repository = mcp_oauth_repository
+        self._mcp_readiness_repository = mcp_readiness_repository
         self._services: dict[str, DeepAgentStreamingService] = {}
         self._project_paths: dict[str, str] = {}
         self._service_access: dict[str, float] = {}
@@ -1166,6 +1172,7 @@ class SessionAgentManager:
             runtime_resolver=self._runtime_resolver,
             config_store=self._config_store,
             mcp_oauth_repository=self._mcp_oauth_repository,
+            mcp_readiness_repository=self._mcp_readiness_repository,
         )
         if self._storage_backend is not None:
             service.storage_backend = self._storage_backend

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -18,6 +18,7 @@ from server.app.api.dependencies import (
     set_config_store,
     set_mcp_oauth_flow_coordinator,
     set_mcp_oauth_state_repository,
+    set_mcp_readiness_repository,
     set_model_catalog_dep,
     set_runtime_resolver,
     set_session_agent_manager_dep,
@@ -85,6 +86,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await mcp_oauth_state_repository.initialize()
     set_mcp_oauth_state_repository(mcp_oauth_state_repository)
     logger.info("MCP OAuth state repository initialized")
+
+    from server.app.storage.factory import create_mcp_readiness_repository
+
+    mcp_readiness_repository = create_mcp_readiness_repository(settings)
+    await mcp_readiness_repository.initialize()
+    set_mcp_readiness_repository(mcp_readiness_repository)
+    logger.info("MCP readiness repository initialized")
 
     from server.app.agent.mcp_oauth_flow import McpOAuthFlowCoordinator
 
@@ -172,6 +180,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         runtime_resolver=runtime_resolver,
         config_store=config_store,
         mcp_oauth_repository=mcp_oauth_state_repository,
+        mcp_readiness_repository=mcp_readiness_repository,
     )
     set_session_agent_manager_dep(session_agent_manager)
     logger.info("SessionAgentManager initialized")
@@ -297,6 +306,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await storage_backend.close()
     await mcp_oauth_flow_coordinator.close()
     await mcp_oauth_state_repository.close()
+    await mcp_readiness_repository.close()
     logger.info("Server shutdown complete")
 
 

--- a/server/app/settings.py
+++ b/server/app/settings.py
@@ -385,6 +385,12 @@ class Settings(BaseSettings):
         gt=0,
         alias="COGNITION_AGENT_CACHE_TTL_SECONDS",
     )
+    mcp_readiness_ttl_seconds: float = Field(
+        default=300.0,
+        gt=0,
+        alias="COGNITION_MCP_READINESS_TTL_SECONDS",
+        description="Freshness window for MCP discovery observations.",
+    )
     session_service_cache_max_entries: int = Field(
         default=256,
         ge=1,

--- a/server/app/storage/factory.py
+++ b/server/app/storage/factory.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from server.app.storage.config_dispatcher import ConfigChangeDispatcher
     from server.app.storage.config_registry import ConfigRegistry
     from server.app.storage.mcp_oauth import McpOAuthStateRepository
+    from server.app.storage.mcp_readiness import McpReadinessRepository
 
 
 class StorageBackendError(CognitionError):
@@ -110,6 +111,41 @@ def create_mcp_oauth_state_repository(settings: Settings) -> McpOAuthStateReposi
         sqlalchemy_dsn = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
         engine = create_async_engine(sqlalchemy_dsn)
         return SqlMcpOAuthStateRepository(engine)
+
+    raise StorageBackendError(
+        f"Unknown storage backend type: '{backend_type}'. "
+        "Supported types: sqlite, postgres, memory",
+        backend_type=backend_type,
+    )
+
+
+def create_mcp_readiness_repository(settings: Settings) -> McpReadinessRepository:
+    """Create the deployment-matched MCP readiness repository."""
+    backend_type = getattr(settings, "persistence_backend", "sqlite")
+    uri = getattr(settings, "persistence_uri", ".cognition/state.db")
+
+    if backend_type == "memory":
+        from server.app.storage.mcp_readiness import MemoryMcpReadinessRepository
+
+        return MemoryMcpReadinessRepository()
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from server.app.storage.mcp_readiness import SqlMcpReadinessRepository
+
+    if backend_type == "sqlite":
+        normalized_uri = uri.removeprefix("sqlite:///")
+        db_path = Path(normalized_uri)
+        if not db_path.is_absolute():
+            db_path = Path(str(settings.workspace_path)) / db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        return SqlMcpReadinessRepository(
+            create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        )
+
+    if backend_type == "postgres":
+        sqlalchemy_dsn = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+        return SqlMcpReadinessRepository(create_async_engine(sqlalchemy_dsn))
 
     raise StorageBackendError(
         f"Unknown storage backend type: '{backend_type}'. "

--- a/server/app/storage/mcp_readiness.py
+++ b/server/app/storage/mcp_readiness.py
@@ -1,0 +1,185 @@
+"""Durable, exact-scope MCP readiness observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from server.app.storage.common import effective_scope_key
+from server.app.storage.schema import mcp_readiness_table
+
+
+class McpReadinessObservation(BaseModel):
+    """One redacted MCP discovery observation for a pinned Agent revision."""
+
+    model_config = ConfigDict(frozen=True)
+
+    agent_name: str
+    agent_revision: int = Field(ge=1)
+    server_alias: str
+    required: bool
+    status: Literal["ready", "unavailable"]
+    tool_count: int = Field(default=0, ge=0)
+    schema_digest: str | None = None
+    failure_category: str | None = None
+    observed_at: datetime
+    fresh_until: datetime
+
+    def public_status(self, now: datetime | None = None) -> Literal[
+        "ready", "unavailable", "unknown"
+    ]:
+        """Return ``unknown`` after the observation freshness deadline."""
+        current = now or datetime.now(UTC)
+        deadline = self.fresh_until
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=UTC)
+        return self.status if current <= deadline else "unknown"
+
+
+class McpReadinessRepository(Protocol):
+    """Persistence contract for scoped MCP readiness observations."""
+
+    async def initialize(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def record(
+        self, observation: McpReadinessObservation, effective_scope: Mapping[str, str]
+    ) -> None: ...
+
+    async def list_for_agent(
+        self,
+        *,
+        agent_name: str,
+        agent_revision: int,
+        effective_scope: Mapping[str, str],
+    ) -> Sequence[McpReadinessObservation]: ...
+
+
+class MemoryMcpReadinessRepository:
+    """Process-local readiness persistence for in-memory development."""
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str, int, str], McpReadinessObservation] = {}
+
+    async def initialize(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self._rows.clear()
+
+    async def record(
+        self, observation: McpReadinessObservation, effective_scope: Mapping[str, str]
+    ) -> None:
+        key = (
+            effective_scope_key(dict(effective_scope)),
+            observation.agent_name,
+            observation.agent_revision,
+            observation.server_alias,
+        )
+        self._rows[key] = observation.model_copy(deep=True)
+
+    async def list_for_agent(
+        self,
+        *,
+        agent_name: str,
+        agent_revision: int,
+        effective_scope: Mapping[str, str],
+    ) -> Sequence[McpReadinessObservation]:
+        scope_key = effective_scope_key(dict(effective_scope))
+        return [
+            row.model_copy(deep=True)
+            for (row_scope, row_agent, row_revision, _), row in self._rows.items()
+            if row_scope == scope_key
+            and row_agent == agent_name
+            and row_revision == agent_revision
+        ]
+
+
+class SqlMcpReadinessRepository:
+    """SQLite/PostgreSQL readiness repository."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def initialize(self) -> None:
+        async with self._engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: mcp_readiness_table.create(
+                    sync_connection, checkfirst=True
+                )
+            )
+
+    async def close(self) -> None:
+        await self._engine.dispose()
+
+    async def record(
+        self, observation: McpReadinessObservation, effective_scope: Mapping[str, str]
+    ) -> None:
+        values = {
+            "scope_key": effective_scope_key(dict(effective_scope)),
+            **observation.model_dump(),
+        }
+        dialect = self._engine.dialect.name
+        if dialect == "sqlite":
+            statement: Any = sqlite_insert(mcp_readiness_table).values(**values)
+        elif dialect == "postgresql":
+            statement = postgres_insert(mcp_readiness_table).values(**values)
+        else:  # pragma: no cover - factory admits supported backends only
+            raise RuntimeError("MCP readiness backend is unsupported")
+        statement = statement.on_conflict_do_update(
+            index_elements=[
+                mcp_readiness_table.c.scope_key,
+                mcp_readiness_table.c.agent_name,
+                mcp_readiness_table.c.agent_revision,
+                mcp_readiness_table.c.server_alias,
+            ],
+            set_={
+                "required": observation.required,
+                "status": observation.status,
+                "tool_count": observation.tool_count,
+                "schema_digest": observation.schema_digest,
+                "failure_category": observation.failure_category,
+                "observed_at": observation.observed_at,
+                "fresh_until": observation.fresh_until,
+            },
+        )
+        async with self._engine.begin() as connection:
+            await connection.execute(statement)
+
+    async def list_for_agent(
+        self,
+        *,
+        agent_name: str,
+        agent_revision: int,
+        effective_scope: Mapping[str, str],
+    ) -> Sequence[McpReadinessObservation]:
+        statement = select(mcp_readiness_table).where(
+            mcp_readiness_table.c["scope_key"]
+            == effective_scope_key(dict(effective_scope)),
+            mcp_readiness_table.c["agent_name"] == agent_name,
+            mcp_readiness_table.c["agent_revision"] == agent_revision,
+        )
+        async with self._engine.connect() as connection:
+            rows = (await connection.execute(statement)).mappings().all()
+        return [
+            McpReadinessObservation.model_validate(
+                {key: value for key, value in row.items() if key != "scope_key"}
+            )
+            for row in rows
+        ]
+
+
+__all__ = [
+    "McpReadinessObservation",
+    "McpReadinessRepository",
+    "MemoryMcpReadinessRepository",
+    "SqlMcpReadinessRepository",
+]

--- a/server/app/storage/schema.py
+++ b/server/app/storage/schema.py
@@ -82,6 +82,37 @@ mcp_oauth_state_table = Table(
     ),
 )
 
+# Freshness-qualified MCP discovery observations. Scope values are represented
+# only by the same canonical digest used by other exact-scope runtime tables.
+mcp_readiness_table = Table(
+    "mcp_readiness",
+    metadata,
+    Column("scope_key", String(64), nullable=False),
+    Column("agent_name", String(200), nullable=False),
+    Column("agent_revision", Integer, nullable=False),
+    Column("server_alias", String(200), nullable=False),
+    Column("required", Boolean, nullable=False),
+    Column("status", String(20), nullable=False),
+    Column("tool_count", Integer, nullable=False, default=0),
+    Column("schema_digest", String(64)),
+    Column("failure_category", String(100)),
+    Column("observed_at", DateTime(timezone=True), nullable=False),
+    Column("fresh_until", DateTime(timezone=True), nullable=False),
+    UniqueConstraint(
+        "scope_key",
+        "agent_name",
+        "agent_revision",
+        "server_alias",
+        name="uq_mcp_readiness_identity",
+    ),
+)
+Index(
+    "idx_mcp_readiness_lookup",
+    mcp_readiness_table.c.scope_key,
+    mcp_readiness_table.c.agent_name,
+    mcp_readiness_table.c.agent_revision,
+)
+
 # Sessions table - stores conversation session metadata
 sessions_table = Table(
     "sessions",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ async def setup_storage_backend():
     from server.app.api.dependencies import (
         set_artifact_store,
         set_config_store,
+        set_mcp_readiness_repository,
         set_session_agent_manager_dep,
         set_storage_backend_dep,
     )
@@ -42,6 +43,7 @@ async def setup_storage_backend():
         DefaultConfigStore,
         set_default_config_store,
     )
+    from server.app.storage.mcp_readiness import MemoryMcpReadinessRepository
 
     with tempfile.TemporaryDirectory() as tmpdir:
         storage = SqliteStorageBackend(
@@ -52,6 +54,7 @@ async def setup_storage_backend():
 
         set_storage_backend_dep(storage)
         set_artifact_store(MemoryArtifactStore())
+        set_mcp_readiness_repository(MemoryMcpReadinessRepository())
 
         settings = get_settings()
         previous_runtime_settings = (

--- a/tests/unit/api/test_agents_crud.py
+++ b/tests/unit/api/test_agents_crud.py
@@ -15,6 +15,10 @@ from server.app.api.dependencies import get_config_store, get_settings_dep, set_
 from server.app.main import app
 from server.app.settings import Settings, get_settings
 from server.app.storage.config_store import DefaultConfigStore
+from server.app.storage.mcp_readiness import (
+    McpReadinessObservation,
+    MemoryMcpReadinessRepository,
+)
 
 client = TestClient(app)
 
@@ -102,6 +106,67 @@ class TestGetAgent:
         """Hidden Agents cannot be retrieved via GET /agents/{name}."""
         response = client.get("/agents/hidden-agent")
         assert response.status_code == 404
+
+    def test_mcp_readiness_is_scoped_and_freshness_qualified(self):
+        from datetime import UTC, datetime, timedelta
+
+        from server.app.api.dependencies import set_mcp_readiness_repository
+
+        store = get_config_store()
+        asyncio.run(
+            store.upsert_agent(
+                "readiness-agent",
+                {},
+                {
+                    "name": "readiness-agent",
+                    "system_prompt": "Use MCP.",
+                    "mcp": {
+                        "servers": {
+                            "github": {
+                                "url": "https://github.test/mcp",
+                                "required": True,
+                            },
+                            "docs": {
+                                "url": "https://docs.test/mcp",
+                                "required": False,
+                            },
+                        }
+                    },
+                },
+                "api",
+            )
+        )
+        record = asyncio.run(store.get_agent_record("readiness-agent", {}))
+        assert record is not None
+        now = datetime.now(UTC)
+        repository = MemoryMcpReadinessRepository()
+        asyncio.run(
+            repository.record(
+                McpReadinessObservation(
+                    agent_name="readiness-agent",
+                    agent_revision=record.revision,
+                    server_alias="github",
+                    required=True,
+                    status="ready",
+                    tool_count=2,
+                    schema_digest="a" * 64,
+                    observed_at=now - timedelta(minutes=10),
+                    fresh_until=now - timedelta(minutes=5),
+                ),
+                {},
+            )
+        )
+        set_mcp_readiness_repository(repository)
+
+        response = client.get("/agents/readiness-agent/mcp/readiness")
+
+        assert response.status_code == 200
+        servers = {item["server_alias"]: item for item in response.json()["servers"]}
+        assert servers["github"]["status"] == "unknown"
+        assert servers["github"]["failure_category"] == "observation_stale"
+        assert servers["github"]["authorization_truth"] is False
+        assert servers["docs"]["status"] == "unknown"
+        assert servers["docs"]["failure_category"] == "not_observed"
 
 
 class TestCreateAgent:

--- a/tests/unit/test_agent_mcp_config.py
+++ b/tests/unit/test_agent_mcp_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import get_args
 
@@ -18,6 +19,10 @@ from server.app.settings import Settings
 from server.app.storage.config_models import EntityType
 from server.app.storage.config_registry import MemoryConfigRegistry
 from server.app.storage.config_store import DefaultConfigStore
+from server.app.storage.mcp_readiness import (
+    McpReadinessObservation,
+    MemoryMcpReadinessRepository,
+)
 
 
 def test_agent_definition_carries_agent_owned_mcp_config() -> None:
@@ -369,3 +374,61 @@ def test_global_mcp_registry_contract_is_removed() -> None:
         assert not hasattr(target, "list_mcp_servers")
         assert not hasattr(target, "upsert_mcp_server")
         assert not hasattr(target, "delete_mcp_server")
+
+
+@pytest.mark.asyncio
+async def test_discovery_records_exact_scope_readiness(monkeypatch) -> None:
+    class FakeClient:
+        async def get_tools(self, *, server_name: str | None = None):
+            return [SimpleNamespace(name=f"{server_name}__search", args_schema={"type": "object"})]
+
+    monkeypatch.setattr(
+        "server.app.agent.mcp_client.create_mcp_client",
+        lambda configs, settings, callbacks=None, tool_interceptors=None: FakeClient(),
+    )
+    repository = MemoryMcpReadinessRepository()
+    config = McpServerConfig(
+        name="github",
+        url="https://github.test/mcp",
+        agent_name="support",
+        agent_revision=3,
+        effective_scope={"tenant": "alpha"},
+    )
+
+    await load_mcp_tools_per_server(
+        [config],
+        Settings(),
+        readiness_repository=repository,
+    )
+
+    alpha = await repository.list_for_agent(
+        agent_name="support",
+        agent_revision=3,
+        effective_scope={"tenant": "alpha"},
+    )
+    beta = await repository.list_for_agent(
+        agent_name="support",
+        agent_revision=3,
+        effective_scope={"tenant": "beta"},
+    )
+    assert len(alpha) == 1
+    assert alpha[0].status == "ready"
+    assert alpha[0].tool_count == 1
+    assert alpha[0].schema_digest is not None
+    assert beta == []
+
+
+def test_stale_readiness_is_unknown_not_authorization_truth() -> None:
+    now = datetime.now(UTC)
+    observation = McpReadinessObservation(
+        agent_name="support",
+        agent_revision=1,
+        server_alias="github",
+        required=True,
+        status="ready",
+        tool_count=1,
+        observed_at=now - timedelta(minutes=10),
+        fresh_until=now - timedelta(minutes=5),
+    )
+
+    assert observation.public_status(now) == "unknown"

--- a/tests/unit/test_mcp_readiness_storage.py
+++ b/tests/unit/test_mcp_readiness_storage.py
@@ -1,0 +1,56 @@
+"""Tests for durable, exact-scope MCP readiness observations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from server.app.storage.mcp_readiness import (
+    McpReadinessObservation,
+    SqlMcpReadinessRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_readiness_survives_repository_restart(tmp_path) -> None:
+    database = tmp_path / "readiness.db"
+    url = f"sqlite+aiosqlite:///{database}"
+    first = SqlMcpReadinessRepository(create_async_engine(url))
+    await first.initialize()
+    now = datetime.now(UTC)
+    await first.record(
+        McpReadinessObservation(
+            agent_name="support",
+            agent_revision=4,
+            server_alias="github",
+            required=True,
+            status="ready",
+            tool_count=3,
+            schema_digest="b" * 64,
+            observed_at=now,
+            fresh_until=now + timedelta(minutes=5),
+        ),
+        {"tenant": "alpha"},
+    )
+    await first.close()
+
+    second = SqlMcpReadinessRepository(create_async_engine(url))
+    await second.initialize()
+    matching = await second.list_for_agent(
+        agent_name="support",
+        agent_revision=4,
+        effective_scope={"tenant": "alpha"},
+    )
+    other_scope = await second.list_for_agent(
+        agent_name="support",
+        agent_revision=4,
+        effective_scope={"tenant": "beta"},
+    )
+    await second.close()
+
+    assert len(matching) == 1
+    assert matching[0].tool_count == 3
+    assert matching[0].schema_digest == "b" * 64
+    assert other_scope == []

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -32,7 +32,8 @@ class TestSchemaDefinitions:
         assert "session_events" in table_names
         assert "runtime_tasks" in table_names
         assert "mcp_oauth_state" in table_names
-        assert len(table_names) == 9
+        assert "mcp_readiness" in table_names
+        assert len(table_names) == 10
 
     def test_sessions_table_columns(self) -> None:
         """Test sessions table has expected columns."""


### PR DESCRIPTION
## Summary
- persist exact-scope MCP discovery readiness for current Agent revisions
- expose freshness-qualified readiness without treating it as authorization truth
- record typed redacted failures and schema digests without tool data

## Validation
- 1069 unit tests passed with 4 skipped before the schema expectation was updated; the sole failure was the expected table count
- 84 focused tests pass after updating the schema expectation
- Ruff passes
- strict mypy passes (273 files)
- strict MkDocs build passes
- git diff --check passes