### PR TITLE
fix(deps): patch release dependency advisories

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Severity | Layer | Status |
 |------|-------------|----------|-------|--------|
-| 2026-08-03 | Resolve High Dependabot alerts in `uv.lock` by upgrading `mcp`, `GitPython`, `Pillow`, and `pyasn1` to patched versions before the v0.14.0 pre-release image. | High | 1 | In Review |
+| 2026-08-03 | Resolve High-and-above dependency advisories before the v0.14.0 pre-release image: upgrade `mcp`, `GitPython`, `Pillow`, `pyasn1`, Click, and `langgraph-checkpoint` to patched versions and audit the installed release environment. | High | 1 | In Review |
 | 2026-07-23 | Default per-message completion callbacks to denied and require operator-approved HTTPS origins so scoped callers cannot select arbitrary destinations from the shared Cognition runtime. | High | 1/6 | Implemented on `release/v0.13.0`; release validation pending |
 | 2026-06-26 | Resolve open Dependabot alerts in `uv.lock` by upgrading `pydantic-settings`, `langsmith`, `langchain`, `langchain-anthropic`, `starlette`, `cryptography`, `aiohttp`, `python-multipart`, and `pyjwt` to patched versions | High | 1 | Completed |
 | 2026-05-27 | Resolve open Dependabot alerts in `uv.lock` by upgrading `GitPython`, `Mako`, `urllib3`, `python-multipart`, `idna`, and `langchain-openai` to patched versions | High | 1 | Completed |
@@ -218,6 +218,8 @@ The following fallback patterns exist and are tracked for removal. They produce 
 
 | Package | From | To | Breaking Changes | Status |
 |---------|------|-----|------------------|--------|
+| `click` | 8.3.2 | 8.4.2 | None intentional; fixes command injection in `click.edit()` before the v0.14.0 pre-release image. | In Review |
+| `langgraph-checkpoint` | 4.1.0 | 4.1.1 | None intentional; narrows unsafe checkpoint JSON object revival before the v0.14.0 pre-release image. | In Review |
 | `mcp` | 1.27.0 | 1.29.0 | None intentional; security patch refresh for High Dependabot alerts before v0.14.0 pre-release image. | In Review |
 | `GitPython` | 3.1.50 | 3.1.57 | None intentional; security patch refresh for High Dependabot alerts before v0.14.0 pre-release image. | In Review |
 | `Pillow` | 12.2.0 | 12.3.0 | None intentional; security patch refresh for High Dependabot alerts before v0.14.0 pre-release image. | In Review |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "deepagents>=0.7.1",
     "langchain>=1.3.0",
     "langgraph>=0.2.0",
+    "langgraph-checkpoint>=4.1.1",
     "langchain-core>=1.4.0",
     # Server
     "fastapi>=0.115.0",
@@ -42,6 +43,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
     # CLI
+    "click>=8.3.3",
     "typer>=0.12.0",
     "rich>=13.0.0",
     # File watching

--- a/uv.lock
+++ b/uv.lock
@@ -584,14 +584,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -609,6 +609,7 @@ source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "alembic" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "deepagents" },
     { name = "fastapi" },
@@ -618,6 +619,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "langsmith", extra = ["otel"] },
     { name = "opentelemetry-api" },
@@ -721,6 +723,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "deepagents", specifier = ">=0.7.1" },
     { name = "docker", marker = "extra == 'all'", specifier = ">=7.0.0" },
@@ -744,6 +747,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langgraph-checkpoint", specifier = ">=4.1.1" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'deploy'", specifier = ">=2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=1.0.0" },
@@ -2290,15 +2294,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- raise the explicit Click floor to 8.3.3 and resolve the lock to 8.4.2
- raise `langgraph-checkpoint` to the patched 4.1.1 release
- record both newly published advisories alongside the earlier High Dependabot remediation

## Security evidence
- `uvx pip-audit --path .venv/lib/python3.12/site-packages` reports no known vulnerabilities
- installed versions: Click 8.4.2, langgraph-checkpoint 4.1.1
- earlier patched lock versions remain: mcp 1.29.0, GitPython 3.1.57, Pillow 12.3.0, pyasn1 0.6.4

## Validation
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest tests/unit -q` (1044 passed, 4 skipped)
- `uv run pytest --collect-only -q tests/e2e` (446 collected)
- `uv run mkdocs build --strict`
- `git diff --check`