### PR TITLE
chore: prepare v0.14.0 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.0-rc.1] — 2026-08-03
+
+### Highlights
+
+- Updated Cognition to Deep Agents 0.7 and aligned Agent Skills, MCP tools,
+  sandbox binding, and backend composition with Deep Agents-native extension
+  points.
+- Made Skills and MCP server declarations part of immutable, scope-owned Agent
+  revisions so every run executes against one pinned capability snapshot.
+- Added four standards-oriented MCP authentication modes: anonymous transport,
+  standard MCP OAuth, workload token exchange, and static bearer credentials.
+- Added S3-compatible durable storage for file and artifact bodies while keeping
+  authoritative metadata and runtime state in the configured database.
+
+### Breaking Changes
+
+- Removed the global MCP server registry and its API. MCP servers are now
+  declared on Agent definitions, with no compatibility layer.
+- Removed the standalone Skill registry and API. Skill bundles are now stored
+  in complete Agent revisions, with no compatibility layer.
+- Production deployments no longer implicitly fall back to host-local durable
+  storage. Builders must configure durable database and S3-compatible storage;
+  SQLite, in-memory storage, and local filesystems remain supported deployment
+  choices when explicitly selected.
+- Raw MCP authorization headers and provider credentials are not part of Agent
+  configuration. Authentication behavior is selected by typed server auth
+  configuration and deployment-owned profiles.
+
+### Added
+
+- Added direct MCP OAuth discovery and authorization handoff, encrypted and
+  scope-partitioned OAuth token persistence, refresh handling, and canonical
+  server-resource isolation.
+- Added workload token exchange using ambient workload identity, exact
+  audience-bound tokens, trusted model-invisible runtime context, and
+  builder-controlled live gateway authorization.
+- Added static bearer authentication as a supported but not recommended MCP
+  transport option for deployments that require it.
+- Added per-server MCP discovery, canonical tool identities, required and
+  optional server failure semantics, and durable scope-aware readiness
+  observations with freshness state.
+- Added digest-addressed S3 object publication, read-after-write verification,
+  persisted SHA-256 and size metadata, and checksum verification on every read.
+- Added startup and readiness verification for the selected S3-compatible
+  backend, including Garage-backed integration coverage.
+
+### Security
+
+- Updated vulnerable transitive and direct dependencies, including MCP,
+  GitPython, Pillow, pyasn1, Click, and langgraph-checkpoint, and verified the
+  resolved project environment with `pip-audit`.
+- Kept MCP credentials, tokens, authorization headers, scopes, tool arguments,
+  and results out of persisted Agent configuration and bounded their exposure
+  in telemetry and readiness projections.
+
 ## [0.13.1] — 2026-07-29
 
 ### Added

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.13.1"
+VERSION = "0.14.0-rc.1"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- set the runtime/package version to `0.14.0-rc.1`
- add v0.14.0-rc.1 release notes covering the approved breaking architecture
- preserve the official-release boundary: this PR does not create a tag or GitHub release

## Validation
- `git diff --check`
- runtime version assertion
- `uv run mkdocs build --strict`

## Next gate
After merge, run `.github/workflows/pre-release-images.yml` against the exact `release/v0.14.0` commit with candidate tag `0.14.0-rc1`, then review the A2A evidence and both multi-architecture manifests.
