### PR TITLE
fix(release): keep A2A evidence release-independent

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-08-03 | Keep generated A2A release evidence release-independent and exclude external consumer names from public release artifacts. | v0.14.0-rc.1 evidence review | 7 | In Review |
 | 2026-07-29 | Avoid duplicate CI runs for release branches by using pull-request validation for `release/**` and reserving push validation for long-lived branches. | PR #166 ran identical push and pull-request jobs | 7 | Implemented |
 | 2026-07-29 | Reject inbound A2A Parts whose declared `mediaType` is not advertised by the selected Agent Card, returning `ContentTypeNotSupportedError` before durable task creation or model execution for unary and streaming sends. | Official A2A v1 TCK `CORE-SEND-003` | 6 | Implemented; upstream TCK requirement metadata incorrectly treats the required error as an operation failure |
 | 2026-07-27 | Ensure release images install Cognition's project console scripts and migration assets so documented `cognition db upgrade/current/history` commands are available inside the container with required Alembic/PostgreSQL packages; fix async SQLite migration URLs for disposable migration smoke tests. | Kennel rc1 staging upgrade blocker: image lacks documented migration executable/package path | 1/2 | Implemented on `release/v0.13.0`; release validation pending |

--- a/docs/guides/a2a.md
+++ b/docs/guides/a2a.md
@@ -216,7 +216,7 @@ Card, as recommended by the TCK, instead of forcing a transport on the command
 line.
 
 Pull requests run the applicable `MUST` suite. Pre-release and release
-workflows run the full suite. For v0.13.1 these results are non-blocking
+workflows run the full suite. These results are non-blocking
 compatibility disclosures: reports show users where Cognition aligns or
 diverges, while TCK findings do not prevent a release. Failure to produce a
 valid report remains a CI failure.
@@ -232,11 +232,9 @@ The system under test is `tests/support/a2a_tck_sut.py`, a deterministic,
 test-only Cognition agent definition. It exercises Cognition's real Agent Card,
 JSON-RPC, persistence, task lifecycle, artifact, and streaming paths without
 introducing model-provider or OAuth-gateway availability into protocol
-conformance. The manual Kennel Stock Guru TCK run was the exploratory signal
-that prompted investigation of the Cognition runtime; Stock Guru was not
-identified as the source of the discrepancies. The deterministic fixture is
-used for repeatable release reporting and is never mounted in the production
-application.
+conformance. Exploratory production-agent runs remain outside repeatable
+release reporting. The deterministic fixture is never mounted in the
+production application.
 
 Each run produces a versioned evidence archive containing the official HTML,
 JSON, and JUnit reports, a redacted fixture log, a machine-readable manifest,

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -43,7 +43,7 @@ runtime. It runs the unchanged official A2A TCK revision pinned in
 test-only fixture.
 
 1. Pull requests run all applicable `MUST` requirements and preserve the
-   resulting compatibility evidence; findings are advisory for v0.13.1.
+   resulting non-blocking compatibility evidence.
 2. The pre-release workflow must run the full suite for the exact candidate
    commit.
 3. Review `COGNITION-EXPLANATION.md` in the uploaded evidence and record the
@@ -56,8 +56,7 @@ test-only fixture.
      Cognition gap or a verified external harness defect first.
 4. Treat `SHOULD` and `MAY` findings as advisory follow-up unless a release
    explicitly declares that optional capability.
-5. Keep exploratory production-agent runs, such as the Kennel Stock Guru run
-   that surfaced this investigation, separate from repeatable release reporting.
+5. Keep exploratory production-agent runs separate from repeatable release reporting.
    Do not patch the TCK or add model/OAuth gateway dependencies to the
    deterministic fixture.
 

--- a/scripts/a2a_tck_evidence.py
+++ b/scripts/a2a_tck_evidence.py
@@ -149,12 +149,9 @@ def render_explanation(
         "## What this validates",
         "",
         "This report validates Cognition's A2A v1 adapter using Cognition's "
-        "deterministic, test-only TCK fixture. The earlier manual Kennel Stock "
-        "Guru run was the exploratory signal that prompted this runtime-level "
-        "investigation; Stock Guru was not identified as the cause of the "
-        "discrepancies. Production agents, model providers, gateways, and OAuth "
-        "deployments are outside this release report so it can isolate Cognition's "
-        "protocol runtime.",
+        "deterministic, test-only TCK fixture. Production agents, model providers, "
+        "gateways, and OAuth deployments are outside this release report so it "
+        "can isolate Cognition's protocol runtime.",
         "",
         "The official A2A TCK source was used unchanged at revision "
         f"`{manifest['officialTckRevision']}`. The fixture implements the TCK's "
@@ -233,10 +230,10 @@ def render_explanation(
             "",
             conclusion,
             "",
-            "For v0.13.1 this result is advisory: Cognition publishes the report "
-            "so users can assess protocol alignment, but compatibility findings "
-            "do not block the release. Failure to produce valid evidence remains "
-            "a release-pipeline error.",
+            "This result is advisory: Cognition publishes the report so users can "
+            "assess protocol alignment, but compatibility findings do not block "
+            "the release. Failure to produce valid evidence remains a "
+            "release-pipeline error.",
             "",
             "The release owner must review this explanation and record reviewer, "
             "date, and workflow URL in the release PR before tagging.",

--- a/tests/unit/test_a2a_tck_evidence.py
+++ b/tests/unit/test_a2a_tck_evidence.py
@@ -112,7 +112,8 @@ def test_builds_versioned_bundle_manifest_explanation_and_checksum(tmp_path: Pat
     assert manifest["cognitionRevision"] == "cognition-sha"
     assert manifest["officialTckRevision"] == "tck-sha"
     assert manifest["conformancePassed"] is True
-    assert "Stock Guru was not identified as the cause" in explanation
+    assert "Production agents" in explanation
+    assert "v0.13.1" not in explanation
     assert "PASS — all applicable MUST requirements passed" in explanation
     assert "secret-token" not in log
     assert "eyJhbGci" not in log


### PR DESCRIPTION
## Summary
- remove external consumer names from generated/public A2A release evidence
- remove the stale v0.13.1 policy wording from the versioned report generator and guides
- add regression assertions and record the release-evidence bug in the roadmap

## Why
Review of the successful v0.14.0-rc.1 evidence artifact found release-specific text inherited from v0.13.1. The conformance results themselves remain valid; this fixes the public report boundary before the final pre-release candidate.

## Validation
- `uv run pytest tests/unit/test_a2a_tck_evidence.py -q` (7 passed)
- `uv run ruff check scripts/a2a_tck_evidence.py tests/unit/test_a2a_tck_evidence.py`
- `uv run mkdocs build --strict`
- `git diff --check`
