### PR TITLE
chore: prepare v0.14.0 rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.14.0-rc.1] — 2026-08-03
+## [0.14.0-rc.2] — 2026-08-03
 
 ### Highlights
 

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.14.0-rc.1"
+VERSION = "0.14.0-rc.2"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- advance the pre-release runtime version and changelog heading to `0.14.0-rc.2`
- keep the immutable rc1 images intact after the A2A evidence-boundary correction

## Validation
- `git diff --check`
- runtime version assertion

No Git tag or official release is created by this PR.
