### PR TITLE
fix: migrate legacy Agent definitions for v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.1] — Unreleased
+
+### Fixed
+
+- Added an idempotent database migration for Agent definitions persisted before
+  the final v0.14 schema. The migration removes retired inline `skills` and
+  `tools` fields, preserves public `a2a.skills`, and refreshes Agent revision
+  identity so upgraded definitions remain readable under strict validation.
+
 ## [0.14.0] — 2026-08-14
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
+| 2026-09-02 | Normalize persisted pre-v0.14 Agent definitions by removing retired inline capability fields, updating revision identity, and preserving exact-scope and historical run boundaries. | [#209](https://github.com/CognicellAI/Cognition/issues/209), [Kennel #63](https://github.com/CognicellAI/Kennel/issues/63#issuecomment-5515261183) | 2/4 | In Review |
 | 2026-08-04 | Align the Agent-owned Skills backend with the installed Deep Agents `BackendProtocol` (`ls`/`als` and raw read content), and add a two-server workload-token-exchange regression proving exact-audience token isolation under concurrent use. | KennelAMS RC2 local integration evaluation | 4 | Implemented on `release/v0.14.0`; release validation pending |
 | 2026-08-03 | Keep generated A2A release evidence release-independent and exclude external consumer names from public release artifacts. | v0.14.0-rc.1 evidence review | 7 | In Review |
 | 2026-07-29 | Avoid duplicate CI runs for release branches by using pull-request validation for `release/**` and reserving push validation for long-lived branches. | PR #166 ran identical push and pull-request jobs | 7 | Implemented |

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -151,6 +151,19 @@ on exact-scope columns and pinned run manifests. Existing sessions that
 referenced removed built-in default Agents need compatible builder-provisioned
 Agent definitions before cutover.
 
+When upgrading a database created by v0.13 or a v0.14 release candidate to
+v0.14.1 or later, migration `007` normalizes persisted Agent definitions for
+the native Skills runtime. It removes retired top-level `skills` and `tools`
+fields and nested subagent `tools`, then advances the affected Agent revision
+and digest. Valid public capability declarations under `a2a.skills` are
+preserved, as are historical run manifests and their recorded Agent revisions.
+
+This conversion discards any inline Skill bundle content stored in an Agent
+definition. Before restoring traffic, builders that still require those Skills
+must install equivalent standard bundles under `<sandbox workspace>/skills`.
+Back up the database, drain incompatible writers, run the migration, and verify
+every Agent and generated Agent Card before admitting the new runtime.
+
 For explicit migration management:
 
 ```bash

--- a/server/alembic/versions/007_normalize_legacy_agent_definitions.py
+++ b/server/alembic/versions/007_normalize_legacy_agent_definitions.py
@@ -1,0 +1,97 @@
+"""Normalize persisted Agent definitions for the native Skills runtime.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-09-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _definition(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return dict(parsed) if isinstance(parsed, dict) else None
+    return None
+
+
+def _digest(value: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _normalize_agent_definition(definition: dict[str, Any]) -> bool:
+    changed = False
+    for field in ("skills", "tools"):
+        if field in definition:
+            del definition[field]
+            changed = True
+
+    subagents = definition.get("subagents")
+    if isinstance(subagents, list):
+        for subagent in subagents:
+            if isinstance(subagent, dict) and "tools" in subagent:
+                del subagent["tools"]
+                changed = True
+    return changed
+
+
+def upgrade() -> None:
+    """Remove obsolete capability fields from persisted Agent definitions."""
+    connection = op.get_bind()
+    config_entities = sa.table(
+        "config_entities",
+        sa.column("id", sa.Integer()),
+        sa.column("entity_type", sa.String()),
+        sa.column("definition", sa.JSON()),
+        sa.column("revision", sa.Integer()),
+        sa.column("definition_digest", sa.String()),
+    )
+    rows = connection.execute(
+        sa.select(
+            config_entities.c.id,
+            config_entities.c.definition,
+            config_entities.c.revision,
+        ).where(config_entities.c.entity_type == "agent")
+    ).mappings()
+    for row in rows:
+        definition = _definition(row["definition"])
+        if definition is None or not _normalize_agent_definition(definition):
+            continue
+        connection.execute(
+            config_entities.update()
+            .where(config_entities.c.id == row["id"])
+            .values(
+                definition=definition,
+                revision=int(row["revision"] or 1) + 1,
+                definition_digest=_digest(definition),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Do not recreate discarded legacy capability fields."""
+

--- a/tests/unit/test_alembic_migrations.py
+++ b/tests/unit/test_alembic_migrations.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
 
 import aiosqlite
 
+from server.app.protocols.a2a.card import build_agent_card_for_agent
 from server.app.storage.common import canonical_json_digest, effective_scope_key
+from server.app.storage.config_registry import SqliteConfigRegistry
+from server.app.storage.config_store import DefaultConfigStore
 
 
 async def _run_alembic(database: Path, *args: str) -> tuple[int, str]:
@@ -53,7 +57,8 @@ async def test_alembic_upgrade_head_creates_runtime_task_schema(tmp_path: Path) 
         async with connection.execute("PRAGMA table_info(artifacts)") as cursor:
             artifact_columns = {str(row[1]) async for row in cursor}
 
-    assert version == ("006",)
+    assert version is not None
+    assert version[0] == "007"
     assert "runtime_tasks" in tables
     assert "task_id" in run_columns
     assert {"scope_key", "agent_revision", "runtime_manifest", "manifest_digest"} <= run_columns
@@ -308,7 +313,7 @@ async def test_v013_migration_backfills_scope_keys_and_manifests(
         ) as cursor:
             config_row = await cursor.fetchone()
 
-    assert version == ("006",)
+    assert version == ("007",)
     assert session_scope_key == (expected_scope_key,)
     assert run_row == (
         expected_scope_key,
@@ -319,3 +324,207 @@ async def test_v013_migration_backfills_scope_keys_and_manifests(
     assert event_scope_key == (expected_scope_key,)
     assert artifact_scope_key == (expected_scope_key,)
     assert config_row == (expected_scope_key, 1, expected_definition_digest)
+
+
+async def test_v014_migration_normalizes_persisted_agent_definitions(
+    tmp_path: Path,
+) -> None:
+    """Revision 007 makes RC4 and v0.13 Agent rows readable by v0.14."""
+    database = tmp_path / "legacy-v014.db"
+    returncode, output = await _run_alembic(database, "upgrade", "006")
+    assert returncode == 0, output
+
+    alice_scope = {"tenant": "acme", "project": "alpha"}
+    bob_scope = {"tenant": "acme", "project": "beta"}
+    public_skill = {
+        "id": "analysis",
+        "name": "Analysis",
+        "description": "Analyze documents.",
+        "tags": ["documents"],
+    }
+    rc4_definition = {
+        "name": "rc4-agent",
+        "system_prompt": "RC4 agent.",
+        "mode": "primary",
+        "skills": [
+            {
+                "name": "legacy-bundle",
+                "content": "---\nname: legacy-bundle\n---\nLegacy instructions.",
+                "files": {"reference.md": "Legacy reference."},
+            }
+        ],
+        "subagents": [
+            {
+                "name": "researcher",
+                "system_prompt": "Research.",
+                "tools": ["legacy-tool"],
+            }
+        ],
+        "a2a": {"exposed": True, "skills": [public_skill]},
+    }
+    v013_definition = {
+        "name": "v013-agent",
+        "system_prompt": "v0.13 agent.",
+        "skills": ["registry-skill"],
+        "tools": ["registry-tool"],
+    }
+    unchanged_definition = {
+        "name": "current-agent",
+        "system_prompt": "Current agent.",
+    }
+    provider_definition = {
+        "id": "provider",
+        "skills": ["not-an-agent-field"],
+    }
+    historical_manifest = {
+        "agent": {
+            "name": "rc4-agent",
+            "revision": 4,
+            "definition": rc4_definition,
+        }
+    }
+
+    async with aiosqlite.connect(database) as connection:
+        for entity_type, name, scope, definition, revision in (
+            ("agent", "rc4-agent", alice_scope, rc4_definition, 4),
+            ("agent", "v013-agent", bob_scope, v013_definition, 2),
+            ("agent", "current-agent", alice_scope, unchanged_definition, 3),
+            ("provider", "provider", alice_scope, provider_definition, 7),
+        ):
+            await connection.execute(
+                """
+                INSERT INTO config_entities
+                (entity_type, name, scope, scope_key, definition, revision,
+                 definition_digest, source, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 'api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                (
+                    entity_type,
+                    name,
+                    json.dumps(scope),
+                    effective_scope_key(scope),
+                    json.dumps(definition),
+                    revision,
+                    canonical_json_digest(definition),
+                ),
+            )
+        await connection.execute(
+            """
+            INSERT INTO session_runs
+            (id, session_id, thread_id, status, effective_scope, scope_key,
+             agent_revision, runtime_manifest, manifest_digest, attempt, metadata,
+             created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            """,
+            (
+                "run-1",
+                "session-1",
+                "thread-1",
+                "completed",
+                json.dumps(alice_scope),
+                effective_scope_key(alice_scope),
+                4,
+                json.dumps(historical_manifest),
+                canonical_json_digest(historical_manifest),
+                1,
+                "{}",
+            ),
+        )
+        await connection.commit()
+
+    returncode, output = await _run_alembic(database, "upgrade", "head")
+    assert returncode == 0, output
+
+    expected_rc4 = json.loads(json.dumps(rc4_definition))
+    expected_rc4.pop("skills")
+    expected_rc4.pop("tools", None)
+    expected_rc4["subagents"][0].pop("tools")
+    expected_v013 = {
+        key: value
+        for key, value in v013_definition.items()
+        if key not in {"skills", "tools"}
+    }
+    async with aiosqlite.connect(database) as connection:
+        connection.row_factory = aiosqlite.Row
+        rows = {
+            row["name"]: row
+            async for row in await connection.execute(
+                """
+                SELECT name, definition, revision, definition_digest
+                FROM config_entities
+                ORDER BY name
+                """
+            )
+        }
+        run_row = await (
+            await connection.execute(
+                """
+                SELECT agent_revision, runtime_manifest, manifest_digest
+                FROM session_runs WHERE id='run-1'
+                """
+            )
+        ).fetchone()
+        version = await (
+            await connection.execute("SELECT version_num FROM alembic_version")
+        ).fetchone()
+
+    assert version is not None
+    assert version[0] == "007"
+    assert json.loads(rows["rc4-agent"]["definition"]) == expected_rc4
+    assert rows["rc4-agent"]["revision"] == 5
+    assert rows["rc4-agent"]["definition_digest"] == canonical_json_digest(expected_rc4)
+    assert json.loads(rows["v013-agent"]["definition"]) == expected_v013
+    assert rows["v013-agent"]["revision"] == 3
+    assert rows["v013-agent"]["definition_digest"] == canonical_json_digest(expected_v013)
+    assert json.loads(rows["current-agent"]["definition"]) == unchanged_definition
+    assert rows["current-agent"]["revision"] == 3
+    assert rows["current-agent"]["definition_digest"] == canonical_json_digest(
+        unchanged_definition
+    )
+    assert json.loads(rows["provider"]["definition"]) == provider_definition
+    assert rows["provider"]["revision"] == 7
+    assert run_row is not None
+    assert run_row["agent_revision"] == 4
+    assert json.loads(run_row["runtime_manifest"]) == historical_manifest
+    assert run_row["manifest_digest"] == canonical_json_digest(historical_manifest)
+
+    registry = SqliteConfigRegistry(str(database))
+    store = DefaultConfigStore(registry, workspace_path=tmp_path)
+    try:
+        exact_agent = await store.get_agent_definition("rc4-agent", alice_scope)
+        assert exact_agent is not None
+        assert exact_agent.a2a.skills[0].id == "analysis"
+        assert await store.get_agent_definition("rc4-agent", bob_scope) is None
+        assert {agent.name for agent in await store.list_agent_definitions(scope=alice_scope)} == {
+            "current-agent",
+            "rc4-agent",
+        }
+        card = build_agent_card_for_agent(exact_agent, "https://agents.example", "0.14.1")
+        assert [skill.id for skill in card.skills] == ["analysis"]
+    finally:
+        await registry.close()
+
+    before_rerun = {
+        name: (row["definition"], row["revision"], row["definition_digest"])
+        for name, row in rows.items()
+    }
+    returncode, output = await _run_alembic(database, "downgrade", "006")
+    assert returncode == 0, output
+    returncode, output = await _run_alembic(database, "upgrade", "head")
+    assert returncode == 0, output
+    async with aiosqlite.connect(database) as connection:
+        connection.row_factory = aiosqlite.Row
+        rerun_rows = {
+            row["name"]: (
+                row["definition"],
+                row["revision"],
+                row["definition_digest"],
+            )
+            async for row in await connection.execute(
+                """
+                SELECT name, definition, revision, definition_digest
+                FROM config_entities ORDER BY name
+                """
+            )
+        }
+    assert rerun_rows == before_rerun


### PR DESCRIPTION
## Summary

Fixes the v0.14 upgrade incompatibility reported during KennelAMS PB1 staging admission. Persisted RC4/v0.13 Agent definitions can contain capability fields removed by the final v0.14 schema; migration `006` left those rows unchanged, so strict `AgentDefinition` reads failed with Pydantic `extra_forbidden`.

Closes #209.
Downstream report: https://github.com/CognicellAI/Kennel/issues/63#issuecomment-5515261183

## Changes

- add idempotent Alembic migration `007` for persisted Agent rows only
- remove obsolete top-level `skills` and `tools` and nested subagent `tools`
- preserve valid public `a2a.skills`
- recompute `definition_digest` and increment `revision` only for changed Agents
- preserve exact scopes, non-Agent config, timestamps, and historical run manifests/revisions
- document the destructive inline-Skill conversion and builder remediation
- record the Layers 2/4 bug fix in ROADMAP and add v0.14.1 release notes without changing the package version

## Data migration notice

Non-empty inline Skill bundles are discarded because the final v0.14 runtime uses Deep Agents native discovery from `<sandbox workspace>/skills`. Builders that still require those capabilities must install equivalent standard bundles in that directory before restoring traffic. Strict Agent validation remains enabled; this PR does not add a fallback compatibility path.

## Validation

- `uv run pytest tests/unit -v` — **984 passed, 4 skipped**
- `uv run ruff check .` — passed
- `uv run mypy .` — passed (257 source files)
- `git diff --check` — passed
- disposable PostgreSQL 16 rehearsal from migration `006` to `007` — passed

The migration regression covers empty/non-empty legacy Skills, top-level tools, nested subagent tools, unaffected Agent and non-Agent records, exact-scope denial, Agent list/read/runtime resolution, Agent Card generation, digest/revision changes, historical run preservation, and repeat execution.

## KennelAMS follow-up

After review and merge, prepare `release/v0.14.1` under the standard release process. KennelAMS must repeat PB1 from a fresh backup, ensure required legacy bundles are builder-mounted, validate all 27 migrated Agents and their Agent Cards, and complete hosted admission before promotion.

## Stop point

This PR is intentionally open and unmerged. No release branch, version bump, release workflow, tag, image publication, or staging mutation has been performed.