### PR TITLE
chore: prepare v0.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.14.1] — Unreleased
+## [0.14.1] — 2026-09-02
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ See AGENTS.md for category definitions, DoD requirements, and precedence rules.
 
 | Date | Description | Issue | Layer | Status |
 |------|-------------|-------|-------|--------|
-| 2026-09-02 | Normalize persisted pre-v0.14 Agent definitions by removing retired inline capability fields, updating revision identity, and preserving exact-scope and historical run boundaries. | [#209](https://github.com/CognicellAI/Cognition/issues/209), [Kennel #63](https://github.com/CognicellAI/Kennel/issues/63#issuecomment-5515261183) | 2/4 | In Review |
+| 2026-09-02 | Normalize persisted pre-v0.14 Agent definitions by removing retired inline capability fields, updating revision identity, and preserving exact-scope and historical run boundaries. | [#209](https://github.com/CognicellAI/Cognition/issues/209), [Kennel #63](https://github.com/CognicellAI/Kennel/issues/63#issuecomment-5515261183) | 2/4 | Implemented on `main`; v0.14.1 release validation pending |
 | 2026-08-04 | Align the Agent-owned Skills backend with the installed Deep Agents `BackendProtocol` (`ls`/`als` and raw read content), and add a two-server workload-token-exchange regression proving exact-audience token isolation under concurrent use. | KennelAMS RC2 local integration evaluation | 4 | Implemented on `release/v0.14.0`; release validation pending |
 | 2026-08-03 | Keep generated A2A release evidence release-independent and exclude external consumer names from public release artifacts. | v0.14.0-rc.1 evidence review | 7 | In Review |
 | 2026-07-29 | Avoid duplicate CI runs for release branches by using pull-request validation for `release/**` and reserving push validation for long-lived branches. | PR #166 ran identical push and pull-request jobs | 7 | Implemented |

--- a/server/version.py
+++ b/server/version.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-VERSION = "0.14.0"
+VERSION = "0.14.1"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary

Prepare Cognition v0.14.1 after the upgrade-compatibility fix landed on `main` in #210.

Release contents:
- Alembic migration `007` normalizes persisted RC4/v0.13 Agent definitions for strict v0.14 validation
- legacy top-level `skills`/`tools` and nested subagent `tools` are removed
- valid `a2a.skills`, exact scopes, and historical run manifests/revisions are preserved
- affected Agent revisions and definition digests are refreshed
- package version and changelog are finalized as v0.14.1

Fixes #209.
Downstream staging report: https://github.com/CognicellAI/Kennel/issues/63#issuecomment-5515261183

## Release metadata

- release branch base: `main` at `5718629e9e528e8498593b0bc8a6e77ee589bf1c`
- candidate commit: `2d6adaa8984d693a9f85f73ee931f9f39ba387e4`
- version: `0.14.1`
- migration head: `007`

## Validation

Run against exact candidate commit `2d6adaa8984d693a9f85f73ee931f9f39ba387e4`:

- `uv run pytest tests/unit -v` — **984 passed, 4 skipped**
- `uv run ruff check .` — passed
- `uv run mypy .` — passed (257 source files)
- `git diff --check origin/main...HEAD` — passed
- PostgreSQL 16 migration rehearsal from `006` to `007` — passed on the underlying fix commit
- pull-request CI on Python 3.11 and 3.12 — passed

## A2A conformance evidence

- reviewer: Herman Haggerty
- review date: 2026-09-02
- workflow: https://github.com/CognicellAI/Cognition/actions/runs/33683179084
- official unchanged TCK revision: `5996b79f9cefa6fc390980e383e358a66fb9e49e`
- MUST result: 66 passed, 1 failed, 25 skipped, 22 not tested (98.5%)
- advisory disposition: the sole non-pass is `CORE-SEND-003`, classified as an upstream TCK defect because Cognition correctly returns `ContentTypeNotSupportedError` while the pinned TCK omits expected-error metadata; tracked at https://github.com/a2aproject/a2a-tck/issues/202
- PR evidence revision: `f5257620660dbf478a94a4e5177e6a91b404951b` (GitHub pull-request merge ref)

Exact-commit pre-release validation passed on attempt 2: https://github.com/CognicellAI/Cognition/actions/runs/33693866081. Python 3.11 and 3.12 unit, mypy, and Ruff gates passed; the unchanged full A2A TCK produced reviewed evidence; app and sandbox images built and pushed for linux/amd64 and linux/arm64; and both `0.14.1-rc1` multi-arch manifests were created. Attempt 1 encountered one non-reproducible Python 3.12 test failure before image jobs started; the isolated test, full module, and exact-commit rerun all passed.

## Migration notice

Migration `007` discards non-empty inline Skill bundles because v0.14 uses Deep Agents native discovery from `<sandbox workspace>/skills`. Builders must install equivalent standard bundles there before restoring traffic. KennelAMS must repeat PB1 from a fresh backup and validate all 27 migrated Agents and Agent Cards before hosted promotion.

## Not performed

Final semver image publication, tagging, GitHub release publication, and staging/production deployment have not yet been performed.